### PR TITLE
refactor(rectangle)!: make bounds exclusive

### DIFF
--- a/bindings/python/tests/test_rectangle.py
+++ b/bindings/python/tests/test_rectangle.py
@@ -12,8 +12,8 @@ def test_rectangle_creation():
     assert rect.top == 20
     assert rect.right == 100
     assert rect.bottom == 80
-    assert rect.width == 90
-    assert rect.height == 60
+    assert rect.width == 90  # 100 - 10
+    assert rect.height == 60  # 80 - 20
 
 
 def test_rectangle_init_center():
@@ -53,3 +53,41 @@ def test_rectangle_methods():
     # Non-overlapping should return None
     rect3 = zignal.Rectangle(200, 200, 300, 300)
     assert rect.intersect(rect3) is None
+
+
+def test_rectangle_exclusive_bounds():
+    """Test that Rectangle uses exclusive bounds for right and bottom."""
+    rect = zignal.Rectangle(0, 0, 100, 100)
+
+    # Points inside the rectangle
+    assert rect.contains(0, 0) is True  # Top-left corner (inclusive)
+    assert rect.contains(50, 50) is True  # Center
+    assert rect.contains(99, 99) is True  # Just inside
+    assert rect.contains(99.9, 99.9) is True  # Very close to edge
+
+    # Points on exclusive edges should be outside
+    assert rect.contains(100, 50) is False  # On right edge (exclusive)
+    assert rect.contains(50, 100) is False  # On bottom edge (exclusive)
+    assert rect.contains(100, 100) is False  # Bottom-right corner (exclusive)
+
+    # Points outside
+    assert rect.contains(101, 50) is False
+    assert rect.contains(50, 101) is False
+    assert rect.contains(-1, 50) is False
+    assert rect.contains(50, -1) is False
+
+
+def test_rectangle_dimensions():
+    """Test that width and height are calculated correctly with exclusive bounds."""
+    # Rectangle from (10, 20) to (110, 70)
+    rect = zignal.Rectangle(10, 20, 110, 70)
+    assert rect.width == 100  # 110 - 10
+    assert rect.height == 50  # 70 - 20
+    assert rect.area() == 5000  # 100 * 50
+
+    # Zero-sized rectangle
+    empty = zignal.Rectangle(50, 50, 50, 50)
+    assert empty.width == 0
+    assert empty.height == 0
+    assert empty.area() == 0
+    assert empty.is_empty() is True

--- a/src/geometry/Rectangle.zig
+++ b/src/geometry/Rectangle.zig
@@ -31,8 +31,8 @@ pub fn Rectangle(comptime T: type) type {
                 .int => {
                     const l = x - @divFloor(w, 2);
                     const t = y - @divFloor(h, 2);
-                    const r = l + w - 1;
-                    const b = t + h - 1;
+                    const r = l + w;
+                    const b = t + h;
                     return .init(l, t, r, b);
                 },
                 .float => {
@@ -59,7 +59,7 @@ pub fn Rectangle(comptime T: type) type {
         /// Checks if a rectangle is ill-formed.
         pub fn isEmpty(self: Self) bool {
             return switch (@typeInfo(T)) {
-                .int => self.t > self.b or self.l > self.r,
+                .int => self.t >= self.b or self.l >= self.r,
                 .float => self.t >= self.b or self.l >= self.r,
                 else => @compileError("Unsupported type " ++ @typeName(T) ++ " for Rectangle"),
             };
@@ -68,7 +68,7 @@ pub fn Rectangle(comptime T: type) type {
         /// Returns the width of the rectangle.
         pub fn width(self: Self) if (@typeInfo(T) == .int) usize else T {
             return if (self.isEmpty()) 0 else switch (@typeInfo(T)) {
-                .int => @intCast(self.r - self.l + 1),
+                .int => @intCast(self.r - self.l),
                 .float => self.r - self.l,
                 else => @compileError("Unsupported type " ++ @typeName(T) ++ " for Rectangle"),
             };
@@ -77,7 +77,7 @@ pub fn Rectangle(comptime T: type) type {
         /// Returns the height of the rectangle.
         pub fn height(self: Self) if (@typeInfo(T) == .int) usize else T {
             return if (self.isEmpty()) 0 else switch (@typeInfo(T)) {
-                .int => @intCast(self.b - self.t + 1),
+                .int => @intCast(self.b - self.t),
                 .float => self.b - self.t,
                 else => @compileError("Unsupported type " ++ @typeName(T) ++ " for Rectangle"),
             };
@@ -90,7 +90,7 @@ pub fn Rectangle(comptime T: type) type {
 
         /// Returns true if the point at x, y is inside the rectangle.
         pub fn contains(self: Self, x: T, y: T) bool {
-            if (x < self.l or x > self.r or y < self.t or y > self.b) {
+            if (x < self.l or x >= self.r or y < self.t or y >= self.b) {
                 return false;
             }
             return true;
@@ -143,7 +143,7 @@ pub fn Rectangle(comptime T: type) type {
 
             // Check if the intersection is empty
             return switch (@typeInfo(T)) {
-                .int => if (l > r or t > b) null else Self.init(l, t, r, b),
+                .int => if (l >= r or t >= b) null else Self.init(l, t, r, b),
                 .float => if (l >= r or t >= b) null else Self.init(l, t, r, b),
                 else => @compileError("Unsupported type " ++ @typeName(T) ++ " for Rectangle"),
             };
@@ -152,13 +152,13 @@ pub fn Rectangle(comptime T: type) type {
 }
 
 test "Rectangle" {
-    const irect = Rectangle(isize){ .l = 0, .t = 0, .r = 639, .b = 479 };
+    const irect = Rectangle(isize){ .l = 0, .t = 0, .r = 640, .b = 480 };
     try expectEqual(irect.width(), 640);
     try expectEqual(irect.height(), 480);
-    const frect = Rectangle(f64){ .l = 0, .t = 0, .r = 639, .b = 479 };
-    try expectEqual(frect.width(), 639);
-    try expectEqual(frect.height(), 479);
-    try expectEqual(frect.contains(640 / 2, 480 / 2), true);
+    const frect = Rectangle(f64){ .l = 0, .t = 0, .r = 640, .b = 480 };
+    try expectEqual(frect.width(), 640);
+    try expectEqual(frect.height(), 480);
+    try expectEqual(frect.contains(320, 240), true);
     try expectEqual(irect.contains(640, 480), false);
     try expectEqualDeep(frect.cast(isize), irect);
 }

--- a/src/image/Image.zig
+++ b/src/image/Image.zig
@@ -137,7 +137,7 @@ pub fn Image(comptime T: type) type {
 
         /// Returns the bounding rectangle for the current image.
         pub fn getRectangle(self: Self) Rectangle(usize) {
-            return .{ .l = 0, .t = 0, .r = self.cols - 1, .b = self.rows - 1 };
+            return .{ .l = 0, .t = 0, .r = self.cols, .b = self.rows };
         }
 
         /// Returns the center point of the image as a Point(2, f32).
@@ -161,13 +161,13 @@ pub fn Image(comptime T: type) type {
             const bounded = Rectangle(usize){
                 .l = rect.l,
                 .t = rect.t,
-                .r = @min(rect.r, self.cols - 1),
-                .b = @min(rect.b, self.rows - 1),
+                .r = @min(rect.r, self.cols),
+                .b = @min(rect.b, self.rows),
             };
             return .{
                 .rows = bounded.height(),
                 .cols = bounded.width(),
-                .data = self.data[bounded.t * self.stride + bounded.l .. bounded.b * self.stride + bounded.r + 1],
+                .data = self.data[bounded.t * self.stride + bounded.l .. (bounded.b - 1) * self.stride + bounded.r],
                 .stride = self.cols,
             };
         }
@@ -375,8 +375,8 @@ pub fn Image(comptime T: type) type {
             const content_rect: Rectangle(usize) = .init(
                 offset_col,
                 offset_row,
-                offset_col + scaled_cols - 1,
-                offset_row + scaled_rows - 1,
+                offset_col + scaled_cols,
+                offset_row + scaled_rows,
             );
 
             // Create a view of the output at the calculated position

--- a/src/image/PixelIterator.zig
+++ b/src/image/PixelIterator.zig
@@ -105,7 +105,7 @@ test "PixelIterator with views" {
     }
 
     // Create a view (2x2 from position 1,1)
-    const view = img.view(Rectangle(usize){ .l = 1, .t = 1, .r = 2, .b = 2 });
+    const view = img.view(Rectangle(usize){ .l = 1, .t = 1, .r = 3, .b = 3 });
 
     // Test that view is indeed a view
     try std.testing.expect(view.isView());
@@ -173,7 +173,7 @@ test "PixelIterator reuse with init" {
     try std.testing.expectEqual(@as(usize, 9), count);
 
     // Verify we can still use it with views
-    const view = img2.view(Rectangle(usize){ .l = 1, .t = 1, .r = 2, .b = 2 });
+    const view = img2.view(Rectangle(usize){ .l = 1, .t = 1, .r = 3, .b = 3 });
     iter.init(view);
     const expected = [_]u8{ 4, 5, 7, 8 };
     count = 0;

--- a/src/image/tests/resize.zig
+++ b/src/image/tests/resize.zig
@@ -40,7 +40,7 @@ test "letterbox maintains aspect ratio with padding" {
                 try expectEqual(@as(u8, 0), output.at(r, c).*);
             }
         }
-        for (rect.b + 1 .. output.rows) |r| {
+        for (rect.b..output.rows) |r| {
             for (0..output.cols) |c| {
                 try expectEqual(@as(u8, 0), output.at(r, c).*);
             }
@@ -84,7 +84,7 @@ test "letterbox maintains aspect ratio with padding" {
             for (0..rect.l) |c| {
                 try expectEqual(black, output.at(r, c).*);
             }
-            for (rect.r + 1 .. output.cols) |c| {
+            for (rect.r..output.cols) |c| {
                 try expectEqual(black, output.at(r, c).*);
             }
         }


### PR DESCRIPTION
The `right` and `bottom` coordinates of a `Rectangle` are now exclusive. This aligns with common graphics APIs and Python slicing conventions.

This affects `width`, `height`, `contains`, `isEmpty`, and `intersect` methods. Image `getRectangle` and `view` methods also reflect this change.

BREAKING CHANGE: Rectangle's right and bottom coordinates are now exclusive. This means points on the right/bottom edge are no longer considered inside, and width/height calculations no longer include a '+1' for integer types. Rectangles where left == right or top == bottom are now considered empty.