### PR TITLE
feat(python): add pixel access to Image class

### DIFF
--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -254,6 +254,11 @@ fn generateStubFile(allocator: std.mem.Allocator) ![]u8 {
         .bases = &.{},
     });
 
+    // Add special methods for Image class (pixel access)
+    try stub.write("    def __len__(self) -> int: ...\n");
+    try stub.write("    def __getitem__(self, key: Tuple[int, int]) -> Rgba: ...\n");
+    try stub.write("    def __setitem__(self, key: Tuple[int, int], value: Union[Tuple[int, int, int], Tuple[int, int, int, int], Rgb, Rgba, Hsl, Hsv, Lab, Lch, Lms, Oklab, Oklch, Xyb, Xyz, Ycbcr]) -> None: ...\n");
+
     // Generate Canvas class from metadata
     const canvas_methods = stub_metadata.extractMethodInfo(&canvas_module.canvas_methods_metadata);
     const canvas_properties = stub_metadata.extractPropertyInfo(&canvas_module.canvas_properties_metadata);

--- a/bindings/python/tests/test_canvas.py
+++ b/bindings/python/tests/test_canvas.py
@@ -136,9 +136,7 @@ class TestDrawLineBinding:
         canvas.draw_line((0, 20), (50, 20), (0, 255, 0), mode=zignal.DrawMode.SOFT)
 
         # Test both
-        canvas.draw_line(
-            (0, 30), (50, 30), (0, 0, 255), width=5, mode=zignal.DrawMode.FAST
-        )
+        canvas.draw_line((0, 30), (50, 30), (0, 0, 255), width=5, mode=zignal.DrawMode.FAST)
 
         # All should work without errors
         result = img.to_numpy()

--- a/bindings/python/tests/test_colors.py
+++ b/bindings/python/tests/test_colors.py
@@ -30,9 +30,7 @@ class TestColorAvailability:
 
         for color_type in expected_types:
             assert hasattr(zignal, color_type), f"Missing color type: {color_type}"
-            assert callable(getattr(zignal, color_type)), (
-                f"{color_type} is not callable"
-            )
+            assert callable(getattr(zignal, color_type)), f"{color_type} is not callable"
 
     def test_color_type_signatures(self):
         """Test that color types accept the correct number of arguments."""


### PR DESCRIPTION
Implement `__len__`, `__getitem__`, and `__setitem__` for the Image class. This allows direct pixel access and modification using `img[row, col]` syntax. Pixels can be set using RGB/RGBA tuples or various color objects.