### PR TITLE
chore(python-docs): improve docs build and URL

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/bfactory-ai/zignal"
 Repository = "https://github.com/bfactory-ai/zignal"
-Documentation = "https://bfactory-ai.github.io/zignal/python"
+Documentation = "https://bfactory-ai.github.io/zignal/python/zignal.html"
 Issues = "https://github.com/bfactory-ai/zignal/issues"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Refactor the documentation build script to use an 'empty' module for pdoc's search index generation. This enables pdoc to naturally create 'index.html' as the module listing and 'zignal.html' as the main documentation page. Update pyproject.toml to point to the new primary documentation URL.