### PR TITLE
Add various matrix norms

### DIFF
--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -329,7 +329,7 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
             return result;
         }
 
-        /// Computes the Min norm of the matrix as the maximum absolute value.
+        /// Computes the Min norm of the matrix as the minimum absolute value.
         pub fn minNorm(self: Self) T {
             var result: T = std.math.inf(T);
             for (self.items) |row| {

--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -296,11 +296,11 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
             } else {
                 var result: T = 0;
                 for (self.items) |row| {
-                    for (row) | col| {
+                    for (row) |col| {
                         result += std.math.pow(T, @abs(col), p);
                     }
                 }
-                result = std.math.pow(T, result, (1/p));
+                result = std.math.pow(T, result, (1 / p));
                 return result;
             }
         }
@@ -319,7 +319,7 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
         pub fn maxNorm(self: Self) T {
             var result: T = -std.math.inf(T);
             for (self.items) |row| {
-                for (row) | col| {
+                for (row) |col| {
                     const val = @abs(col);
                     if (val > result) {
                         result = val;
@@ -333,7 +333,7 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
         pub fn minNorm(self: Self) T {
             var result: T = std.math.inf(T);
             for (self.items) |row| {
-                for (row) | col| {
+                for (row) |col| {
                     const val = @abs(col);
                     if (val < result) {
                         result = val;

--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -290,16 +290,9 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
         pub fn norm(self: Self, p: T) T {
             assert(p >= 1);
             if (p == std.math.inf(T)) {
-                var result: T = -std.math.inf(T);
-                for (self.items) |row| {
-                    for (row) | col| {
-                        const val = @abs(col);
-                        if (val > result) {
-                            result = val;
-                        }
-                    }
-                }
-                return result;
+                return self.maxNorm();
+            } else if (p == -std.math.inf(T)) {
+                return self.minNorm();
             } else {
                 var result: T = 0;
                 for (self.items) |row| {
@@ -324,7 +317,30 @@ pub fn Matrix(comptime T: type, comptime rows: usize, comptime cols: usize) type
 
         /// Computes the Max norm of the matrix as the maximum absolute value.
         pub fn maxNorm(self: Self) T {
-            return self.norm(std.math.inf(T));
+            var result: T = -std.math.inf(T);
+            for (self.items) |row| {
+                for (row) | col| {
+                    const val = @abs(col);
+                    if (val > result) {
+                        result = val;
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// Computes the Min norm of the matrix as the maximum absolute value.
+        pub fn minNorm(self: Self) T {
+            var result: T = std.math.inf(T);
+            for (self.items) |row| {
+                for (row) | col| {
+                    const val = @abs(col);
+                    if (val < result) {
+                        result = val;
+                    }
+                }
+            }
+            return result;
         }
     };
 }
@@ -401,6 +417,10 @@ test "norm" {
 
     matrix.set(2, 3, 1000000);
     try expectEqual(matrix.maxNorm(), 1000000);
+
+    matrix = matrix.offset(10);
+    matrix.set(2, 3, -5);
+    try expectEqual(matrix.minNorm(), 5);
 }
 
 test "sum" {


### PR DESCRIPTION
Though it is a image processing library, it is nice to have them at least in near future, I believe.

## Changes
- Added `sumRows()`, `sumCols()` for dim-wise sum
- Changed `norm` function to a general p-norm one
- Added typical norms including `Frobenius`, `Nuclear`, `Max`, `Min`