### PR TITLE
chore(python): consolidate dev dependencies and stub generation

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,24 +31,19 @@ Documentation = "https://bfactory-ai.github.io/zignal/python"
 Issues = "https://github.com/bfactory-ai/zignal/issues"
 
 [project.optional-dependencies]
-dev = ["pytest", "uv", "ruff"]
 test = ["pytest", "numpy"]
 docs = ["pdoc"]
-
-[dependency-groups]
-dev = [
-    "build>=1.2.2.post1",
-    "twine>=6.1.0",
-]
 
 [tool.uv]
 dev-dependencies = [
     "pytest",
     "ruff",
+    "numpy",
+    "pdoc",
 ]
 
 [tool.ruff]
-line-length = 88
+line-length = 99
 target-version = "py39"
 
 [tool.ruff.lint]
@@ -58,7 +53,6 @@ select = [
     "F",  # pyflakes
     "I",  # isort
 ]
-ignore = []
 
 [tool.ruff.format]
 quote-style = "double"

--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -325,14 +325,7 @@ pub fn main() !void {
     const init_stub_content = try generateInitStub(allocator);
     defer allocator.free(init_stub_content);
 
-    // Write zignal.pyi (comprehensive stub file)
-    {
-        const file = try std.fs.cwd().createFile("zignal.pyi", .{});
-        defer file.close();
-        try file.writeAll(main_stub_content);
-    }
-
-    // Write _zignal.pyi (copy of comprehensive stub file for C extension)
+    // Write _zignal.pyi (stub file for C extension)
     {
         const file = try std.fs.cwd().createFile("_zignal.pyi", .{});
         defer file.close();
@@ -347,7 +340,6 @@ pub fn main() !void {
     }
 
     std.debug.print("Generated stub files:\n", .{});
-    std.debug.print("  zignal.pyi: {} bytes\n", .{main_stub_content.len});
     std.debug.print("  _zignal.pyi: {} bytes\n", .{main_stub_content.len});
     std.debug.print("  __init__.pyi: {} bytes\n", .{init_stub_content.len});
 }


### PR DESCRIPTION
Moves test and docs dependencies into uv's dev-dependencies. Removes the redundant 'zignal.pyi' stub file.
Adjusts Ruff line length to 99 characters.