### PR TITLE
feat(python): add convex hull computation

### DIFF
--- a/bindings/python/src/convex_hull.zig
+++ b/bindings/python/src/convex_hull.zig
@@ -1,0 +1,181 @@
+const std = @import("std");
+
+const zignal = @import("zignal");
+const ConvexHull = zignal.ConvexHull;
+
+const py_utils = @import("py_utils.zig");
+pub const registerType = py_utils.registerType;
+const c = py_utils.c;
+const stub_metadata = @import("stub_metadata.zig");
+
+pub const ConvexHullObject = extern struct {
+    ob_base: c.PyObject,
+    hull: ?*ConvexHull(f32),
+};
+
+fn convex_hull_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    _ = kwds;
+
+    const self = @as(?*ConvexHullObject, @ptrCast(c.PyType_GenericAlloc(type_obj, 0)));
+    if (self) |obj| {
+        obj.hull = null;
+    }
+    return @as(?*c.PyObject, @ptrCast(self));
+}
+
+fn convex_hull_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
+    _ = args;
+    _ = kwds;
+    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
+
+    const hull = py_utils.allocator.create(ConvexHull(f32)) catch {
+        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate ConvexHull");
+        return -1;
+    };
+    hull.* = ConvexHull(f32).init(py_utils.allocator);
+    self.hull = hull;
+
+    return 0;
+}
+
+fn convex_hull_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
+    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
+
+    if (self.hull) |hull| {
+        hull.deinit();
+        py_utils.allocator.destroy(hull);
+    }
+
+    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+}
+
+fn convex_hull_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = self_obj;
+    return c.PyUnicode_FromString("ConvexHull()");
+}
+
+// Instance methods
+const convex_hull_find_doc =
+    \\Find the convex hull of a set of 2D points.
+    \\
+    \\Returns the vertices of the convex hull in clockwise order as a list of
+    \\(x, y) tuples, or None if the hull is degenerate (e.g., all points are
+    \\collinear).
+    \\
+    \\## Parameters
+    \\- `points` (list[tuple[float, float]]): List of (x, y) coordinate pairs.
+    \\  At least 3 points are required.
+    \\
+    \\## Examples
+    \\```python
+    \\hull = ConvexHull()
+    \\points = [(0, 0), (1, 1), (2, 2), (3, 1), (4, 0), (2, 4), (1, 3)]
+    \\result = hull.find(points)
+    \\# Returns: [(0.0, 0.0), (1.0, 3.0), (2.0, 4.0), (4.0, 0.0)]
+    \\```
+;
+
+fn convex_hull_find(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
+
+    // Check if hull is initialized
+    if (self.hull == null) {
+        c.PyErr_SetString(c.PyExc_RuntimeError, "ConvexHull not initialized");
+        return null;
+    }
+
+    // Parse points argument
+    var points_obj: ?*c.PyObject = undefined;
+    const format = std.fmt.comptimePrint("O", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &points_obj) == 0) {
+        return null;
+    }
+
+    // Parse the point list
+    const points = py_utils.parsePointList(points_obj) catch {
+        // Error already set by parsePointList
+        return null;
+    };
+    defer py_utils.freePointList(points);
+
+    // Find convex hull
+    const hull_points = self.hull.?.find(points) catch {
+        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to compute convex hull");
+        return null;
+    };
+
+    // Check if hull is degenerate
+    if (hull_points == null) {
+        const none = c.Py_None();
+        c.Py_INCREF(none);
+        return none;
+    }
+
+    // Convert hull points to Python list of tuples
+    const result_list = c.PyList_New(@intCast(hull_points.?.len));
+    if (result_list == null) {
+        return null;
+    }
+
+    for (hull_points.?, 0..) |point, i| {
+        const tuple = c.PyTuple_New(2);
+        if (tuple == null) {
+            c.Py_DECREF(result_list);
+            return null;
+        }
+
+        const x_obj = c.PyFloat_FromDouble(@as(f64, point.x()));
+        if (x_obj == null) {
+            c.Py_DECREF(tuple);
+            c.Py_DECREF(result_list);
+            return null;
+        }
+
+        const y_obj = c.PyFloat_FromDouble(@as(f64, point.y()));
+        if (y_obj == null) {
+            c.Py_DECREF(x_obj);
+            c.Py_DECREF(tuple);
+            c.Py_DECREF(result_list);
+            return null;
+        }
+
+        // PyTuple_SetItem steals references
+        _ = c.PyTuple_SetItem(tuple, 0, x_obj);
+        _ = c.PyTuple_SetItem(tuple, 1, y_obj);
+
+        // PyList_SetItem steals reference to tuple
+        _ = c.PyList_SetItem(result_list, @intCast(i), tuple);
+    }
+
+    return result_list;
+}
+
+pub const convex_hull_methods_metadata = [_]stub_metadata.MethodWithMetadata{
+    .{
+        .name = "find",
+        .meth = @ptrCast(&convex_hull_find),
+        .flags = c.METH_VARARGS,
+        .doc = convex_hull_find_doc,
+        .params = "self, points: list[tuple[float, float]]",
+        .returns = "Optional[list[tuple[float, float]]]",
+    },
+};
+
+var convex_hull_methods = stub_metadata.toPyMethodDefArray(&convex_hull_methods_metadata);
+
+pub var ConvexHullType = c.PyTypeObject{
+    .ob_base = .{
+        .ob_base = .{},
+        .ob_size = 0,
+    },
+    .tp_name = "zignal.ConvexHull",
+    .tp_basicsize = @sizeOf(ConvexHullObject),
+    .tp_dealloc = convex_hull_dealloc,
+    .tp_repr = convex_hull_repr,
+    .tp_flags = c.Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Convex hull computation using Graham's scan algorithm",
+    .tp_methods = @ptrCast(&convex_hull_methods),
+    .tp_init = convex_hull_init,
+    .tp_new = convex_hull_new,
+};

--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -13,6 +13,7 @@ const canvas_module = @import("canvas.zig");
 const main_module = @import("main.zig");
 const fdm_module = @import("fdm.zig");
 const rectangle_module = @import("rectangle.zig");
+const convex_hull_module = @import("convex_hull.zig");
 
 const GeneratedStub = struct {
     content: std.ArrayList(u8),
@@ -336,6 +337,17 @@ fn generateStubFile(allocator: std.mem.Allocator) ![]u8 {
         .bases = &.{},
     });
 
+    // Generate ConvexHull class from metadata
+    const convex_hull_methods = stub_metadata.extractMethodInfo(&convex_hull_module.convex_hull_methods_metadata);
+    const convex_hull_doc = std.mem.span(convex_hull_module.ConvexHullType.tp_doc);
+    try generateClassFromMetadata(&stub, .{
+        .name = "ConvexHull",
+        .doc = convex_hull_doc,
+        .methods = &convex_hull_methods,
+        .properties = &[_]stub_metadata.PropertyInfo{},
+        .bases = &.{},
+    });
+
     // Generate module-level functions from metadata
     const module_functions = stub_metadata.extractFunctionInfo(&main_module.module_functions_metadata);
     try generateModuleFunctionsFromMetadata(&stub, &module_functions);
@@ -378,6 +390,7 @@ fn generateInitStub(allocator: std.mem.Allocator) ![]u8 {
     try stub.write("    InterpolationMethod as InterpolationMethod,\n");
     try stub.write("    DrawMode as DrawMode,\n");
     try stub.write("    FeatureDistributionMatching as FeatureDistributionMatching,\n");
+    try stub.write("    ConvexHull as ConvexHull,\n");
     try stub.write(")\n\n");
 
     // Module metadata

--- a/bindings/python/src/main.zig
+++ b/bindings/python/src/main.zig
@@ -4,6 +4,7 @@ const build_options = @import("build_options");
 const bitmap_font = @import("bitmap_font.zig");
 const canvas = @import("canvas.zig");
 const color = @import("color.zig");
+const convex_hull = @import("convex_hull.zig");
 const fdm = @import("fdm.zig");
 const image = @import("image.zig");
 const interpolation = @import("interpolation.zig");
@@ -83,6 +84,13 @@ pub export fn PyInit__zignal() ?*c.PyObject {
     // Register FeatureDistributionMatching type
     py_utils.registerType(@ptrCast(m), "FeatureDistributionMatching", @ptrCast(&fdm.FeatureDistributionMatchingType)) catch |err| {
         std.log.err("Failed to register FeatureDistributionMatching: {}", .{err});
+        c.Py_DECREF(m);
+        return null;
+    };
+
+    // Register ConvexHull type
+    py_utils.registerType(@ptrCast(m), "ConvexHull", @ptrCast(&convex_hull.ConvexHullType)) catch |err| {
+        std.log.err("Failed to register ConvexHull: {}", .{err});
         c.Py_DECREF(m);
         return null;
     };

--- a/bindings/python/src/py_utils.zig
+++ b/bindings/python/src/py_utils.zig
@@ -538,7 +538,6 @@ pub fn parsePointList(list_obj: ?*c.PyObject) ![]Point(2, f32) {
             c.PyTuple_GetItem(list_obj, @intCast(i));
 
         points[i] = parsePointTuple(item) catch {
-            allocator.free(points);
             return error.InvalidPointList;
         };
     }

--- a/bindings/python/tests/test_convex_hull.py
+++ b/bindings/python/tests/test_convex_hull.py
@@ -1,0 +1,157 @@
+import pytest
+
+import zignal
+
+
+def test_convex_hull_creation():
+    """Test ConvexHull object creation."""
+    hull = zignal.ConvexHull()
+    assert hull is not None
+    assert repr(hull) == "ConvexHull()"
+
+
+def test_convex_hull_basic_api():
+    """Test basic API usage of ConvexHull."""
+    hull = zignal.ConvexHull()
+
+    # Basic triangle - should return list of tuples
+    points = [(0, 0), (1, 0), (0.5, 1)]
+    result = hull.find(points)
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(p, tuple) for p in result)
+    assert all(len(p) == 2 for p in result)
+    assert all(isinstance(p[0], float) and isinstance(p[1], float) for p in result)
+
+
+def test_convex_hull_returns_none():
+    """Test cases where find() returns None."""
+    hull = zignal.ConvexHull()
+
+    # Empty list
+    assert hull.find([]) is None
+
+    # Single point
+    assert hull.find([(1, 1)]) is None
+
+    # Two points
+    assert hull.find([(0, 0), (1, 1)]) is None
+
+    # Collinear points
+    assert hull.find([(0, 0), (1, 1), (2, 2)]) is None
+
+
+def test_convex_hull_input_types():
+    """Test that ConvexHull accepts both lists and tuples."""
+    hull = zignal.ConvexHull()
+
+    # Test with list
+    points_list = [(0, 0), (1, 0), (0.5, 1)]
+    result1 = hull.find(points_list)
+    assert result1 is not None
+    assert isinstance(result1, list)
+
+    # Test with tuple
+    points_tuple = ((0, 0), (1, 0), (0.5, 1))
+    result2 = hull.find(points_tuple)
+    assert result2 is not None
+    assert isinstance(result2, list)
+
+
+def test_convex_hull_coordinate_types():
+    """Test that ConvexHull handles different numeric types."""
+    hull = zignal.ConvexHull()
+
+    # Integer coordinates
+    points = [(0, 0), (4, 0), (2, 3)]
+    result = hull.find(points)
+    assert result is not None
+    # Results should be floats
+    assert all(isinstance(p[0], float) and isinstance(p[1], float) for p in result)
+
+    # Mixed int/float coordinates
+    points = [(0.5, 0), (4, 0.5), (2.0, 3)]
+    result = hull.find(points)
+    assert result is not None
+
+
+def test_convex_hull_reuse():
+    """Test multiple calls on the same ConvexHull object."""
+    hull = zignal.ConvexHull()
+
+    # First call
+    result1 = hull.find([(0, 0), (1, 0), (0, 1)])
+    assert result1 is not None
+    assert len(result1) == 3
+
+    # Second call with different points
+    result2 = hull.find([(0, 0), (2, 0), (2, 2), (0, 2)])
+    assert result2 is not None
+    assert len(result2) >= 3  # At least triangle
+
+    # Third call returning None
+    result3 = hull.find([(0, 0), (1, 1)])
+    assert result3 is None
+
+
+def test_convex_hull_invalid_input():
+    """Test ConvexHull with invalid input."""
+    hull = zignal.ConvexHull()
+
+    # Non-list/tuple input
+    with pytest.raises(TypeError):
+        hull.find("not a list")
+
+    with pytest.raises(TypeError):
+        hull.find(123)
+
+    with pytest.raises(TypeError):
+        hull.find(None)
+
+    # List with non-tuple elements
+    with pytest.raises(TypeError):
+        hull.find([1, 2, 3])
+
+    with pytest.raises(TypeError):
+        hull.find(["point1", "point2"])
+
+    # Tuple with wrong number of elements
+    with pytest.raises(ValueError):
+        hull.find([(1,)])  # Only one coordinate
+
+    with pytest.raises(ValueError):
+        hull.find([(1, 2, 3)])  # Three coordinates
+
+    with pytest.raises(ValueError):
+        hull.find([tuple()])  # Empty tuple
+
+    # Non-numeric coordinates
+    with pytest.raises(TypeError):
+        hull.find([("a", "b")])
+
+    with pytest.raises(TypeError):
+        hull.find([(1, "b")])
+
+    with pytest.raises(TypeError):
+        hull.find([(None, 1)])
+
+
+def test_convex_hull_edge_cases():
+    """Test edge cases for the API."""
+    hull = zignal.ConvexHull()
+
+    # Large coordinate values
+    points = [(1e6, 1e6), (1e6 + 1, 1e6), (1e6, 1e6 + 1)]
+    result = hull.find(points)
+    assert result is not None
+
+    # Very small differences
+    points = [(0, 0), (0.0001, 0), (0, 0.0001)]
+    result = hull.find(points)
+    assert result is not None
+
+    # Negative coordinates
+    points = [(-1, -1), (1, -1), (0, 1)]
+    result = hull.find(points)
+    assert result is not None


### PR DESCRIPTION
Introduces a `ConvexHull` class to the Python bindings, allowing computation of the convex hull of 2D points using Graham's scan.