### PR TITLE
feat(python): add `__format__` method for display

### DIFF
--- a/bindings/python/scripts/update_version.py
+++ b/bindings/python/scripts/update_version.py
@@ -127,7 +127,7 @@ def main():
     # Update pyproject.toml
     update_pyproject_toml(python_version)
 
-    print("✅ Version synchronization complete!")
+    print("Version synchronization complete!")
 
 
 if __name__ == "__main__":

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -853,11 +853,11 @@ const win_api = if (builtin.os.tag == .windows) struct {
     const STD_OUTPUT_HANDLE: i32 = -11;
 
     // API functions
-    extern "kernel32" fn GetStdHandle(nStdHandle: i32) callconv(.C) ?*anyopaque;
-    extern "kernel32" fn GetConsoleMode(hConsoleHandle: ?*anyopaque, lpMode: *u32) callconv(.C) i32;
-    extern "kernel32" fn SetConsoleMode(hConsoleHandle: ?*anyopaque, dwMode: u32) callconv(.C) i32;
-    extern "msvcrt" fn _kbhit() callconv(.C) c_int;
-    extern "msvcrt" fn _getch() callconv(.C) c_int;
+    extern "kernel32" fn GetStdHandle(nStdHandle: i32) callconv(.c) ?*anyopaque;
+    extern "kernel32" fn GetConsoleMode(hConsoleHandle: ?*anyopaque, lpMode: *u32) callconv(.c) i32;
+    extern "kernel32" fn SetConsoleMode(hConsoleHandle: ?*anyopaque, dwMode: u32) callconv(.c) i32;
+    extern "msvcrt" fn _kbhit() callconv(.c) c_int;
+    extern "msvcrt" fn _getch() callconv(.c) c_int;
 } else void;
 
 /// Terminal state for restoration

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -997,7 +997,7 @@ const TerminalDetector = struct {
                 }
 
                 // Small delay to prevent busy waiting
-                std.time.sleep(1_000_000); // 1ms
+                std.Thread.sleep(1_000_000); // 1ms
             }
 
             return total_read;

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -941,8 +941,10 @@ const TerminalDetector = struct {
                 }
             },
             .posix => |termios| {
-                // Restore original terminal settings
-                std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+                if (builtin.os.tag != .windows) {
+                    // Restore original terminal settings
+                    std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+                }
             },
         }
     }
@@ -953,17 +955,19 @@ const TerminalDetector = struct {
                 // Already in raw mode from init
             },
             .posix => |original| {
-                var raw = original;
+                if (builtin.os.tag != .windows) {
+                    var raw = original;
 
-                // Disable canonical mode and echo
-                raw.lflag.ICANON = false;
-                raw.lflag.ECHO = false;
+                    // Disable canonical mode and echo
+                    raw.lflag.ICANON = false;
+                    raw.lflag.ECHO = false;
 
-                // Set minimum characters and timeout
-                raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
-                raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
+                    // Set minimum characters and timeout
+                    raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
+                    raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
 
-                try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
+                    try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
+                }
             },
         }
     }
@@ -1011,7 +1015,9 @@ const TerminalDetector = struct {
             switch (self.original_state) {
                 .windows => {},
                 .posix => |termios| {
-                    std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+                    if (builtin.os.tag != .windows) {
+                        std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+                    }
                 },
             }
         }

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -841,83 +841,197 @@ pub const SixelDetectionOptions = struct {
     timeout_ms: u64 = 100,
 };
 
-/// Terminal control and detection utilities
-const TerminalDetector = if (builtin.os.tag == .windows) struct {
-    // Stub implementation for Windows
-    fn init() !TerminalDetector {
-        return error.Unsupported;
-    }
-    fn deinit(self: *TerminalDetector) void {
-        _ = self;
-    }
-    fn query(self: *TerminalDetector, sequence: []const u8, buffer: []u8, timeout_ms: u64) ![]const u8 {
-        _ = self;
-        _ = sequence;
-        _ = buffer;
-        _ = timeout_ms;
-        return error.Unsupported;
-    }
-} else struct {
+// Windows API declarations and constants (conditionally compiled)
+const win_api = if (builtin.os.tag == .windows) struct {
+    // Console mode constants
+    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+    const ENABLE_LINE_INPUT: u32 = 0x0002;
+    const ENABLE_ECHO_INPUT: u32 = 0x0004;
+
+    // Standard handle constants
+    const STD_INPUT_HANDLE: i32 = -10;
+    const STD_OUTPUT_HANDLE: i32 = -11;
+
+    // API functions
+    extern "kernel32" fn GetStdHandle(nStdHandle: i32) callconv(.C) ?*anyopaque;
+    extern "kernel32" fn GetConsoleMode(hConsoleHandle: ?*anyopaque, lpMode: *u32) callconv(.C) i32;
+    extern "kernel32" fn SetConsoleMode(hConsoleHandle: ?*anyopaque, dwMode: u32) callconv(.C) i32;
+    extern "msvcrt" fn _kbhit() callconv(.C) c_int;
+    extern "msvcrt" fn _getch() callconv(.C) c_int;
+} else void;
+
+/// Terminal state for restoration
+const TerminalState = union(enum) {
+    windows: struct {
+        output_mode: u32,
+        input_mode: u32,
+    },
+    posix: std.posix.termios,
+};
+
+/// Terminal control and detection utilities (cross-platform)
+const TerminalDetector = struct {
     stdin: std.fs.File,
     stdout: std.fs.File,
     stderr: std.fs.File,
-    original_termios: std.posix.termios,
+    original_state: TerminalState,
 
     fn init() !TerminalDetector {
         const stdin = std.fs.File.stdin();
         const stdout = std.fs.File.stdout();
         const stderr = std.fs.File.stderr();
 
-        // Get current terminal settings
-        const original = try std.posix.tcgetattr(stdin.handle);
+        if (builtin.os.tag == .windows) {
+            // Windows-specific initialization
+            const stdin_handle = win_api.GetStdHandle(win_api.STD_INPUT_HANDLE);
+            const stdout_handle = win_api.GetStdHandle(win_api.STD_OUTPUT_HANDLE);
 
-        return TerminalDetector{
-            .stdin = stdin,
-            .stdout = stdout,
-            .stderr = stderr,
-            .original_termios = original,
-        };
+            // Save original console modes
+            var original_output_mode: u32 = 0;
+            var original_input_mode: u32 = 0;
+
+            if (win_api.GetConsoleMode(stdout_handle, &original_output_mode) == 0) {
+                return error.ConsoleError;
+            }
+            if (win_api.GetConsoleMode(stdin_handle, &original_input_mode) == 0) {
+                return error.ConsoleError;
+            }
+
+            // Enable Virtual Terminal Processing for ANSI sequences
+            const new_output_mode = original_output_mode | win_api.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            if (win_api.SetConsoleMode(stdout_handle, new_output_mode) == 0) {
+                return error.ConsoleError;
+            }
+
+            // Set input mode for raw reading
+            const raw_input_mode = original_input_mode & ~(win_api.ENABLE_LINE_INPUT | win_api.ENABLE_ECHO_INPUT);
+            _ = win_api.SetConsoleMode(stdin_handle, raw_input_mode);
+
+            return TerminalDetector{
+                .stdin = stdin,
+                .stdout = stdout,
+                .stderr = stderr,
+                .original_state = .{ .windows = .{
+                    .output_mode = original_output_mode,
+                    .input_mode = original_input_mode,
+                } },
+            };
+        } else {
+            // POSIX: Get current terminal settings
+            const original = try std.posix.tcgetattr(stdin.handle);
+
+            return TerminalDetector{
+                .stdin = stdin,
+                .stdout = stdout,
+                .stderr = stderr,
+                .original_state = .{ .posix = original },
+            };
+        }
     }
 
     fn deinit(self: *TerminalDetector) void {
-        // Restore original terminal settings
-        std.posix.tcsetattr(self.stdin.handle, .FLUSH, self.original_termios) catch {};
+        switch (self.original_state) {
+            .windows => |win_state| {
+                if (builtin.os.tag == .windows) {
+                    // Restore original console modes
+                    const stdin_handle = win_api.GetStdHandle(win_api.STD_INPUT_HANDLE);
+                    const stdout_handle = win_api.GetStdHandle(win_api.STD_OUTPUT_HANDLE);
+                    _ = win_api.SetConsoleMode(stdout_handle, win_state.output_mode);
+                    _ = win_api.SetConsoleMode(stdin_handle, win_state.input_mode);
+                }
+            },
+            .posix => |termios| {
+                // Restore original terminal settings
+                std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+            },
+        }
     }
 
     fn enterRawMode(self: *TerminalDetector) !void {
-        var raw = self.original_termios;
+        switch (self.original_state) {
+            .windows => {
+                // Already in raw mode from init
+            },
+            .posix => |original| {
+                var raw = original;
 
-        // Disable canonical mode and echo
-        raw.lflag.ICANON = false;
-        raw.lflag.ECHO = false;
+                // Disable canonical mode and echo
+                raw.lflag.ICANON = false;
+                raw.lflag.ECHO = false;
 
-        // Set minimum characters and timeout
-        raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
-        raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
+                // Set minimum characters and timeout
+                raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
+                raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
 
-        try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
+                try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
+            },
+        }
+    }
+
+    fn readWithTimeout(self: *TerminalDetector, buffer: []u8, timeout_ms: u64) !usize {
+        if (builtin.os.tag == .windows) {
+            const start_time = std.time.milliTimestamp();
+            var total_read: usize = 0;
+
+            while (std.time.milliTimestamp() - start_time < timeout_ms) {
+                // Check if console has input available
+                if (win_api._kbhit() != 0) {
+                    // Read one character
+                    const ch = win_api._getch();
+                    if (ch >= 0 and ch <= 255) {
+                        buffer[total_read] = @intCast(ch);
+                        total_read += 1;
+
+                        if (total_read >= buffer.len) break;
+
+                        // Check for response terminators
+                        const char: u8 = @intCast(ch);
+                        if ((char == 'c' or char == 'R' or char == '\\' or char == ';') and total_read > 3) {
+                            break;
+                        }
+                    }
+                }
+
+                // Small delay to prevent busy waiting
+                std.time.sleep(1_000_000); // 1ms
+            }
+
+            return total_read;
+        } else {
+            // POSIX: Use the existing termios timeout mechanism
+            return try self.stdin.read(buffer);
+        }
     }
 
     fn query(self: *TerminalDetector, sequence: []const u8, buffer: []u8, timeout_ms: u64) ![]const u8 {
-        _ = timeout_ms; // Will use termios timeout for now
-
         // Enter raw mode
         try self.enterRawMode();
-        defer std.posix.tcsetattr(self.stdin.handle, .FLUSH, self.original_termios) catch {};
+        defer {
+            // Restore terminal state
+            switch (self.original_state) {
+                .windows => {},
+                .posix => |termios| {
+                    std.posix.tcsetattr(self.stdin.handle, .FLUSH, termios) catch {};
+                },
+            }
+        }
 
         // Clear any pending input
-        // TODO: tcflush not available in current Zig version
-        // std.posix.tcflush(self.stdin.handle, .I) catch {};
-
-        // Alternative: consume any pending input
-        var discard_buf: [response_buffer_size]u8 = undefined;
-        _ = self.stdin.read(&discard_buf) catch 0;
+        if (builtin.os.tag == .windows) {
+            // Consume any pending input
+            while (win_api._kbhit() != 0) {
+                _ = win_api._getch();
+            }
+        } else {
+            var discard_buf: [response_buffer_size]u8 = undefined;
+            _ = self.stdin.read(&discard_buf) catch 0;
+        }
 
         // Send query sequence
         _ = try self.stdout.write(sequence);
 
-        // Read response
-        const n = try self.stdin.read(buffer);
+        // Read response with timeout
+        const n = try self.readWithTimeout(buffer, timeout_ms);
 
         if (n == 0) return error.NoResponse;
 
@@ -992,11 +1106,6 @@ fn checkSixelSupport(detector: *TerminalDetector, method: enum { param_query, de
 
 /// Detect terminal sixel capability using multiple methods
 fn detectTerminalSixelCapability(options: SixelDetectionOptions) !bool {
-    // Terminal detection is only supported on POSIX systems
-    if (builtin.os.tag == .windows) {
-        return false;
-    }
-
     var detector = try TerminalDetector.init();
     defer detector.deinit();
 
@@ -1016,20 +1125,13 @@ fn detectTerminalSixelCapability(options: SixelDetectionOptions) !bool {
 
 /// Checks if the terminal supports sixel graphics
 pub fn isSixelSupported() !bool {
-    // On Windows, sixel is not supported
-    if (builtin.os.tag == .windows) {
-        return false;
-    }
-
     // Check if we're connected to a terminal
-    const stdin = std.fs.File.stdin();
+    const stdout = std.fs.File.stdout();
 
-    // Try to get terminal attributes - if this fails with NotATerminal,
-    // we're redirected to a file/pipe, so allow sixel output
-    _ = std.posix.tcgetattr(stdin.handle) catch |err| switch (err) {
-        error.NotATerminal => return true, // Not a TTY, allow sixel for file output
-        else => return err,
-    };
+    if (!stdout.isTty()) {
+        // Not a TTY, allow sixel for file output
+        return true;
+    }
 
     // We're in a terminal, so perform actual detection
     const options = SixelDetectionOptions{};


### PR DESCRIPTION
Implement Python's `__format__` method for `ImageRgb` objects, allowing formatted string representation for display using specifiers like 'ansi', 'sixel', and 'auto'.