### PR TITLE
feat(color): add LCh color space and conversions

### DIFF
--- a/examples/src/colorspaces.zig
+++ b/examples/src/colorspaces.zig
@@ -5,6 +5,7 @@ const convertColor = @import("zignal").convertColor;
 const Hsl = @import("zignal").Hsl;
 const Hsv = @import("zignal").Hsv;
 const Lab = @import("zignal").Lab;
+const Lch = @import("zignal").Lch;
 const Lms = @import("zignal").Lms;
 const Oklab = @import("zignal").Oklab;
 const Oklch = @import("zignal").Oklch;
@@ -84,6 +85,14 @@ export fn rgb2xyb(red: u8, green: u8, blue: u8, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn rgb2lch(red: u8, green: u8, blue: u8, out: [*]f64) void {
+    const res = convertColor(Lch, Rgb{ .r = red, .g = green, .b = blue });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn rgb2ycbcr(red: u8, green: u8, blue: u8, out: [*]f64) void {
     const res = convertColor(Ycbcr, Rgb{ .r = red, .g = green, .b = blue });
     std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
@@ -155,6 +164,14 @@ export fn hsl2xyb(h: f64, s: f64, l: f64, out: [*]f64) void {
     out[0] = res.x;
     out[1] = res.y;
     out[2] = res.b;
+}
+
+export fn hsl2lch(h: f64, s: f64, l: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Hsl{ .h = h, .s = s, .l = l });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn hsl2ycbcr(h: f64, s: f64, l: f64, out: [*]f64) void {
@@ -231,6 +248,14 @@ export fn hsv2xyb(h: f64, s: f64, v: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn hsv2lch(h: f64, s: f64, v: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Hsv{ .h = h, .s = s, .v = v });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn hsv2ycbcr(h: f64, s: f64, v: f64, out: [*]f64) void {
     const res = convertColor(Ycbcr, Hsv{ .h = h, .s = s, .v = v });
     std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
@@ -305,6 +330,14 @@ export fn xyz2xyb(x: f64, y: f64, z: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn xyz2lch(x: f64, y: f64, z: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Xyz{ .x = x, .y = y, .z = z });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn xyz2ycbcr(x: f64, y: f64, z: f64, out: [*]f64) void {
     const res = convertColor(Ycbcr, Xyz{ .x = x, .y = y, .z = z });
     std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
@@ -366,6 +399,14 @@ export fn lab2oklab(l: f64, a: f64, b: f64, out: [*]f64) void {
 export fn lab2oklch(l: f64, a: f64, b: f64, out: [*]f64) void {
     const res = convertColor(Oklch, Lab{ .l = l, .a = a, .b = b });
     std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
+export fn lab2lch(l: f64, a: f64, b: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Lab{ .l = l, .a = a, .b = b });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
     out[0] = res.l;
     out[1] = res.c;
     out[2] = res.h;
@@ -437,6 +478,14 @@ export fn lms2oklch(l: f64, m: f64, s: f64, out: [*]f64) void {
     out[2] = res.h;
 }
 
+export fn lms2lch(l: f64, m: f64, s: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Lms{ .l = l, .m = m, .s = s });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn lms2xyb(l: f64, m: f64, s: f64, out: [*]f64) void {
     const res = convertColor(Xyb, Lms{ .l = l, .m = m, .s = s });
     std.log.debug("Xyb: {[x]d} {[y]d} {[b]d}", res);
@@ -493,6 +542,14 @@ export fn oklab2lab(l: f64, a: f64, b: f64, out: [*]f64) void {
     out[0] = res.l;
     out[1] = res.a;
     out[2] = res.b;
+}
+
+export fn oklab2lch(l: f64, a: f64, b: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Oklab{ .l = l, .a = a, .b = b });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
 }
 
 export fn oklab2xyb(l: f64, a: f64, b: f64, out: [*]f64) void {
@@ -569,6 +626,14 @@ export fn oklch2xyb(l: f64, c: f64, h: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn oklch2lch(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Oklch{ .l = l, .c = c, .h = h });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 export fn oklch2ycbcr(l: f64, c: f64, h: f64, out: [*]f64) void {
     const res = convertColor(Ycbcr, Oklch{ .l = l, .c = c, .h = h });
     std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
@@ -643,6 +708,14 @@ export fn xyb2lab(x: f64, y: f64, b: f64, out: [*]f64) void {
     out[2] = res.b;
 }
 
+export fn xyb2lch(x: f64, y: f64, b: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Xyb{ .x = x, .y = y, .b = b });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
 // Add all remaining Ycbcr conversion functions
 export fn lab2ycbcr(l: f64, a: f64, b: f64, out: [*]f64) void {
     const res = convertColor(Ycbcr, Lab{ .l = l, .a = a, .b = b });
@@ -670,6 +743,88 @@ export fn oklab2ycbcr(l: f64, a: f64, b: f64, out: [*]f64) void {
 
 export fn xyb2ycbcr(x: f64, y: f64, b: f64, out: [*]f64) void {
     const res = convertColor(Ycbcr, Xyb{ .x = x, .y = y, .b = b });
+    std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
+    out[0] = res.y;
+    out[1] = res.cb;
+    out[2] = res.cr;
+}
+
+// --- LCH ---
+
+export fn lch2rgb(l: f64, c: f64, h: f64, out: [*]u8) void {
+    const res = convertColor(Rgb, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("RGB: {[r]d} {[g]d} {[b]d}", res);
+    out[0] = res.r;
+    out[1] = res.g;
+    out[2] = res.b;
+}
+
+export fn lch2hsl(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Hsl, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("HSL: {[h]d} {[s]d} {[l]d}", res);
+    out[0] = res.h;
+    out[1] = res.s;
+    out[2] = res.l;
+}
+
+export fn lch2hsv(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Hsv, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("HSV: {[h]d} {[s]d} {[v]d}", res);
+    out[0] = res.h;
+    out[1] = res.s;
+    out[2] = res.v;
+}
+
+export fn lch2xyz(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Xyz, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("XYZ: {[x]d} {[y]d} {[z]d}", res);
+    out[0] = res.x;
+    out[1] = res.y;
+    out[2] = res.z;
+}
+
+export fn lch2lab(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Lab, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("Lab: {[l]d} {[a]d} {[b]d}", res);
+    out[0] = res.l;
+    out[1] = res.a;
+    out[2] = res.b;
+}
+
+export fn lch2lms(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Lms, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("LMS: {[l]d} {[m]d} {[s]d}", res);
+    out[0] = res.l;
+    out[1] = res.m;
+    out[2] = res.s;
+}
+
+export fn lch2oklab(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Oklab, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("Oklab: {[l]d} {[a]d} {[b]d}", res);
+    out[0] = res.l;
+    out[1] = res.a;
+    out[2] = res.b;
+}
+
+export fn lch2oklch(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Oklch, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
+export fn lch2xyb(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Xyb, Lch{ .l = l, .c = c, .h = h });
+    std.log.debug("Xyb: {[x]d} {[y]d} {[b]d}", res);
+    out[0] = res.x;
+    out[1] = res.y;
+    out[2] = res.b;
+}
+
+export fn lch2ycbcr(l: f64, c: f64, h: f64, out: [*]f64) void {
+    const res = convertColor(Ycbcr, Lch{ .l = l, .c = c, .h = h });
     std.log.debug("Ycbcr: {[y]d} {[cb]d} {[cr]d}", res);
     out[0] = res.y;
     out[1] = res.cb;
@@ -737,6 +892,14 @@ export fn ycbcr2oklab(y: f64, cb: f64, cr: f64, out: [*]f64) void {
 export fn ycbcr2oklch(y: f64, cb: f64, cr: f64, out: [*]f64) void {
     const res = convertColor(Oklch, Ycbcr{ .y = @floatCast(y), .cb = @floatCast(cb), .cr = @floatCast(cr) });
     std.log.debug("Oklch: {[l]d} {[c]d} {[h]d}", res);
+    out[0] = res.l;
+    out[1] = res.c;
+    out[2] = res.h;
+}
+
+export fn ycbcr2lch(y: f64, cb: f64, cr: f64, out: [*]f64) void {
+    const res = convertColor(Lch, Ycbcr{ .y = @floatCast(y), .cb = @floatCast(cb), .cr = @floatCast(cr) });
+    std.log.debug("Lch: {[l]d} {[c]d} {[h]d}", res);
     out[0] = res.l;
     out[1] = res.c;
     out[2] = res.h;

--- a/examples/web/colorspaces.html
+++ b/examples/web/colorspaces.html
@@ -50,7 +50,7 @@
   <body>
     <div class="header">
       <h1>Color Space Converter</h1>
-      <p>Convert colors between different color spaces: RGB, HSL, HSV, XYZ, Lab, LMS, Oklab, Oklch, XYB, and YCbCr</p>
+      <p>Convert colors between different color spaces: RGB, HSL, HSV, XYZ, Lab, LCh, LMS, Oklab, Oklch, XYB, and YCbCr</p>
     </div>
     <div class="instructions">
       Change values in any color space to see real-time conversion to all other formats. Click color space names to copy values.
@@ -91,6 +91,12 @@
         <input type="number" id="lab-l" min="0" max="100" step="0.1" value="0">
         <input type="number" id="lab-a" min="-128" max="127" step="0.1" value="0">
         <input type="number" id="lab-b" min="-128" max="127" step="0.1" value="0">
+      </div>
+      <div id="lch" class="color-space">
+        <button class="copy-button" onclick="copyToClipboard('lch')">LCh</button>
+        <input type="number" id="lch-l" min="0" max="100" step="0.1" value="0">
+        <input type="number" id="lch-c" min="0" max="200" step="0.1" value="0">
+        <input type="number" id="lch-h" min="0" max="360" step="1" value="0">
       </div>
       <div id="lms" class="color-space">
         <button class="copy-button" onclick="copyToClipboard('lms')">LMS</button>
@@ -154,6 +160,9 @@
             break;
           case 'lab':
             inputs = ['lab-l', 'lab-a', 'lab-b'].map(id => document.getElementById(id));
+            break;
+          case 'lch':
+            inputs = ['lch-l', 'lch-c', 'lch-h'].map(id => document.getElementById(id));
             break;
           case 'lms':
             inputs = ['lms-l', 'lms-m', 'lms-s'].map(id => document.getElementById(id));

--- a/examples/web/colorspaces.js
+++ b/examples/web/colorspaces.js
@@ -64,6 +64,10 @@
     document.getElementById("lab-l").addEventListener("input", updateFromLab);
     document.getElementById("lab-a").addEventListener("input", updateFromLab);
     document.getElementById("lab-b").addEventListener("input", updateFromLab);
+    // Event listeners for LCH
+    document.getElementById("lch-l").addEventListener("input", updateFromLch);
+    document.getElementById("lch-c").addEventListener("input", updateFromLch);
+    document.getElementById("lch-h").addEventListener("input", updateFromLch);
     // Event listeners for LMS
     document.getElementById("lms-l").addEventListener("input", updateFromLms);
     document.getElementById("lms-m").addEventListener("input", updateFromLms);
@@ -192,6 +196,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function rgb2lch(r, g, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.rgb2lch(r, g, b, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function rgb2ycbcr(r, g, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -219,6 +232,7 @@
       rgb2oklab(r, g, b);
       rgb2oklch(r, g, b);
       rgb2xyb(r, g, b);
+      rgb2lch(r, g, b);
       rgb2ycbcr(r, g, b);
       updateHex();
     }
@@ -296,6 +310,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function hsl2lch(h, s, l) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.hsl2lch(h, s, l, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function hsl2ycbcr(h, s, l) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -323,6 +346,7 @@
       hsl2oklab(h, s, l);
       hsl2oklch(h, s, l);
       hsl2xyb(h, s, l);
+      hsl2lch(h, s, l);
       hsl2ycbcr(h, s, l);
       updateHex();
     }
@@ -401,6 +425,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function hsv2lch(h, s, v) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.hsv2lch(h, s, v, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function hsv2ycbcr(h, s, v) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -428,6 +461,7 @@
       hsv2oklab(h, s, v);
       hsv2oklch(h, s, v);
       hsv2xyb(h, s, v);
+      hsv2lch(h, s, v);
       hsv2ycbcr(h, s, v);
       updateHex();
     }
@@ -506,6 +540,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function xyz2lch(x, y, z) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.xyz2lch(x, y, z, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function xyz2ycbcr(x, y, z) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -533,6 +576,7 @@
       xyz2oklab(x, y, z);
       xyz2oklch(x, y, z);
       xyz2xyb(x, y, z);
+      xyz2lch(x, y, z);
       xyz2ycbcr(x, y, z);
       updateHex();
     }
@@ -611,6 +655,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function lab2lch(l, a, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lab2lch(l, a, b, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function lab2ycbcr(l, a, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -638,6 +691,7 @@
       lab2oklab(l, a, b);
       lab2oklch(l, a, b);
       lab2xyb(l, a, b);
+      lab2lch(l, a, b);
       lab2ycbcr(l, a, b);
       updateHex();
     }
@@ -716,6 +770,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function lms2lch(l, m, s) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lms2lch(l, m, s, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function lms2ycbcr(l, m, s) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -740,6 +803,7 @@
       lms2oklab(l, a, b);
       lms2oklch(l, a, b);
       lms2xyb(l, a, b);
+      lms2lch(l, a, b);
       lms2ycbcr(l, a, b);
       updateHex();
     }
@@ -818,6 +882,15 @@
       document.getElementById("oklch-h").value = out[2].toFixed(6);
     }
 
+    function oklab2lch(l, a, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklab2lch(l, a, b, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function oklab2ycbcr(l, a, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -845,6 +918,7 @@
       oklab2lab(l, a, b);
       oklab2oklch(l, a, b);
       oklab2xyb(l, a, b);
+      oklab2lch(l, a, b);
       oklab2ycbcr(l, a, b);
       updateHex();
     }
@@ -923,6 +997,15 @@
       document.getElementById("xyb-b").value = out[2].toFixed(6);
     }
 
+    function oklch2lch(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.oklch2lch(l, c, h, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function oklch2ycbcr(l, c, h) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -950,6 +1033,7 @@
       oklch2lms(l, c, h);
       oklch2oklab(l, c, h);
       oklch2xyb(l, c, h);
+      oklch2lch(l, c, h);
       oklch2ycbcr(l, c, h);
       updateHex();
     }
@@ -1026,6 +1110,15 @@
       document.getElementById("oklch-h").value = out[2].toFixed(6);
     }
 
+    function xyb2lch(x, y, b) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.xyb2lch(x, y, b, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function xyb2ycbcr(x, y, b) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -1048,7 +1141,123 @@
       xyb2lms(x, y, b);
       xyb2oklab(x, y, b);
       xyb2oklch(x, y, b);
+      xyb2lch(x, y, b);
       xyb2ycbcr(x, y, b);
+      updateHex();
+    }
+
+    // --- LCH ---
+
+    function lch2rgb(l, c, h) {
+      const outPtr = wasmExports.alloc(3);
+      const out = new Uint8Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2rgb(l, c, h, outPtr);
+      document.getElementById("rgb-r").value = out[0];
+      document.getElementById("rgb-g").value = out[1];
+      document.getElementById("rgb-b").value = out[2];
+    }
+
+    function lch2hsl(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2hsl(l, c, h, outPtr);
+      document.getElementById("hsl-h").value = out[0].toFixed(6);
+      document.getElementById("hsl-s").value = out[1].toFixed(6);
+      document.getElementById("hsl-l").value = out[2].toFixed(6);
+    }
+
+    function lch2hsv(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2hsv(l, c, h, outPtr);
+      document.getElementById("hsv-h").value = out[0].toFixed(6);
+      document.getElementById("hsv-s").value = out[1].toFixed(6);
+      document.getElementById("hsv-v").value = out[2].toFixed(6);
+    }
+
+    function lch2xyz(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2xyz(l, c, h, outPtr);
+      document.getElementById("xyz-x").value = out[0].toFixed(6);
+      document.getElementById("xyz-y").value = out[1].toFixed(6);
+      document.getElementById("xyz-z").value = out[2].toFixed(6);
+    }
+
+    function lch2lab(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2lab(l, c, h, outPtr);
+      document.getElementById("lab-l").value = out[0].toFixed(6);
+      document.getElementById("lab-a").value = out[1].toFixed(6);
+      document.getElementById("lab-b").value = out[2].toFixed(6);
+    }
+
+    function lch2lms(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2lms(l, c, h, outPtr);
+      document.getElementById("lms-l").value = out[0].toFixed(6);
+      document.getElementById("lms-m").value = out[1].toFixed(6);
+      document.getElementById("lms-s").value = out[2].toFixed(6);
+    }
+
+    function lch2oklab(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2oklab(l, c, h, outPtr);
+      document.getElementById("oklab-l").value = out[0].toFixed(6);
+      document.getElementById("oklab-a").value = out[1].toFixed(6);
+      document.getElementById("oklab-b").value = out[2].toFixed(6);
+    }
+
+    function lch2oklch(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2oklch(l, c, h, outPtr);
+      document.getElementById("oklch-l").value = out[0].toFixed(6);
+      document.getElementById("oklch-c").value = out[1].toFixed(6);
+      document.getElementById("oklch-h").value = out[2].toFixed(6);
+    }
+
+    function lch2xyb(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2xyb(l, c, h, outPtr);
+      document.getElementById("xyb-x").value = out[0].toFixed(6);
+      document.getElementById("xyb-y").value = out[1].toFixed(6);
+      document.getElementById("xyb-b").value = out[2].toFixed(6);
+    }
+
+    function lch2ycbcr(l, c, h) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.lch2ycbcr(l, c, h, outPtr);
+      document.getElementById("ycbcr-y").value = out[0].toFixed(6);
+      document.getElementById("ycbcr-cb").value = out[1].toFixed(6);
+      document.getElementById("ycbcr-cr").value = out[2].toFixed(6);
+    }
+
+    function updateFromLch() {
+      const l = parseFloat(document.getElementById("lch-l").value);
+      const c = parseFloat(document.getElementById("lch-c").value);
+      const h = parseFloat(document.getElementById("lch-h").value);
+      if (l < 0) document.getElementById("lch-l").value = 0;
+      if (c < 0) document.getElementById("lch-c").value = 0;
+      if (h < 0) document.getElementById("lch-h").value = 0;
+      if (l > 100) document.getElementById("lch-l").value = 100;
+      if (c > 200) document.getElementById("lch-c").value = 200;
+      if (h >= 360) document.getElementById("lch-h").value = h % 360;
+      lch2rgb(l, c, h);
+      lch2hsl(l, c, h);
+      lch2hsv(l, c, h);
+      lch2xyz(l, c, h);
+      lch2lab(l, c, h);
+      lch2lms(l, c, h);
+      lch2oklab(l, c, h);
+      lch2oklch(l, c, h);
+      lch2xyb(l, c, h);
+      lch2ycbcr(l, c, h);
       updateHex();
     }
 
@@ -1126,6 +1335,15 @@
       document.getElementById("oklch-h").value = out[2].toFixed(6);
     }
 
+    function ycbcr2lch(y, cb, cr) {
+      const outPtr = wasmExports.alloc(3 * 4);
+      const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
+      wasmExports.ycbcr2lch(y, cb, cr, outPtr);
+      document.getElementById("lch-l").value = out[0].toFixed(6);
+      document.getElementById("lch-c").value = out[1].toFixed(6);
+      document.getElementById("lch-h").value = out[2].toFixed(6);
+    }
+
     function ycbcr2xyb(y, cb, cr) {
       const outPtr = wasmExports.alloc(3 * 4);
       const out = new Float64Array(wasmExports.memory.buffer, outPtr, 3);
@@ -1153,6 +1371,7 @@
       ycbcr2lms(y, cb, cr);
       ycbcr2oklab(y, cb, cr);
       ycbcr2oklch(y, cb, cr);
+      ycbcr2lch(y, cb, cr);
       ycbcr2xyb(y, cb, cr);
       updateHex();
     }

--- a/src/color.zig
+++ b/src/color.zig
@@ -14,6 +14,7 @@ pub const isColor = conversions.isColor;
 pub const Hsl = @import("color/Hsl.zig");
 pub const Hsv = @import("color/Hsv.zig");
 pub const Lab = @import("color/Lab.zig");
+pub const Lch = @import("color/Lch.zig");
 pub const Lms = @import("color/Lms.zig");
 pub const Oklab = @import("color/Oklab.zig");
 pub const Oklch = @import("color/Oklch.zig");
@@ -375,7 +376,7 @@ test "extended color space round trips" {
 }
 
 /// List of color types to test. This is the only thing to update when adding a new color space.
-const ColorTypes = .{ Rgb, Rgba, Hsl, Hsv, Lab, Xyz, Lms, Oklab, Oklch, Xyb, Ycbcr };
+const ColorTypes = .{ Rgb, Rgba, Hsl, Hsv, Lab, Lch, Xyz, Lms, Oklab, Oklch, Xyb, Ycbcr };
 
 /// Strips all type names to their unqualified base names.
 fn getSimpleTypeName(comptime T: type) []const u8 {

--- a/src/color/Hsl.zig
+++ b/src/color/Hsl.zig
@@ -9,6 +9,7 @@ const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -65,6 +66,11 @@ pub fn toXyz(self: Hsl) Xyz {
 /// Converts HSL to CIELAB color space using direct conversion.
 pub fn toLab(self: Hsl) Lab {
     return conversions.hslToLab(self);
+}
+
+/// Converts HSL to LCh via Lab intermediate conversion.
+pub fn toLch(self: Hsl) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts HSL to LMS cone response via RGB intermediate conversion.

--- a/src/color/Hsv.zig
+++ b/src/color/Hsv.zig
@@ -9,6 +9,7 @@ const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -65,6 +66,11 @@ pub fn toXyz(self: Hsv) Xyz {
 /// Converts HSV to CIELAB color space using direct conversion.
 pub fn toLab(self: Hsv) Lab {
     return conversions.hsvToLab(self);
+}
+
+/// Converts HSV to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Hsv) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts HSV to LMS cone response via RGB intermediate conversion.

--- a/src/color/Lab.zig
+++ b/src/color/Lab.zig
@@ -10,6 +10,7 @@ const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -91,6 +92,11 @@ pub fn toXyb(self: Lab) Xyb {
 /// Converts CIELAB to YCbCr via RGB.
 pub fn toYcbcr(self: Lab) Ycbcr {
     return self.toRgb().toYcbcr();
+}
+
+/// Converts CIELAB to LCh (cylindrical representation).
+pub fn toLch(self: Lab) Lch {
+    return conversions.labToLch(self);
 }
 
 /// Alpha blends the given RGBA color onto this CIELAB color in-place.

--- a/src/color/Lch.zig
+++ b/src/color/Lch.zig
@@ -1,0 +1,108 @@
+//! A color in the [CIELCh color space](https://en.wikipedia.org/wiki/CIELAB_color_space#Cylindrical_model).
+//! LCh is the cylindrical representation of the CIELAB color space.
+//! - l: Lightness (0 for black to 100 for white).
+//! - c: Chroma (chromatic intensity) (0 for achromatic, no upper bound).
+//! - h: Hue angle in degrees (0-360).
+
+const std = @import("std");
+
+const conversions = @import("conversions.zig");
+const formatting = @import("formatting.zig");
+const Hsl = @import("Hsl.zig");
+const Hsv = @import("Hsv.zig");
+const Lab = @import("Lab.zig");
+const Lms = @import("Lms.zig");
+const Oklab = @import("Oklab.zig");
+const Oklch = @import("Oklch.zig");
+const Rgb = @import("Rgb.zig");
+const Rgba = @import("Rgba.zig").Rgba;
+const Xyb = @import("Xyb.zig");
+const Xyz = @import("Xyz.zig");
+const Ycbcr = @import("Ycbcr.zig");
+
+l: f64,
+c: f64,
+h: f64,
+
+const Lch = @This();
+
+pub const black: Lch = .{ .l = 0, .c = 0, .h = 0 };
+pub const white: Lch = .{ .l = 100, .c = 0, .h = 0 };
+
+/// Default formatting with ANSI color output
+pub fn format(self: Lch, writer: anytype) !void {
+    return formatting.formatColor(Lch, self, writer);
+}
+
+/// Returns true if chroma is 0 (neutral gray).
+pub fn isGray(self: Lch) bool {
+    return self.c == 0;
+}
+
+/// Converts to grayscale using the L* (lightness) component.
+pub fn toGray(self: Lch) u8 {
+    return @intFromFloat(@round(@max(0, @min(100, self.l)) / 100 * 255));
+}
+
+/// Converts LCh to Lab color space.
+pub fn toLab(self: Lch) Lab {
+    return conversions.lchToLab(self);
+}
+
+/// Converts LCh to RGB color space.
+pub fn toRgb(self: Lch) Rgb {
+    return conversions.lchToRgb(self);
+}
+
+/// Converts LCh to RGBA by first converting to RGB and adding alpha.
+pub fn toRgba(self: Lch, alpha: u8) Rgba {
+    return self.toRgb().toRgba(alpha);
+}
+
+/// Converts LCh to HSL color space via Lab intermediate conversion.
+pub fn toHsl(self: Lch) Hsl {
+    return conversions.lchToHsl(self);
+}
+
+/// Converts LCh to HSV color space via RGB intermediate conversion.
+pub fn toHsv(self: Lch) Hsv {
+    return conversions.lchToHsv(self);
+}
+
+/// Converts LCh to CIE XYZ color space via Lab intermediate conversion.
+pub fn toXyz(self: Lch) Xyz {
+    return self.toLab().toXyz();
+}
+
+/// Converts LCh to LMS cone response via XYZ intermediate conversion.
+pub fn toLms(self: Lch) Lms {
+    return self.toXyz().toLms();
+}
+
+/// Converts LCh to Oklab via LMS intermediate conversion.
+pub fn toOklab(self: Lch) Oklab {
+    return self.toLms().toOklab();
+}
+
+/// Converts LCh to Oklch via Oklab intermediate conversion.
+pub fn toOklch(self: Lch) Oklch {
+    return self.toOklab().toOklch();
+}
+
+/// Converts LCh to XYB via LMS intermediate conversion.
+pub fn toXyb(self: Lch) Xyb {
+    return self.toLms().toXyb();
+}
+
+/// Converts LCh to YCbCr via RGB intermediate conversion.
+pub fn toYcbcr(self: Lch) Ycbcr {
+    return self.toRgb().toYcbcr();
+}
+
+/// Alpha blending: blends the given RGBA color onto this LCh color.
+pub fn blend(self: *Lch, overlay: Rgba) void {
+    // Convert to RGB, blend, then convert back
+    var rgb = self.toRgb();
+    rgb.blend(overlay);
+    self.* = rgb.toLch();
+}

--- a/src/color/Lms.zig
+++ b/src/color/Lms.zig
@@ -9,6 +9,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
@@ -70,6 +71,11 @@ pub fn toXyz(self: Lms) Xyz {
 /// Converts LMS to CIELAB color space using direct conversion.
 pub fn toLab(self: Lms) Lab {
     return conversions.lmsToLab(self);
+}
+
+/// Converts LMS to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Lms) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts LMS to Oklab color space using direct conversion.

--- a/src/color/Oklab.zig
+++ b/src/color/Oklab.zig
@@ -11,6 +11,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklch = @import("Oklch.zig");
 const Rgb = @import("Rgb.zig");
@@ -71,6 +72,11 @@ pub fn toXyz(self: Oklab) Xyz {
 /// Converts Oklab to CIELAB color space using direct conversion.
 pub fn toLab(self: Oklab) Lab {
     return conversions.oklabToLab(self);
+}
+
+/// Converts Oklab to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Oklab) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts Oklab to LMS cone response using direct conversion.

--- a/src/color/Oklch.zig
+++ b/src/color/Oklch.zig
@@ -11,6 +11,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Rgb = @import("Rgb.zig");
@@ -76,6 +77,11 @@ pub fn toXyz(self: Oklch) Xyz {
 /// Converts Oklch to CIELAB color space via Oklab intermediate conversion.
 pub fn toLab(self: Oklch) Lab {
     return conversions.oklchToLab(self);
+}
+
+/// Converts Oklch to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Oklch) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts Oklch to LMS cone response via Oklab intermediate conversion.

--- a/src/color/Rgb.zig
+++ b/src/color/Rgb.zig
@@ -8,6 +8,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -90,6 +91,11 @@ pub fn toXyz(self: Rgb) Xyz {
 /// Converts RGB to CIELAB color space via XYZ intermediate conversion.
 pub fn toLab(self: Rgb) Lab {
     return conversions.rgbToLab(self);
+}
+
+/// Converts RGB to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Rgb) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts RGB to LMS (Long, Medium, Short) cone response space.

--- a/src/color/Rgba.zig
+++ b/src/color/Rgba.zig
@@ -5,6 +5,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -78,6 +79,11 @@ pub const Rgba = packed struct {
     /// Converts RGBA to CIELAB by first converting to RGB.
     pub fn toLab(self: Rgba) Lab {
         return self.toRgb().toLab();
+    }
+
+    /// Converts RGBA to LCh by first converting to RGB.
+    pub fn toLch(self: Rgba) Lch {
+        return self.toRgb().toLch();
     }
 
     /// Converts RGBA to CIE XYZ by first converting to RGB.

--- a/src/color/Xyb.zig
+++ b/src/color/Xyb.zig
@@ -12,6 +12,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -73,6 +74,11 @@ pub fn toXyz(self: Xyb) Xyz {
 /// Converts XYB to CIELAB color space using direct conversion.
 pub fn toLab(self: Xyb) Lab {
     return conversions.xybToLab(self);
+}
+
+/// Converts XYB to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Xyb) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts XYB to LMS cone response using direct conversion.

--- a/src/color/Xyz.zig
+++ b/src/color/Xyz.zig
@@ -12,6 +12,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -68,6 +69,11 @@ pub fn toHsv(self: Self) Hsv {
 /// Converts CIE XYZ to CIELAB color space using direct conversion.
 pub fn toLab(self: Self) Lab {
     return conversions.xyzToLab(self);
+}
+
+/// Converts CIE XYZ to LCh color space via Lab intermediate conversion.
+pub fn toLch(self: Self) Lch {
+    return self.toLab().toLch();
 }
 
 /// Converts CIE XYZ to LMS cone response space using direct conversion.

--- a/src/color/Ycbcr.zig
+++ b/src/color/Ycbcr.zig
@@ -9,6 +9,7 @@ const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
+const Lch = @import("Lch.zig");
 const Lms = @import("Lms.zig");
 const Oklab = @import("Oklab.zig");
 const Oklch = @import("Oklch.zig");
@@ -59,6 +60,11 @@ pub fn toHsv(self: Ycbcr) Hsv {
 /// Converts to Lab via RGB.
 pub fn toLab(self: Ycbcr) Lab {
     return self.toRgb().toLab();
+}
+
+/// Converts to LCh via RGB.
+pub fn toLch(self: Ycbcr) Lch {
+    return self.toRgb().toLch();
 }
 
 /// Converts to XYZ via RGB.

--- a/src/root.zig
+++ b/src/root.zig
@@ -8,7 +8,7 @@
 //!
 //! - **Image Operations**: Load, save, manipulate, and transform images
 //! - **Drawing & Canvas**: Lines, circles, polygons, Bézier curves with antialiasing
-//! - **Color Spaces**: RGB, HSL, HSV, XYZ, Lab, LMS, Oklab, XYB conversions
+//! - **Color Spaces**: RGB, HSL, HSV, XYZ, Lab, LCh, LMS, Oklab, Oklch, XYB conversions
 //! - **Geometry**: 2D/3D points, rectangles, transforms (affine, projective, similarity)
 //! - **Matrix Operations**: Linear algebra with SVD decomposition support
 //! - **Computer Vision**: Feature distribution matching, convex hull algorithms
@@ -44,6 +44,7 @@ pub const Hsl = color.Hsl;
 pub const Hsv = color.Hsv;
 pub const Xyz = color.Xyz;
 pub const Lab = color.Lab;
+pub const Lch = color.Lch;
 pub const Lms = color.Lms;
 pub const Oklab = color.Oklab;
 pub const Oklch = color.Oklch;


### PR DESCRIPTION
Introduces the LCh (Lightness, Chroma, Hue) color space with full conversion support to and from all other color spaces. Updates the web example to include LCh for interactive conversions.