### PR TITLE
feat(colorspaces): add Oklch color space

### DIFF
--- a/examples/src/colorspaces.zig
+++ b/examples/src/colorspaces.zig
@@ -7,6 +7,7 @@ const Hsv = @import("zignal").Hsv;
 const Lab = @import("zignal").Lab;
 const Lms = @import("zignal").Lms;
 const Oklab = @import("zignal").Oklab;
+const Oklch = @import("zignal").Oklch;
 const Rgb = @import("zignal").Rgb;
 const Xyb = @import("zignal").Xyb;
 const Xyz = @import("zignal").Xyz;
@@ -65,6 +66,14 @@ export fn rgb2oklab(red: u8, green: u8, blue: u8, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn rgb2oklch(red: u8, green: u8, blue: u8, out: [*]f64) void {
+    const res = convertColor(Oklch, Rgb{ .r = red, .g = green, .b = blue });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn rgb2xyb(red: u8, green: u8, blue: u8, out: [*]f64) void {
@@ -130,6 +139,14 @@ export fn hsl2oklab(h: f64, s: f64, l: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn hsl2oklch(h: f64, s: f64, l: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Hsl{ .h = h, .s = s, .l = l });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn hsl2xyb(h: f64, s: f64, l: f64, out: [*]f64) void {
@@ -198,6 +215,14 @@ export fn hsv2oklab(h: f64, s: f64, v: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn hsv2oklch(h: f64, s: f64, v: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Hsv{ .h = h, .s = s, .v = v });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn hsv2xyb(h: f64, s: f64, v: f64, out: [*]f64) void {
     const res = convertColor(Xyb, Hsv{ .h = h, .s = s, .v = v });
     std.log.debug("Xyb: {[x]d} {[y]d} {[b]d}", res);
@@ -262,6 +287,14 @@ export fn xyz2oklab(x: f64, y: f64, z: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn xyz2oklch(x: f64, y: f64, z: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Xyz{ .x = x, .y = y, .z = z });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn xyz2xyb(x: f64, y: f64, z: f64, out: [*]f64) void {
@@ -330,6 +363,14 @@ export fn lab2oklab(l: f64, a: f64, b: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn lab2oklch(l: f64, a: f64, b: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Lab{ .l = l, .a = a, .b = b });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn lab2xyb(l: f64, a: f64, b: f64, out: [*]f64) void {
     const res = convertColor(Xyb, Lab{ .l = l, .a = a, .b = b });
     std.log.debug("Xyb: {[x]d} {[y]d} {[b]d}", res);
@@ -386,6 +427,14 @@ export fn lms2oklab(h: f64, m: f64, s: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn lms2oklch(l: f64, m: f64, s: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Lms{ .l = l, .m = m, .s = s });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn lms2xyb(l: f64, m: f64, s: f64, out: [*]f64) void {
@@ -454,6 +503,80 @@ export fn oklab2xyb(l: f64, a: f64, b: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+// --- Oklch ---
+
+export fn oklch2rgb(l: f64, c: f64, h: f64, out: [*]u8) void {
+    const res = convertColor(Rgb, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("RGB: {[r]d} {[g]d} {[b]d}", res);
+    out[0] = res.r;
+    out[1] = res.g;
+    out[2] = res.b;
+}
+
+export fn oklch2hsl(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Hsl, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("HSL: {[h]d} {[s]d} {[l]d}", res);
+    out[0] = res.h;
+    out[1] = res.s;
+    out[2] = res.l;
+}
+
+export fn oklch2hsv(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Hsv, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("HSV: {[h]d} {[s]d} {[v]d}", res);
+    out[0] = res.h;
+    out[1] = res.s;
+    out[2] = res.v;
+}
+
+export fn oklch2xyz(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Xyz, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("XYZ: {[x]d} {[y]d} {[z]d}", res);
+    out[0] = res.x;
+    out[1] = res.y;
+    out[2] = res.z;
+}
+
+export fn oklch2lab(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Lab, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("Lab: {[l]d} {[a]d} {[b]d}", res);
+    out[0] = res.l;
+    out[1] = res.a;
+    out[2] = res.b;
+}
+
+export fn oklch2lms(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Lms, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("LMS: {[l]d} {[m]d} {[s]d}", res);
+    out[0] = res.l;
+    out[1] = res.m;
+    out[2] = res.s;
+}
+
+export fn oklch2oklab(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Oklab, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("Oklab: {[l]d} {[a]d} {[b]d}", res);
+    out[0] = res.l;
+    out[1] = res.a;
+    out[2] = res.b;
+}
+
+export fn oklch2xyb(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Xyb, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("Xyb: {[x]d} {[y]d} {[b]d}", res);
+    out[0] = res.x;
+    out[1] = res.y;
+    out[2] = res.b;
+}
+
+export fn oklch2ycbcr(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Ycbcr, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
+    out[0] = res.y;
+    out[1] = res.cb;
+    out[2] = res.cr;
+}
+
 // --- XYB ---
 
 export fn xyb2rgb(x: f64, y: f64, b: f64, out: [*]u8) void {
@@ -502,6 +625,14 @@ export fn xyb2oklab(x: f64, y: f64, b: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn xyb2oklch(x: f64, y: f64, b: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Xyb{ .x = x, .y = y, .b = b });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn xyb2lab(x: f64, y: f64, b: f64, out: [*]f64) void {
@@ -601,6 +732,14 @@ export fn ycbcr2oklab(y: f64, cb: f64, cr: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn ycbcr2oklch(y: f64, cb: f64, cr: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Ycbcr{ .y = @floatCast(y), .cb = @floatCast(cb), .cr = @floatCast(cr) });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn ycbcr2xyb(y: f64, cb: f64, cr: f64, out: [*]f64) void {

--- a/examples/web/colorspaces.html
+++ b/examples/web/colorspaces.html
@@ -40,7 +40,7 @@
             margin: 0 auto;
             text-align: center;
         }
-        
+
         /* Dynamic background transition */
         body {
             transition: background-color 0.3s ease;
@@ -50,74 +50,78 @@
   <body>
     <div class="header">
       <h1>Color Space Converter</h1>
-      <p>Convert colors between different color spaces: RGB, HSL, HSV, XYZ, Lab, LMS, Oklab, XYB, and YCbCr</p>
+      <p>Convert colors between different color spaces: RGB, HSL, HSV, XYZ, Lab, LMS, Oklab, Oklch, XYB, and YCbCr</p>
     </div>
-
     <div class="instructions">
       Change values in any color space to see real-time conversion to all other formats. Click color space names to copy values.
     </div>
-
     <div class="color-converter-table">
       <div id="hex" class="color-space">
-      <button class="copy-button" onClick="copyToClipboard('hex')">HEX</button>
-      <input type="text" id="hex-#" value="#000000">
-      <input type="color" name="color" id="color" value="#000000">
-      <label id="validation-message" style="min-height: 1em; display: inline-block; min-width: 150px;">&nbsp;</label>
-    </div>
-    <div id="rgb" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('rgb')">RGB</button>
-      <input type="number" id="rgb-r" min="0" max="255" value="0">
-      <input type="number" id="rgb-g" min="0" max="255" value="0">
-      <input type="number" id="rgb-b" min="0" max="255" value="0">
-    </div>
-    <div id="hsl" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('hsl')">HSL</button>
-      <input type="number" id="hsl-h" min="0" max="360" value="0">
-      <input type="number" id="hsl-s" min="0" max="100" value="0">
-      <input type="number" id="hsl-l" min="0" max="100" value="0">
-    </div>
-    <div id="hsv" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('hsv')">HSV</button>
-      <input type="number" id="hsv-h" min="0" max="360" value="0">
-      <input type="number" id="hsv-s" min="0" max="100" value="0">
-      <input type="number" id="hsv-v" min="0" max="100" value="0">
-    </div>
-    <div id="xyz" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('xyz')">XYZ</button>
-      <input type="number" id="xyz-x" min="0" max="95.050" step="0.1" value="0">
-      <input type="number" id="xyz-y" min="0" max="100" step="0.1" value="0">
-      <input type="number" id="xyz-z" min="0" max="108.900" step="0.1" value="0">
-    </div>
-    <div id="lab" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('lab')">Lab</button>
-      <input type="number" id="lab-l" min="0" max="100" step="0.1" value="0">
-      <input type="number" id="lab-a" min="-128" max="127" step="0.1" value="0">
-      <input type="number" id="lab-b" min="-128" max="127" step="0.1" value="0">
-    </div>
-    <div id="lms" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('lms')">LMS</button>
-      <input type="number" id="lms-l" min="0" step="0.001" value="0">
-      <input type="number" id="lms-m" min="0" step="0.001" value="0">
-      <input type="number" id="lms-s" min="0" step="0.001" value="0">
-    </div>
-    <div id="oklab" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('oklab')">Oklab</button>
-      <input type="number" id="oklab-l" min="0" max="1" step="0.01" value="0">
-      <input type="number" id="oklab-a" min="-0.5" max="0.5" step="0.01" value="0">
-      <input type="number" id="oklab-b" min="-0.5" max="0.5" step="0.01" value="0">
-    </div>
-    <div id="xyb" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('xyb')">XYB</button>
-      <input type="number" id="xyb-x" step="0.1" value="0">
-      <input type="number" id="xyb-y" step="0.1" value="0">
-      <input type="number" id="xyb-b" min="0" step="0.1" value="0">
-    </div>
-    <div id="ycbcr" class="color-space">
-      <button class="copy-button" onclick="copyToClipboard('ycbcr')">YCbCr</button>
-      <input type="number" id="ycbcr-y" min="0" max="255" step="0.1" value="0">
-      <input type="number" id="ycbcr-cb" min="0" max="255" step="0.1" value="128">
-      <input type="number" id="ycbcr-cr" min="0" max="255" step="0.1" value="128">
-    </div>
+        <button class="copy-button" onClick="copyToClipboard('hex')">HEX</button>
+        <input type="text" id="hex-#" value="#000000">
+        <input type="color" name="color" id="color" value="#000000">
+        <label id="validation-message" style="min-height: 1em; display: inline-block; min-width: 150px;">&nbsp;</label>
+      </div>
+      <div id="rgb" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('rgb')">RGB</button>
+        <input type="number" id="rgb-r" min="0" max="255" value="0">
+        <input type="number" id="rgb-g" min="0" max="255" value="0">
+        <input type="number" id="rgb-b" min="0" max="255" value="0">
+      </div>
+      <div id="hsl" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('hsl')">HSL</button>
+        <input type="number" id="hsl-h" min="0" max="360" value="0">
+        <input type="number" id="hsl-s" min="0" max="100" value="0">
+        <input type="number" id="hsl-l" min="0" max="100" value="0">
+      </div>
+      <div id="hsv" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('hsv')">HSV</button>
+        <input type="number" id="hsv-h" min="0" max="360" value="0">
+        <input type="number" id="hsv-s" min="0" max="100" value="0">
+        <input type="number" id="hsv-v" min="0" max="100" value="0">
+      </div>
+      <div id="xyz" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('xyz')">XYZ</button>
+        <input type="number" id="xyz-x" min="0" max="95.050" step="0.1" value="0">
+        <input type="number" id="xyz-y" min="0" max="100" step="0.1" value="0">
+        <input type="number" id="xyz-z" min="0" max="108.900" step="0.1" value="0">
+      </div>
+      <div id="lab" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('lab')">Lab</button>
+        <input type="number" id="lab-l" min="0" max="100" step="0.1" value="0">
+        <input type="number" id="lab-a" min="-128" max="127" step="0.1" value="0">
+        <input type="number" id="lab-b" min="-128" max="127" step="0.1" value="0">
+      </div>
+      <div id="lms" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('lms')">LMS</button>
+        <input type="number" id="lms-l" min="0" step="0.001" value="0">
+        <input type="number" id="lms-m" min="0" step="0.001" value="0">
+        <input type="number" id="lms-s" min="0" step="0.001" value="0">
+      </div>
+      <div id="oklab" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('oklab')">Oklab</button>
+        <input type="number" id="oklab-l" min="0" max="1" step="0.01" value="0">
+        <input type="number" id="oklab-a" min="-0.5" max="0.5" step="0.01" value="0">
+        <input type="number" id="oklab-b" min="-0.5" max="0.5" step="0.01" value="0">
+      </div>
+      <div id="oklch" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('oklch')">Oklch</button>
+        <input type="number" id="oklch-l" min="0" max="1" step="0.01" value="0">
+        <input type="number" id="oklch-c" min="0" max="0.5" step="0.01" value="0">
+        <input type="number" id="oklch-h" min="0" max="360" step="1" value="0">
+      </div>
+      <div id="xyb" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('xyb')">XYB</button>
+        <input type="number" id="xyb-x" step="0.1" value="0">
+        <input type="number" id="xyb-y" step="0.1" value="0">
+        <input type="number" id="xyb-b" min="0" step="0.1" value="0">
+      </div>
+      <div id="ycbcr" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('ycbcr')">YCbCr</button>
+        <input type="number" id="ycbcr-y" min="0" max="255" step="0.1" value="0">
+        <input type="number" id="ycbcr-cb" min="0" max="255" step="0.1" value="128">
+        <input type="number" id="ycbcr-cr" min="0" max="255" step="0.1" value="128">
+      </div>
     </div>
     <script src="colorspaces.js"></script>
     <script>
@@ -157,6 +161,9 @@
           case 'oklab':
             inputs = ['oklab-l', 'oklab-a', 'oklab-b'].map(id => document.getElementById(id));
             break;
+          case 'oklch':
+            inputs = ['oklch-l', 'oklch-c', 'oklch-h'].map(id => document.getElementById(id));
+            break;
           case 'xyb':
             inputs = ['xyb-x', 'xyb-y', 'xyb-b'].map(id => document.getElementById(id));
             break;
@@ -174,57 +181,57 @@
           console.error('Failed to copy: ', err);
         });
       }
-      
+
       // Function to update background with a pastel version of current color
       function updateBackground() {
         try {
           const rgbR = parseInt(document.getElementById('rgb-r').value) || 0;
-          const rgbG = parseInt(document.getElementById('rgb-g').value) || 0; 
+          const rgbG = parseInt(document.getElementById('rgb-g').value) || 0;
           const rgbB = parseInt(document.getElementById('rgb-b').value) || 0;
-          
+
           // Check if color is grayscale (R = G = B)
           if (rgbR === rgbG && rgbG === rgbB) {
             // Use default background for grayscale colors
             document.body.style.backgroundColor = '#f5f5f5';
             return;
           }
-          
+
           // Convert RGB to HSL for easier manipulation
           const hsl = rgbToHsl(rgbR, rgbG, rgbB);
-          
+
           // Check if saturation is very low (essentially gray)
           if (hsl.s < 5) {
             // Use default background for very low saturation colors
             document.body.style.backgroundColor = '#f5f5f5';
             return;
           }
-          
+
           // Create pastel version: high lightness (88%), low saturation (25%)
           const pastelHsl = `hsl(${hsl.h}, 25%, 88%)`;
-          
+
           document.body.style.backgroundColor = pastelHsl;
         } catch (error) {
           // Fallback to default background if conversion fails
           document.body.style.backgroundColor = '#f5f5f5';
         }
       }
-      
+
       // Helper function to convert RGB to HSL
       function rgbToHsl(r, g, b) {
         r /= 255;
         g /= 255;
         b /= 255;
-        
+
         const max = Math.max(r, g, b);
         const min = Math.min(r, g, b);
         let h, s, l = (max + min) / 2;
-        
+
         if (max === min) {
           h = s = 0; // achromatic
         } else {
           const d = max - min;
           s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-          
+
           switch (max) {
             case r: h = (g - b) / d + (g < b ? 6 : 0); break;
             case g: h = (b - r) / d + 2; break;
@@ -232,41 +239,41 @@
           }
           h /= 6;
         }
-        
+
         return {
           h: Math.round(h * 360),
           s: Math.round(s * 100),
           l: Math.round(l * 100)
         };
       }
-      
+
       // Handle mouse wheel events on number inputs
       function handleWheel(event) {
         if (event.target.type === 'number') {
           event.preventDefault();
-          
+
           const input = event.target;
           const step = parseFloat(input.step) || 1;
           const min = parseFloat(input.min);
           const max = parseFloat(input.max);
           let currentValue = parseFloat(input.value) || 0;
-          
+
           // Determine direction (negative deltaY means scroll up)
           const delta = event.deltaY < 0 ? step : -step;
           let newValue = currentValue + delta;
-          
+
           // Clamp to min/max if they exist
           if (!isNaN(min) && newValue < min) newValue = min;
           if (!isNaN(max) && newValue > max) newValue = max;
-          
+
           // Update input value
           input.value = newValue;
-          
+
           // Trigger input event to update other color spaces
           input.dispatchEvent(new Event('input', { bubbles: true }));
         }
       }
-      
+
       // Call updateBackground when any color input changes
       document.addEventListener('DOMContentLoaded', function() {
         // Get all color input elements and add event listeners
@@ -274,13 +281,13 @@
         inputs.forEach(input => {
           input.addEventListener('input', updateBackground);
           input.addEventListener('change', updateBackground);
-          
+
           // Add wheel event listener for number inputs
           if (input.type === 'number') {
             input.addEventListener('wheel', handleWheel);
           }
         });
-        
+
         // Initial background update
         updateBackground();
       });

--- a/examples/web/colorspaces.js
+++ b/examples/web/colorspaces.js
@@ -72,6 +72,10 @@
     document.getElementById("oklab-l").addEventListener("input", updateFromOklab);
     document.getElementById("oklab-a").addEventListener("input", updateFromOklab);
     document.getElementById("oklab-b").addEventListener("input", updateFromOklab);
+    // Event listeners for Oklch
+    document.getElementById("oklch-l").addEventListener("input", updateFromOklch);
+    document.getElementById("oklch-c").addEventListener("input", updateFromOklch);
+    document.getElementById("oklch-h").addEventListener("input", updateFromOklch);
     // Event listeners for XYB
     document.getElementById("xyb-x").addEventListener("input", updateFromXyb);
     document.getElementById("xyb-y").addEventListener("input", updateFromXyb);
@@ -170,6 +174,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function rgb2oklch(r, g, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.rgb2oklch(r, g, b, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function rgb2xyb(r, g, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -204,6 +217,7 @@
       rgb2lab(r, g, b);
       rgb2lms(r, g, b);
       rgb2oklab(r, g, b);
+      rgb2oklch(r, g, b);
       rgb2xyb(r, g, b);
       rgb2ycbcr(r, g, b);
       updateHex();
@@ -264,6 +278,15 @@
       document.getElementById("oklab-a").value = out[1].toFixed(6);
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
+
+    function hsl2oklch(h, s, l) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.hsl2oklch(h, s, l, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
     function hsl2xyb(h, s, l) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -298,6 +321,7 @@
       hsl2lab(h, s, l);
       hsl2lms(h, s, l);
       hsl2oklab(h, s, l);
+      hsl2oklch(h, s, l);
       hsl2xyb(h, s, l);
       hsl2ycbcr(h, s, l);
       updateHex();
@@ -359,6 +383,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function hsv2oklch(h, s, v) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.hsv2oklch(h, s, v, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function hsv2xyb(h, s, v) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -393,6 +426,7 @@
       hsv2lab(h, s, v);
       hsv2lms(h, s, v);
       hsv2oklab(h, s, v);
+      hsv2oklch(h, s, v);
       hsv2xyb(h, s, v);
       hsv2ycbcr(h, s, v);
       updateHex();
@@ -454,6 +488,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function xyz2oklch(x, y, z) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.xyz2oklch(x, y, z, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function xyz2xyb(x, y, z) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -488,6 +531,7 @@
       xyz2lab(x, y, z);
       xyz2lms(x, y, z);
       xyz2oklab(x, y, z);
+      xyz2oklch(x, y, z);
       xyz2xyb(x, y, z);
       xyz2ycbcr(x, y, z);
       updateHex();
@@ -549,6 +593,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function lab2oklch(l, a, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lab2oklch(l, a, b, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function lab2xyb(l, a, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -583,6 +636,7 @@
       lab2xyz(l, a, b);
       lab2lms(l, a, b);
       lab2oklab(l, a, b);
+      lab2oklch(l, a, b);
       lab2xyb(l, a, b);
       lab2ycbcr(l, a, b);
       updateHex();
@@ -644,6 +698,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function lms2oklch(l, m, s) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lms2oklch(l, m, s, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function lms2xyb(l, m, s) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -675,6 +738,7 @@
       lms2xyz(l, a, b);
       lms2lab(l, a, b);
       lms2oklab(l, a, b);
+      lms2oklch(l, a, b);
       lms2xyb(l, a, b);
       lms2ycbcr(l, a, b);
       updateHex();
@@ -745,6 +809,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function oklab2oklch(l, a, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklab2oklch(l, a, b, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function oklab2ycbcr(l, a, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -770,8 +843,114 @@
       oklab2xyz(l, a, b);
       oklab2lms(l, a, b);
       oklab2lab(l, a, b);
+      oklab2oklch(l, a, b);
       oklab2xyb(l, a, b);
       oklab2ycbcr(l, a, b);
+      updateHex();
+    }
+
+    // --- Oklch ---
+
+    function oklch2rgb(l, c, h) {
+      const outPtr = wasmExports.alloc(3);
+      const out = new Uint8Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2rgb(l, c, h, outPtr);
+      document.getElementById("rgb-r").value = out[0];
+      document.getElementById("rgb-g").value = out[1];
+      document.getElementById("rgb-b").value = out[2];
+    }
+
+    function oklch2hsl(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2hsl(l, c, h, outPtr);
+      document.getElementById("hsl-h").value = out[0].toFixed(6);
+      document.getElementById("hsl-s").value = out[1].toFixed(6);
+      document.getElementById("hsl-l").value = out[2].toFixed(6);
+    }
+
+    function oklch2hsv(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2hsv(l, c, h, outPtr);
+      document.getElementById("hsv-h").value = out[0].toFixed(6);
+      document.getElementById("hsv-s").value = out[1].toFixed(6);
+      document.getElementById("hsv-v").value = out[2].toFixed(6);
+    }
+
+    function oklch2xyz(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2xyz(l, c, h, outPtr);
+      document.getElementById("xyz-x").value = out[0].toFixed(6);
+      document.getElementById("xyz-y").value = out[1].toFixed(6);
+      document.getElementById("xyz-z").value = out[2].toFixed(6);
+    }
+
+    function oklch2lab(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2lab(l, c, h, outPtr);
+      document.getElementById("lab-l").value = out[0].toFixed(6);
+      document.getElementById("lab-a").value = out[1].toFixed(6);
+      document.getElementById("lab-b").value = out[2].toFixed(6);
+    }
+
+    function oklch2lms(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2lms(l, c, h, outPtr);
+      document.getElementById("lms-l").value = out[0].toFixed(6);
+      document.getElementById("lms-m").value = out[1].toFixed(6);
+      document.getElementById("lms-s").value = out[2].toFixed(6);
+    }
+
+    function oklch2oklab(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2oklab(l, c, h, outPtr);
+      document.getElementById("oklab-l").value = out[0].toFixed(6);
+      document.getElementById("oklab-a").value = out[1].toFixed(6);
+      document.getElementById("oklab-b").value = out[2].toFixed(6);
+    }
+
+    function oklch2xyb(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2xyb(l, c, h, outPtr);
+      document.getElementById("xyb-x").value = out[0].toFixed(6);
+      document.getElementById("xyb-y").value = out[1].toFixed(6);
+      document.getElementById("xyb-b").value = out[2].toFixed(6);
+    }
+
+    function oklch2ycbcr(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2ycbcr(l, c, h, outPtr);
+      document.getElementById("ycbcr-y").value = out[0].toFixed(6);
+      document.getElementById("ycbcr-cb").value = out[1].toFixed(6);
+      document.getElementById("ycbcr-cr").value = out[2].toFixed(6);
+    }
+
+    function updateFromOklch() {
+      const l = parseFloat(document.getElementById("oklch-l").value);
+      const c = parseFloat(document.getElementById("oklch-c").value);
+      const h = parseFloat(document.getElementById("oklch-h").value);
+      if (l < 0) document.getElementById("oklch-l").value = 0;
+      if (c < 0) document.getElementById("oklch-c").value = 0;
+      if (h < 0) document.getElementById("oklch-h").value = 0;
+      if (l > 1) document.getElementById("oklch-l").value = 1;
+      if (c > 0.5) document.getElementById("oklch-c").value = 0.5;
+      if (h >= 360) document.getElementById("oklch-h").value = h % 360;
+      oklch2rgb(l, c, h);
+      oklch2hsl(l, c, h);
+      oklch2hsv(l, c, h);
+      oklch2xyz(l, c, h);
+      oklch2lab(l, c, h);
+      oklch2lms(l, c, h);
+      oklch2oklab(l, c, h);
+      oklch2xyb(l, c, h);
+      oklch2ycbcr(l, c, h);
       updateHex();
     }
 
@@ -838,6 +1017,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function xyb2oklch(x, y, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.xyb2oklch(x, y, b, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function xyb2ycbcr(x, y, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -859,6 +1047,7 @@
       xyb2lab(x, y, b);
       xyb2lms(x, y, b);
       xyb2oklab(x, y, b);
+      xyb2oklch(x, y, b);
       xyb2ycbcr(x, y, b);
       updateHex();
     }
@@ -928,6 +1117,15 @@
       document.getElementById("oklab-b").value = out[2].toFixed(6);
     }
 
+    function ycbcr2oklch(y, cb, cr) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.ycbcr2oklch(y, cb, cr, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
     function ycbcr2xyb(y, cb, cr) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -954,6 +1152,7 @@
       ycbcr2lab(y, cb, cr);
       ycbcr2lms(y, cb, cr);
       ycbcr2oklab(y, cb, cr);
+      ycbcr2oklch(y, cb, cr);
       ycbcr2xyb(y, cb, cr);
       updateHex();
     }

--- a/src/color.zig
+++ b/src/color.zig
@@ -15,6 +15,7 @@ pub const Hsv = @import("color/Hsv.zig");
 pub const Lab = @import("color/Lab.zig");
 pub const Lms = @import("color/Lms.zig");
 pub const Oklab = @import("color/Oklab.zig");
+pub const Oklch = @import("color/Oklch.zig");
 pub const Rgb = @import("color/Rgb.zig");
 pub const Rgba = @import("color/Rgba.zig").Rgba;
 pub const Xyb = @import("color/Xyb.zig");
@@ -88,6 +89,14 @@ test "blend methods for all color types" {
         var oklab_color = Oklab{ .l = 0, .a = 0, .b = 0 }; // black
         oklab_color.blend(red_rgba);
         const result_rgb = oklab_color.toRgb();
+        try expectEqualDeep(result_rgb, expected_rgb);
+    }
+
+    // Test Oklch.blend
+    {
+        var oklch_color = Oklch{ .l = 0, .c = 0, .h = 0 }; // black
+        oklch_color.blend(red_rgba);
+        const result_rgb = oklch_color.toRgb();
         try expectEqualDeep(result_rgb, expected_rgb);
     }
 
@@ -321,6 +330,7 @@ test "color type validation" {
     try expectEqual(isColor(Xyz), true);
     try expectEqual(isColor(Lms), true);
     try expectEqual(isColor(Oklab), true);
+    try expectEqual(isColor(Oklch), true);
     try expectEqual(isColor(Xyb), true);
     try expectEqual(isColor(Ycbcr), true);
     try expectEqual(isColor(f32), false);
@@ -358,6 +368,7 @@ test "extended color space round trips" {
         try expectEqualDeep(original, original.toXyz().toRgb());
         try expectEqualDeep(original, original.toLms().toRgb());
         try expectEqualDeep(original, original.toOklab().toRgb());
+        try expectEqualDeep(original, original.toOklch().toRgb());
         try expectEqualDeep(original, original.toXyb().toRgb());
     }
 }
@@ -374,6 +385,7 @@ test "comprehensive color conversion paths" {
     const xyz = test_rgb.toXyz();
     const lms = test_rgb.toLms();
     const oklab = test_rgb.toOklab();
+    const oklch = test_rgb.toOklch();
     const xyb = test_rgb.toXyb();
     const ycbcr = test_rgb.toYcbcr();
 
@@ -446,7 +458,7 @@ test "comprehensive color conversion paths" {
     _ = lms.toXyb();
     _ = lms.toYcbcr();
 
-    // From Oklab - test all 9 conversion methods
+    // From Oklab - test all 10 conversion methods
     _ = oklab.toRgb();
     _ = oklab.toRgba(255);
     _ = oklab.toHsl();
@@ -454,10 +466,23 @@ test "comprehensive color conversion paths" {
     _ = oklab.toLab();
     _ = oklab.toXyz();
     _ = oklab.toLms();
+    _ = oklab.toOklch();
     _ = oklab.toXyb();
     _ = oklab.toYcbcr();
 
-    // From Xyb - test all 9 conversion methods
+    // From Oklch - test all 10 conversion methods
+    _ = oklch.toRgb();
+    _ = oklch.toRgba(255);
+    _ = oklch.toHsl();
+    _ = oklch.toHsv();
+    _ = oklch.toLab();
+    _ = oklch.toXyz();
+    _ = oklch.toLms();
+    _ = oklch.toOklab();
+    _ = oklch.toXyb();
+    _ = oklch.toYcbcr();
+
+    // From Xyb - test all 10 conversion methods
     _ = xyb.toRgb();
     _ = xyb.toRgba(255);
     _ = xyb.toHsl();

--- a/src/color.zig
+++ b/src/color.zig
@@ -392,40 +392,44 @@ test "comprehensive color conversion paths" {
     // Test all conversions FROM each color type to ensure no compilation errors
     // and that all conversion methods exist and work correctly
 
-    // From Rgba - test all 9 conversion methods
+    // From Rgba - test all 10 conversion methods
     _ = rgba.toRgb();
     _ = rgba.toHsl();
     _ = rgba.toHsv();
     _ = rgba.toLab();
+    _ = rgba.toOklch();
     _ = rgba.toXyz();
     _ = rgba.toLms();
     _ = rgba.toOklab();
     _ = rgba.toXyb();
     _ = rgba.toYcbcr();
 
-    // From Hsl - test all 9 conversion methods
+    // From Hsl - test all 10 conversion methods
     _ = hsl.toRgb();
     _ = hsl.toRgba(255);
     _ = hsl.toHsv(); // This was the buggy method we fixed
     _ = hsl.toLab();
+    _ = hsl.toOklch();
     _ = hsl.toXyz();
     _ = hsl.toLms();
     _ = hsl.toOklab();
     _ = hsl.toXyb();
     _ = hsl.toYcbcr();
 
-    // From Hsv - test all 9 conversion methods
+    // From Hsv - test all 10 conversion methods
     _ = hsv.toRgb();
     _ = hsv.toRgba(255);
     _ = hsv.toHsl();
     _ = hsv.toLab();
+    _ = hsv.toOklch();
     _ = hsv.toXyz();
     _ = hsv.toLms();
     _ = hsv.toOklab();
     _ = hsv.toXyb();
     _ = hsv.toYcbcr();
 
-    // From Lab - test all 9 conversion methods
+    // From Lab - test all 10 conversion methods
+    // From Lab - toOklchall 10 conversion methods
     _ = lab.toRgb();
     _ = lab.toRgba(255);
     _ = lab.toHsl();
@@ -436,23 +440,25 @@ test "comprehensive color conversion paths" {
     _ = lab.toXyb();
     _ = lab.toYcbcr();
 
-    // From Xyz - test all 9 conversion methods
+    // From Xyz - test all 10 conversion methods
     _ = xyz.toRgb();
     _ = xyz.toRgba(255);
     _ = xyz.toHsl();
     _ = xyz.toHsv();
     _ = xyz.toLab();
+    _ = xyz.toOklch();
     _ = xyz.toLms();
     _ = xyz.toOklab();
     _ = xyz.toXyb();
     _ = xyz.toYcbcr();
 
-    // From Lms - test all 9 conversion methods
+    // From Lms - test all 10 conversion methods
     _ = lms.toRgb();
     _ = lms.toRgba(255);
     _ = lms.toHsl();
     _ = lms.toHsv();
     _ = lms.toLab();
+    _ = lms.toOklch();
     _ = lms.toXyz();
     _ = lms.toOklab();
     _ = lms.toXyb();
@@ -464,6 +470,7 @@ test "comprehensive color conversion paths" {
     _ = oklab.toHsl();
     _ = oklab.toHsv();
     _ = oklab.toLab();
+    _ = oklab.toOklch();
     _ = oklab.toXyz();
     _ = oklab.toLms();
     _ = oklab.toOklch();
@@ -488,17 +495,19 @@ test "comprehensive color conversion paths" {
     _ = xyb.toHsl();
     _ = xyb.toHsv();
     _ = xyb.toLab();
+    _ = xyb.toOklch();
     _ = xyb.toXyz();
     _ = xyb.toLms();
     _ = xyb.toOklab();
     _ = xyb.toYcbcr();
 
-    // From Ycbcr - test all 9 conversion methods
+    // From Ycbcr - test all 10 conversion methods
     _ = ycbcr.toRgb();
     _ = ycbcr.toRgba(255);
     _ = ycbcr.toHsl();
     _ = ycbcr.toHsv();
     _ = ycbcr.toLab();
+    _ = ycbcr.toOklch();
     _ = ycbcr.toXyz();
     _ = ycbcr.toLms();
     _ = ycbcr.toOklab();

--- a/src/color/Hsl.zig
+++ b/src/color/Hsl.zig
@@ -11,6 +11,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -27,7 +28,7 @@ pub const black: Hsl = .{ .h = 0, .s = 0, .l = 0 };
 pub const white: Hsl = .{ .h = 0, .s = 0, .l = 100 };
 
 /// Default formatting with ANSI color output
-pub fn format(self: Hsl, writer: anytype) !void {
+pub fn format(self: Hsl, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Hsl, self, writer);
 }
 
@@ -74,6 +75,11 @@ pub fn toLms(self: Hsl) Lms {
 /// Converts HSL to Oklab via RGB intermediate conversion.
 pub fn toOklab(self: Hsl) Oklab {
     return self.toRgb().toOklab();
+}
+
+/// Converts HSL to Oklch via RGB intermediate conversion.
+pub fn toOklch(self: Hsl) Oklch {
+    return self.toRgb().toOklch();
 }
 
 /// Converts HSL to XYB via RGB intermediate conversion.

--- a/src/color/Hsv.zig
+++ b/src/color/Hsv.zig
@@ -11,6 +11,7 @@ const Hsl = @import("Hsl.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -27,7 +28,7 @@ pub const black: Hsv = .{ .h = 0, .s = 0, .v = 0 };
 pub const white: Hsv = .{ .h = 0, .s = 0, .v = 100 };
 
 /// Default formatting with ANSI color output
-pub fn format(self: Hsv, writer: anytype) !void {
+pub fn format(self: Hsv, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Hsv, self, writer);
 }
 
@@ -74,6 +75,11 @@ pub fn toLms(self: Hsv) Lms {
 /// Converts HSV to Oklab via RGB intermediate conversion.
 pub fn toOklab(self: Hsv) Oklab {
     return self.toRgb().toOklab();
+}
+
+/// Converts HSV to Oklch via RGB intermediate conversion.
+pub fn toOklch(self: Hsv) Oklch {
+    return self.toRgb().toOklch();
 }
 
 /// Converts HSV to XYB via RGB intermediate conversion.

--- a/src/color/Lab.zig
+++ b/src/color/Lab.zig
@@ -12,6 +12,7 @@ const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -28,7 +29,7 @@ pub const black: Lab = .{ .l = 0, .a = 0, .b = 0 };
 pub const white: Lab = .{ .l = 100, .a = 0, .b = 0 };
 
 /// Default formatting with ANSI color output
-pub fn format(self: Lab, writer: anytype) !void {
+pub fn format(self: Lab, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Lab, self, writer);
 }
 
@@ -75,6 +76,11 @@ pub fn toLms(self: Lab) Lms {
 /// Converts CIELAB to Oklab via LMS intermediate conversion.
 pub fn toOklab(self: Lab) Oklab {
     return self.toLms().toOklab();
+}
+
+/// Converts CIELAB to Oklch via Oklab intermediate conversion.
+pub fn toOklch(self: Lab) Oklch {
+    return self.toOklab().toOklch();
 }
 
 /// Converts CIELAB to XYB via LMS intermediate conversion.

--- a/src/color/Lms.zig
+++ b/src/color/Lms.zig
@@ -10,6 +10,7 @@ const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -26,7 +27,7 @@ pub const black: Lms = .{ .l = 0, .m = 0, .s = 0 };
 
 /// Formats the LMS color for display. Use "color" format for ANSI color output.
 /// Default formatting with ANSI color output
-pub fn format(self: Lms, writer: anytype) !void {
+pub fn format(self: Lms, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Lms, self, writer);
 }
 
@@ -74,6 +75,11 @@ pub fn toLab(self: Lms) Lab {
 /// Converts LMS to Oklab color space using direct conversion.
 pub fn toOklab(self: Lms) Oklab {
     return conversions.lmsToOklab(self);
+}
+
+/// Converts LMS to Oklch via Oklab intermediate conversion.
+pub fn toOklch(self: Lms) Oklch {
+    return self.toOklab().toOklch();
 }
 
 /// Converts LMS to XYB color space using direct conversion.

--- a/src/color/Oklab.zig
+++ b/src/color/Oklab.zig
@@ -12,6 +12,7 @@ const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -28,7 +29,7 @@ pub const black: Oklab = .{ .l = 0, .a = 0, .b = 0 };
 
 /// Formats the Oklab color for display. Use "color" format for ANSI color output.
 /// Default formatting with ANSI color output
-pub fn format(self: Oklab, writer: anytype) !void {
+pub fn format(self: Oklab, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Oklab, self, writer);
 }
 
@@ -75,6 +76,11 @@ pub fn toLab(self: Oklab) Lab {
 /// Converts Oklab to LMS cone response using direct conversion.
 pub fn toLms(self: Oklab) Lms {
     return conversions.oklabToLms(self);
+}
+
+/// Converts Oklab to Oklch (cylindrical representation).
+pub fn toOklch(self: Oklab) Oklch {
+    return conversions.oklabToOklch(self);
 }
 
 /// Converts Oklab to XYB color space using direct conversion.

--- a/src/color/Oklch.zig
+++ b/src/color/Oklch.zig
@@ -1,0 +1,101 @@
+//! A color in the [Oklch color space](https://en.wikipedia.org/wiki/Oklab_color_space).
+//! Oklch is the cylindrical representation of the Oklab color space.
+//! - l: Perceived lightness (0 for black to approximately 1 for white).
+//! - c: Chroma (chromatic intensity) (0 for achromatic to approximately 0.5 for pure colors).
+//! - h: Hue angle in degrees (0-360).
+
+const std = @import("std");
+
+const conversions = @import("conversions.zig");
+const formatting = @import("formatting.zig");
+const Hsl = @import("Hsl.zig");
+const Hsv = @import("Hsv.zig");
+const Lab = @import("Lab.zig");
+const Lms = @import("Lms.zig");
+const Oklab = @import("Oklab.zig");
+const Rgb = @import("Rgb.zig");
+const Rgba = @import("Rgba.zig").Rgba;
+const Xyb = @import("Xyb.zig");
+const Xyz = @import("Xyz.zig");
+const Ycbcr = @import("Ycbcr.zig");
+
+l: f64,
+c: f64,
+h: f64,
+
+const Oklch = @This();
+
+pub const black: Oklch = .{ .l = 0, .c = 0, .h = 0 };
+
+/// Formats the Oklch color for display. Use "color" format for ANSI color output.
+/// Default formatting with ANSI color output
+pub fn format(self: Oklch, writer: *std.Io.Writer) !void {
+    return formatting.formatColor(Oklch, self, writer);
+}
+
+/// Returns true if chroma is 0 (neutral gray).
+pub fn isGray(self: Oklch) bool {
+    return self.c == 0;
+}
+
+/// Converts to grayscale using the L (lightness) component.
+pub fn toGray(self: Oklch) u8 {
+    return @intFromFloat(@round(@max(0, @min(1, self.l)) * 255));
+}
+
+/// Converts Oklch to Oklab color space.
+pub fn toOklab(self: Oklch) Oklab {
+    return conversions.oklchToOklab(self);
+}
+
+/// Converts Oklch to RGB color space.
+pub fn toRgb(self: Oklch) Rgb {
+    return conversions.oklchToRgb(self);
+}
+
+/// Converts Oklch to RGBA by first converting to RGB and adding alpha.
+pub fn toRgba(self: Oklch, alpha: u8) Rgba {
+    return self.toRgb().toRgba(alpha);
+}
+
+/// Converts Oklch to HSL color space via RGB intermediate conversion.
+pub fn toHsl(self: Oklch) Hsl {
+    return conversions.oklchToHsl(self);
+}
+
+/// Converts Oklch to HSV color space via RGB intermediate conversion.
+pub fn toHsv(self: Oklch) Hsv {
+    return conversions.oklchToHsv(self);
+}
+
+/// Converts Oklch to CIE XYZ color space via Oklab intermediate conversion.
+pub fn toXyz(self: Oklch) Xyz {
+    return conversions.oklchToXyz(self);
+}
+
+/// Converts Oklch to CIELAB color space via Oklab intermediate conversion.
+pub fn toLab(self: Oklch) Lab {
+    return conversions.oklchToLab(self);
+}
+
+/// Converts Oklch to LMS cone response via Oklab intermediate conversion.
+pub fn toLms(self: Oklch) Lms {
+    return conversions.oklchToLms(self);
+}
+
+/// Converts Oklch to XYB color space via Oklab intermediate conversion.
+pub fn toXyb(self: Oklch) Xyb {
+    return conversions.oklchToXyb(self);
+}
+
+/// Converts Oklch to YCbCr via RGB.
+pub fn toYcbcr(self: Oklch) Ycbcr {
+    return self.toRgb().toYcbcr();
+}
+
+/// Alpha blends the given RGBA color onto this Oklch color in-place.
+pub fn blend(self: *Oklch, color: Rgba) void {
+    var rgb = self.toRgb();
+    rgb.blend(color);
+    self.* = rgb.toOklch();
+}

--- a/src/color/Rgb.zig
+++ b/src/color/Rgb.zig
@@ -10,6 +10,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
 const Xyz = @import("Xyz.zig");
@@ -28,7 +29,7 @@ pub const green: Rgb = .{ .r = 0, .g = 255, .b = 0 };
 pub const blue: Rgb = .{ .r = 0, .g = 0, .b = 255 };
 
 /// Default formatting with ANSI color output
-pub fn format(self: Rgb, writer: anytype) !void {
+pub fn format(self: Rgb, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Rgb, self, writer);
 }
 
@@ -99,6 +100,11 @@ pub fn toLms(self: Rgb) Lms {
 /// Converts RGB to Oklab color space for improved perceptual uniformity.
 pub fn toOklab(self: Rgb) Oklab {
     return conversions.lmsToOklab(self.toLms());
+}
+
+/// Converts RGB to Oklch color space via Oklab intermediate conversion.
+pub fn toOklch(self: Rgb) Oklch {
+    return conversions.oklabToOklch(self.toOklab());
 }
 
 /// Converts RGB to XYB color space via LMS intermediate conversion.

--- a/src/color/Rgba.zig
+++ b/src/color/Rgba.zig
@@ -7,6 +7,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Xyb = @import("Xyb.zig");
 const Xyz = @import("Xyz.zig");
@@ -25,7 +26,7 @@ pub const Rgba = packed struct {
     pub const transparent: Rgba = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
 
     /// Default formatting with ANSI color output
-    pub fn format(self: Rgba, writer: anytype) !void {
+    pub fn format(self: Rgba, writer: *std.Io.Writer) !void {
         return formatting.formatColor(Rgba, self, writer);
     }
 
@@ -92,6 +93,11 @@ pub const Rgba = packed struct {
     /// Converts RGBA to Oklab by first converting to RGB.
     pub fn toOklab(self: Rgba) Oklab {
         return self.toRgb().toOklab();
+    }
+
+    /// Converts RGBA to Oklch by first converting to RGB.
+    pub fn toOklch(self: Rgba) Oklch {
+        return self.toRgb().toOklch();
     }
 
     /// Converts RGBA to XYB by first converting to RGB.

--- a/src/color/Xyb.zig
+++ b/src/color/Xyb.zig
@@ -14,6 +14,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyz = @import("Xyz.zig");
@@ -29,7 +30,7 @@ pub const black: Xyb = .{ .x = 0, .y = 0, .b = 0 };
 
 /// Formats the XYB color for display. Use "color" format for ANSI color output.
 /// Default formatting with ANSI color output
-pub fn format(self: Xyb, writer: anytype) !void {
+pub fn format(self: Xyb, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Xyb, self, writer);
 }
 
@@ -82,6 +83,11 @@ pub fn toLms(self: Xyb) Lms {
 /// Converts XYB to Oklab color space using direct conversion.
 pub fn toOklab(self: Xyb) Oklab {
     return conversions.xybToOklab(self);
+}
+
+/// Converts XYB to Oklch via Oklab intermediate conversion.
+pub fn toOklch(self: Xyb) Oklch {
+    return self.toOklab().toOklch();
 }
 
 /// Converts XYB to YCbCr via RGB.

--- a/src/color/Xyz.zig
+++ b/src/color/Xyz.zig
@@ -14,6 +14,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -30,7 +31,7 @@ pub const black: Self = .{ .x = 0, .y = 0, .z = 0 };
 
 /// Formats the CIE XYZ color for display. Use "color" format for ANSI color output.
 /// Default formatting with ANSI color output
-pub fn format(self: Self, writer: anytype) !void {
+pub fn format(self: Self, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Self, self, writer);
 }
 
@@ -77,6 +78,11 @@ pub fn toLms(self: Self) Lms {
 /// Converts CIE XYZ to Oklab color space using direct conversion.
 pub fn toOklab(self: Self) Oklab {
     return conversions.xyzToOklab(self);
+}
+
+/// Converts CIE XYZ to Oklch via Oklab intermediate conversion.
+pub fn toOklch(self: Self) Oklch {
+    return self.toOklab().toOklch();
 }
 
 /// Converts CIE XYZ to XYB color space using direct conversion.

--- a/src/color/Ycbcr.zig
+++ b/src/color/Ycbcr.zig
@@ -11,6 +11,7 @@ const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
 const Rgba = @import("Rgba.zig").Rgba;
 const Xyb = @import("Xyb.zig");
@@ -31,7 +32,7 @@ pub const white: Ycbcr = .{ .y = 255, .cb = 128, .cr = 128 };
 
 /// Formats the Ycbcr color for display. Use "color" format for ANSI color output.
 /// Default formatting with ANSI color output
-pub fn format(self: Ycbcr, writer: anytype) !void {
+pub fn format(self: Ycbcr, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Ycbcr, self, writer);
 }
 
@@ -73,6 +74,11 @@ pub fn toLms(self: Ycbcr) Lms {
 /// Converts to Oklab via RGB.
 pub fn toOklab(self: Ycbcr) Oklab {
     return self.toRgb().toOklab();
+}
+
+/// Converts to Oklch via RGB.
+pub fn toOklch(self: Ycbcr) Oklch {
+    return self.toRgb().toOklch();
 }
 
 /// Converts to XYB via RGB.

--- a/src/color/formatting.zig
+++ b/src/color/formatting.zig
@@ -15,7 +15,7 @@ const Rgb = @import("Rgb.zig");
 pub fn formatColor(
     comptime T: type,
     self: T,
-    writer: anytype,
+    writer: *std.Io.Writer,
 ) !void {
 
     // Get the short type name

--- a/src/image.zig
+++ b/src/image.zig
@@ -260,7 +260,7 @@ pub fn Image(comptime T: type) type {
         /// Formats the image as a grid of colored spaces, where each pixel is represented by a space
         /// with the appropriate background color. This provides a visual representation of the image
         /// in terminal output.
-        pub fn format(self: Self, writer: anytype) !void {
+        pub fn format(self: Self, writer: *std.Io.Writer) !void {
             const Rgb = @import("color.zig").Rgb;
             for (0..self.rows) |r| {
                 for (0..self.cols) |c| {

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -107,7 +107,7 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Default formatting (scientific notation)
-        pub fn format(self: Self, writer: anytype) !void {
+        pub fn format(self: Self, writer: *std.Io.Writer) !void {
             try formatting.formatMatrix(self, "{e}", writer);
         }
 

--- a/src/matrix/SMatrix.zig
+++ b/src/matrix/SMatrix.zig
@@ -394,7 +394,7 @@ pub fn SMatrix(comptime T: type, comptime rows: usize, comptime cols: usize) typ
         }
 
         /// Default formatting (scientific notation)
-        pub fn format(self: Self, writer: anytype) !void {
+        pub fn format(self: Self, writer: *std.Io.Writer) !void {
             try formatting.formatMatrix(self, "{e}", writer);
         }
 

--- a/src/matrix/formatting.zig
+++ b/src/matrix/formatting.zig
@@ -14,7 +14,7 @@ fn formatNumber(comptime T: type, buf: []u8, comptime format_str: []const u8, va
 }
 
 /// Generic matrix formatting function that works with both SMatrix and Matrix
-pub fn formatMatrix(matrix: anytype, comptime number_fmt: []const u8, writer: anytype) !void {
+pub fn formatMatrix(matrix: anytype, comptime number_fmt: []const u8, writer: *std.Io.Writer) !void {
     const MatrixType = @TypeOf(matrix);
 
     // Matrix has allocator field, SMatrix doesn't
@@ -74,7 +74,7 @@ pub fn DecimalFormatter(comptime MatrixType: type, comptime precision: u8) type 
         const Self = @This();
         matrix: MatrixType,
 
-        pub fn format(self: Self, writer: anytype) !void {
+        pub fn format(self: Self, writer: *std.Io.Writer) !void {
             const number_fmt = std.fmt.comptimePrint("{{d:.{d}}}", .{precision});
             try formatMatrix(self.matrix, number_fmt, writer);
         }
@@ -87,7 +87,7 @@ pub fn ScientificFormatter(comptime MatrixType: type) type {
         const Self = @This();
         matrix: MatrixType,
 
-        pub fn format(self: Self, writer: anytype) !void {
+        pub fn format(self: Self, writer: *std.Io.Writer) !void {
             try formatMatrix(self.matrix, "{e}", writer);
         }
     };

--- a/src/root.zig
+++ b/src/root.zig
@@ -46,6 +46,7 @@ pub const Xyz = color.Xyz;
 pub const Lab = color.Lab;
 pub const Lms = color.Lms;
 pub const Oklab = color.Oklab;
+pub const Oklch = color.Oklch;
 pub const Xyb = color.Xyb;
 pub const Ycbcr = color.Ycbcr;
 


### PR DESCRIPTION
Implement Oklch color space with conversions to and from all
existing color spaces. Update color conversion examples and web
demo to include Oklch. Refine `writer` type annotations in
formatting functions.