### PR TITLE
feature(python): add a file path for verbose error msg

### DIFF
--- a/bindings/python/src/bitmap_font.zig
+++ b/bindings/python/src/bitmap_font.zig
@@ -73,7 +73,9 @@ fn bitmap_font_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c
     std.fs.cwd().access(path_slice, .{}) catch |err| {
         switch (err) {
             error.FileNotFound => {
-                c.PyErr_SetString(c.PyExc_FileNotFoundError, "Font file not found");
+                var buffer: [256]u8 = undefined;
+                const msg = std.fmt.bufPrintZ(&buffer, "File not found: '{s}'", .{path_slice}) catch "File not found";
+                c.PyErr_SetString(c.PyExc_FileNotFoundError, msg.ptr);
                 return null;
             },
             else => {}, // Continue with load attempt
@@ -102,7 +104,6 @@ fn bitmap_font_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c
 
         // Set appropriate Python exception based on error
         switch (err) {
-            error.FileNotFound => c.PyErr_SetString(c.PyExc_FileNotFoundError, "Font file not found"),
             error.UnsupportedFontFormat => c.PyErr_SetString(c.PyExc_ValueError, "Unsupported font format"),
             error.OutOfMemory => c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory"),
             else => c.PyErr_SetString(c.PyExc_IOError, "Failed to load font"),

--- a/bindings/python/src/bitmap_font.zig
+++ b/bindings/python/src/bitmap_font.zig
@@ -106,7 +106,11 @@ fn bitmap_font_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c
         switch (err) {
             error.UnsupportedFontFormat => c.PyErr_SetString(c.PyExc_ValueError, "Unsupported font format"),
             error.OutOfMemory => c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory"),
-            else => c.PyErr_SetString(c.PyExc_IOError, "Failed to load font"),
+            else => {
+                var buffer: [256]u8 = undefined;
+                const msg = std.fmt.bufPrintZ(&buffer, "Failed to load font: '{s}'", .{path_slice}) catch "Failed to load font";
+                c.PyErr_SetString(c.PyExc_IOError, msg.ptr);
+            }
         }
         return null;
     };

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -226,7 +226,11 @@ fn image_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObj
         switch (err) {
             error.UnsupportedImageFormat => c.PyErr_SetString(c.PyExc_ValueError, "Unsupported image format"),
             error.OutOfMemory => c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory"),
-            else => c.PyErr_SetString(c.PyExc_IOError, "Failed to load image"),
+            else => {
+                var buffer: [256]u8 = undefined;
+                const msg = std.fmt.bufPrintZ(&buffer, "Failed to load image: '{s}'", .{path_slice}) catch "Failed to load image";
+                c.PyErr_SetString(c.PyExc_IOError, msg.ptr);
+            },
         }
         return null;
     };
@@ -599,7 +603,11 @@ fn image_save(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObj
                 const msg = std.fmt.bufPrintZ(&buffer, "Directory not found: '{s}'", .{path_slice}) catch "Directory not found";
                 c.PyErr_SetString(c.PyExc_FileNotFoundError, msg.ptr);
             },
-            else => c.PyErr_SetString(c.PyExc_IOError, "Failed to save image"),
+            else => {
+                var buffer: [256]u8 = undefined;
+                const msg = std.fmt.bufPrintZ(&buffer, "Failed to save image: '{s}'", .{path_slice}) catch "Failed to save image";
+                c.PyErr_SetString(c.PyExc_IOError, msg.ptr);
+            },
         }
         return null;
     };

--- a/bindings/python/src/py_utils.zig
+++ b/bindings/python/src/py_utils.zig
@@ -528,6 +528,103 @@ pub fn freePointList(points: []Point(2, f32)) void {
     allocator.free(points);
 }
 
+/// Set a Python exception with an error message that includes a file path.
+/// Automatically selects the appropriate Python exception type based on the error.
+pub fn setErrorWithPath(err: anyerror, path: []const u8) void {
+    // Map Zig errors to appropriate Python exception types
+    const exc_type = switch (err) {
+        // File not found errors
+        error.FileNotFound => c.PyExc_FileNotFoundError,
+
+        // Permission and access errors
+        error.AccessDenied, error.PermissionDenied, error.SharingViolation => c.PyExc_PermissionError,
+
+        // Path and directory errors
+        error.IsDir => c.PyExc_IsADirectoryError,
+        error.NotDir => c.PyExc_NotADirectoryError,
+        error.PathAlreadyExists => c.PyExc_FileExistsError,
+
+        // Value errors for invalid paths/formats
+        error.BadPathName, error.InvalidUtf8, error.InvalidWtf8, error.UnsupportedImageFormat, error.UnsupportedFontFormat => c.PyExc_ValueError,
+
+        // Memory errors
+        error.OutOfMemory => c.PyExc_MemoryError,
+
+        // Blocking I/O errors
+        error.WouldBlock, error.LockViolation => c.PyExc_BlockingIOError,
+
+        // Broken pipe errors
+        error.BrokenPipe => c.PyExc_BrokenPipeError,
+
+        // Connection errors
+        error.ConnectionResetByPeer => c.PyExc_ConnectionResetError,
+
+        // General OS errors
+        error.NameTooLong, error.NoSpaceLeft, error.DiskQuota, error.SystemResources, error.ProcessFdQuotaExceeded, error.SystemFdQuotaExceeded, error.FileTooBig, error.FileBusy, error.DeviceBusy, error.NetworkNotFound, error.NoDevice, error.InputOutput, error.SymLinkLoop, error.AntivirusInterference, error.Unexpected => c.PyExc_OSError,
+
+        // Default to IOError for any other file I/O errors
+        else => c.PyExc_IOError,
+    };
+
+    // Format the error message with the path
+    var buffer: [128 + std.fs.max_path_bytes]u8 = undefined;
+    const msg = std.fmt.bufPrintZ(&buffer, "{s}: '{s}'", .{ @errorName(err), path }) catch @errorName(err);
+    c.PyErr_SetString(exc_type, msg.ptr);
+}
+
+/// Maximum extra bytes needed for error message formatting
+/// Accounts for: "File name too long: '" (21) + "'" (1) + null terminator (1)
+pub const error_message_overhead = 23;
+
+/// Format an error message with a file path, intelligently truncating if needed
+/// to fit within the provided buffer. Shows the tail of the path if truncation
+/// is necessary (more useful than showing the beginning).
+pub fn formatErrorMessage(
+    buffer: []u8,
+    comptime prefix: []const u8,
+    path: []const u8,
+) [:0]const u8 {
+    const suffix = "'";
+    const ellipsis = "...";
+
+    // Calculate available space for the path
+    const overhead = prefix.len + suffix.len + 1; // +1 for null terminator
+    const available_space = if (buffer.len > overhead) buffer.len - overhead else 0;
+
+    if (path.len <= available_space) {
+        // Path fits - use the full path
+        return std.fmt.bufPrintZ(buffer, "{s}{s}'", .{ prefix, path }) catch {
+            // This should rarely happen with max_path_bytes buffer
+            // Fall back to showing just the end of the path
+            const tail_len = @min(path.len, 100);
+            const tail = path[path.len - tail_len ..];
+            return std.fmt.bufPrintZ(buffer, "{s}...{s}'", .{ prefix, tail }) catch {
+                // Last resort - should never happen with max_path_bytes buffer
+                return std.fmt.bufPrintZ(buffer, "{s}<error>'", .{prefix}) catch "Error";
+            };
+        };
+    } else {
+        // Path too long - show tail with ellipsis
+        // This would only happen if path > max_path_bytes (shouldn't be possible for valid paths)
+        const ellipsis_overhead = prefix.len + ellipsis.len + suffix.len + 1;
+        const space_for_tail = if (buffer.len > ellipsis_overhead)
+            buffer.len - ellipsis_overhead
+        else
+            50; // Fallback size
+
+        const tail_start = if (path.len > space_for_tail) path.len - space_for_tail else 0;
+        return std.fmt.bufPrintZ(buffer, "{s}{s}{s}'", .{ prefix, ellipsis, path[tail_start..] }) catch {
+            // Try with shorter tail
+            const short_tail_len = @min(path.len, 100);
+            const short_tail = path[path.len - short_tail_len ..];
+            return std.fmt.bufPrintZ(buffer, "{s}...{s}'", .{ prefix, short_tail }) catch {
+                // This really shouldn't happen with max_path_bytes buffer
+                return std.fmt.bufPrintZ(buffer, "{s}<path too long>'", .{prefix}) catch "Error";
+            };
+        };
+    }
+}
+
 /// Helper to return Python None
 pub fn returnNone() ?*c.PyObject {
     const none = c.Py_None();


### PR DESCRIPTION
# Changes
- verbose error message with a file/directory path
- removed the second `FileNotFound` switch case, as I though it is redundant. If it was on purpose, or any other reasons to leave it as it is, I will bring back.


I used a `256` sized buffer but shouldn't we allocate it in heap? The file/directory path can be arbitrary long.