### PR TITLE
feat(python): add image fill method

### DIFF
--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -39,6 +39,7 @@ class TestImageBinding:
         img = zignal.Image.from_numpy(arr)
 
         # Verify methods exist and are callable
+        assert hasattr(img, "fill")
         assert hasattr(img, "save")
         assert hasattr(img, "to_numpy")
         assert hasattr(img, "resize")


### PR DESCRIPTION
Adds a new `fill` method to set the entire image to a solid color. Also improves documentation for color parsing utilities, clarifying their internal use and Python exception handling.