### PR TITLE
feat(image): add image rotation with interpolation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: master
+        version: 0.15.0-dev.1408+9b509dad3
 
     - name: Install uv
       uses: astral-sh/setup-uv@v2
@@ -50,7 +50,7 @@ jobs:
         uv pip install --upgrade setuptools wheel build pytest
         # Install numpy for more comprehensive testing (optional)
         uv pip install numpy || echo "NumPy installation failed, tests will be skipped"
-    
+
     - name: Install macOS-specific dependencies
       if: runner.os == 'macOS'
       run: |
@@ -137,7 +137,7 @@ jobs:
         uv pip install --upgrade setuptools wheel build pytest
         # Install numpy for more comprehensive testing (optional)
         uv pip install numpy || echo "NumPy installation failed, tests will be skipped"
-    
+
     - name: Install macOS-specific dependencies
       if: runner.os == 'macOS'
       run: |

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -160,25 +160,25 @@ test "rotate orthogonal fast paths" {
 
     // Test 0 degree rotation
     var rotated_0: Image(u8) = .empty;
-    try image.rotate(std.testing.allocator, 0, &rotated_0);
+    try image.rotate(std.testing.allocator, 0, .bilinear, &rotated_0);
     defer rotated_0.deinit(std.testing.allocator);
     try expectEqual(@as(u8, 1), rotated_0.at(0, 0).*);
 
     // Test 90 degree rotation
     var rotated_90: Image(u8) = .empty;
-    try image.rotate(std.testing.allocator, std.math.pi / 2.0, &rotated_90);
+    try image.rotate(std.testing.allocator, std.math.pi / 2.0, .bilinear, &rotated_90);
     defer rotated_90.deinit(std.testing.allocator);
     // After 90° rotation, top-left becomes bottom-left
     // Original (0,0)=1 should be at (2,0) in rotated image (accounting for centering)
 
     // Test 180 degree rotation
     var rotated_180: Image(u8) = .empty;
-    try image.rotate(std.testing.allocator, std.math.pi, &rotated_180);
+    try image.rotate(std.testing.allocator, std.math.pi, .bilinear, &rotated_180);
     defer rotated_180.deinit(std.testing.allocator);
 
     // Test 270 degree rotation
     var rotated_270: Image(u8) = .empty;
-    try image.rotate(std.testing.allocator, 3.0 * std.math.pi / 2.0, &rotated_270);
+    try image.rotate(std.testing.allocator, 3.0 * std.math.pi / 2.0, .bilinear, &rotated_270);
     defer rotated_270.deinit(std.testing.allocator);
 
     // Verify dimensions are as expected
@@ -208,7 +208,7 @@ test "rotate arbitrary angle" {
 
     // Test 45 degree rotation
     var rotated: Image(u8) = .empty;
-    try image.rotate(std.testing.allocator, std.math.pi / 4.0, &rotated);
+    try image.rotate(std.testing.allocator, std.math.pi / 4.0, .bilinear, &rotated);
     defer rotated.deinit(std.testing.allocator);
 
     // Should be larger than original to fit rotated content


### PR DESCRIPTION
The `Image.rotate` function now accepts an `InterpolationMethod` parameter and implicitly rotates around the image's center, automatically sizing the output. The `Image.rotateAround` function has been removed. Optimized paths for orthogonal rotations were updated. Adds Python bindings for the new `Image.rotate` method. Updates the face alignment example to use the new API and improve cropping.

BREAKING CHANGE: The `Image.rotate` function signature changed to include `InterpolationMethod`. The `Image.rotateAround` function has been removed.