### PR TITLE
feat(color)!: add advanced blending modes

### DIFF
--- a/src/canvas.zig
+++ b/src/canvas.zig
@@ -531,9 +531,9 @@ pub fn Canvas(comptime T: type) type {
                             pixel.* = convertColor(T, color);
                         } else if (color.a > 0) {
                             // Transparent - blend
-                            var dst = convertColor(Rgba, pixel.*);
-                            dst.blend(color);
-                            pixel.* = convertColor(T, dst);
+                            const dst = convertColor(Rgba, pixel.*);
+                            const blended = dst.blend(color, .normal);
+                            pixel.* = convertColor(T, blended);
                         }
                     },
                     else => pixel.* = convertColor(T, color),
@@ -1541,7 +1541,6 @@ test "MD5 checksum regression tests" {
     const allocator = testing.allocator;
     const print_md5sums = @import("build_options").print_md5sums;
 
-    // Fixed size for consistent checksums
     const width = 100;
     const height = 100;
 
@@ -1556,6 +1555,9 @@ test "MD5 checksum regression tests" {
 
         const canvas = Canvas(Rgba).init(allocator, img);
         test_case.draw_fn(canvas);
+        // const filename = try std.fmt.allocPrint(allocator, "{s}.png", .{test_case.name});
+        // defer allocator.free(filename);
+        // try canvas.image.save(allocator, filename);
 
         // Calculate MD5
         var md5sum: [std.crypto.hash.Md5.digest_length]u8 = undefined;

--- a/src/color.zig
+++ b/src/color.zig
@@ -8,6 +8,9 @@ const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualDeep = std.testing.expectEqualDeep;
 
+const blending = @import("color/blending.zig");
+pub const BlendMode = blending.BlendMode;
+pub const blendColors = blending.blendColors;
 const conversions = @import("color/conversions.zig");
 pub const convertColor = conversions.convertColor;
 pub const isColor = conversions.isColor;
@@ -29,6 +32,11 @@ const getSimpleTypeName = @import("meta.zig").getSimpleTypeName;
 // TESTS
 // ============================================================================
 
+// Import tests from sub-modules
+test {
+    _ = @import("color/blending.zig");
+}
+
 // Helper function for testing round-trip conversions
 fn testColorConversion(from: Rgb, to: anytype) !void {
     const converted = convertColor(@TypeOf(to), from);
@@ -42,97 +50,6 @@ test "convert grayscale" {
     try expectEqual(convertColor(u8, Hsl{ .h = 0, .s = 100, .l = 50 }), 128);
     try expectEqual(convertColor(u8, Hsv{ .h = 0, .s = 100, .v = 50 }), 128);
     try expectEqual(convertColor(u8, Lab{ .l = 50, .a = 0, .b = 0 }), 128);
-}
-
-test "alphaBlend" {
-    const white = Rgb{ .r = 255, .g = 255, .b = 255 };
-    var output = Rgb{ .r = 0, .g = 0, .b = 0 };
-    output.blend(white.toRgba(128));
-    try expectEqualDeep(output, Rgb{ .r = 128, .g = 128, .b = 128 });
-}
-
-test "blend methods for all color types" {
-    // Test data: blend red (255,0,0) with 50% alpha onto black background
-    const red_rgba = Rgba{ .r = 255, .g = 0, .b = 0, .a = 128 };
-    const expected_rgb = Rgb{ .r = 128, .g = 0, .b = 0 }; // 50% blend of red on black
-
-    // Test Rgba.blend
-    {
-        var rgba_color = Rgba{ .r = 0, .g = 0, .b = 0, .a = 255 };
-        rgba_color.blend(red_rgba);
-        try expectEqualDeep(rgba_color.toRgb(), expected_rgb);
-    }
-
-    // Test Hsl.blend
-    {
-        var hsl_color = Hsl{ .h = 0, .s = 0, .l = 0 }; // black
-        hsl_color.blend(red_rgba);
-        const result_rgb = hsl_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Hsv.blend
-    {
-        var hsv_color = Hsv{ .h = 0, .s = 0, .v = 0 }; // black
-        hsv_color.blend(red_rgba);
-        const result_rgb = hsv_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Lab.blend
-    {
-        var lab_color = Lab{ .l = 0, .a = 0, .b = 0 }; // black
-        lab_color.blend(red_rgba);
-        const result_rgb = lab_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Oklab.blend
-    {
-        var oklab_color = Oklab{ .l = 0, .a = 0, .b = 0 }; // black
-        oklab_color.blend(red_rgba);
-        const result_rgb = oklab_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Oklch.blend
-    {
-        var oklch_color = Oklch{ .l = 0, .c = 0, .h = 0 }; // black
-        oklch_color.blend(red_rgba);
-        const result_rgb = oklch_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Lms.blend
-    {
-        var lms_color = Lms{ .l = 0, .m = 0, .s = 0 }; // black
-        lms_color.blend(red_rgba);
-        const result_rgb = lms_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-
-    // Test Xyb.blend
-    {
-        var xyb_color = Xyb{ .x = 0, .y = 0, .b = 0 }; // black
-        xyb_color.blend(red_rgba);
-        const result_rgb = xyb_color.toRgb();
-        try expectEqualDeep(result_rgb, expected_rgb);
-    }
-}
-
-test "blend with zero alpha should not change color" {
-    const transparent_red = Rgba{ .r = 255, .g = 0, .b = 0, .a = 0 };
-    const original_blue = Rgb{ .r = 0, .g = 0, .b = 255 };
-
-    // Test that blending with zero alpha doesn't change the original color
-    var test_rgb = original_blue;
-    test_rgb.blend(transparent_red);
-    try expectEqualDeep(test_rgb, original_blue);
-
-    var test_hsl = original_blue.toHsl();
-    const original_hsl = test_hsl;
-    test_hsl.blend(transparent_red);
-    try expectEqualDeep(test_hsl, original_hsl);
 }
 
 test "Rgb fromHex and toHex" {

--- a/src/color/Hsl.zig
+++ b/src/color/Hsl.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsv = @import("Hsv.zig");
@@ -98,9 +99,7 @@ pub fn toYcbcr(self: Hsl) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this HSL color in-place.
-pub fn blend(self: *Hsl, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toHsl();
+/// Alpha blends the given RGBA color onto this HSL color and returns the result.
+pub fn blend(self: Hsl, overlay: Rgba, mode: BlendMode) Hsl {
+    return self.toRgb().blend(overlay, mode).toHsl();
 }

--- a/src/color/Hsv.zig
+++ b/src/color/Hsv.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -98,9 +99,7 @@ pub fn toYcbcr(self: Hsv) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this HSV color in-place.
-pub fn blend(self: *Hsv, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toHsv();
+/// Alpha blends the given RGBA color onto this HSV color and returns the result.
+pub fn blend(self: Hsv, overlay: Rgba, mode: BlendMode) Hsv {
+    return self.toRgb().blend(overlay, mode).toHsv();
 }

--- a/src/color/Lab.zig
+++ b/src/color/Lab.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -99,9 +100,7 @@ pub fn toLch(self: Lab) Lch {
     return conversions.labToLch(self);
 }
 
-/// Alpha blends the given RGBA color onto this CIELAB color in-place.
-pub fn blend(self: *Lab, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toLab();
+/// Alpha blends the given RGBA color onto this CIELAB color and returns the result.
+pub fn blend(self: Lab, overlay: Rgba, mode: BlendMode) Lab {
+    return self.toRgb().blend(overlay, mode).toLab();
 }

--- a/src/color/Lch.zig
+++ b/src/color/Lch.zig
@@ -4,6 +4,9 @@
 //! - c: Chroma (chromatic intensity) (0 for achromatic, no upper bound).
 //! - h: Hue angle in degrees (0-360).
 
+const std = @import("std");
+
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -28,7 +31,7 @@ pub const black: Lch = .{ .l = 0, .c = 0, .h = 0 };
 pub const white: Lch = .{ .l = 100, .c = 0, .h = 0 };
 
 /// Default formatting with ANSI color output
-pub fn format(self: Lch, writer: anytype) !void {
+pub fn format(self: Lch, writer: *std.Io.Writer) !void {
     return formatting.formatColor(Lch, self, writer);
 }
 
@@ -97,10 +100,7 @@ pub fn toYcbcr(self: Lch) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blending: blends the given RGBA color onto this LCh color.
-pub fn blend(self: *Lch, overlay: Rgba) void {
-    // Convert to RGB, blend, then convert back
-    var rgb = self.toRgb();
-    rgb.blend(overlay);
-    self.* = rgb.toLch();
+/// Alpha blending: blends the given RGBA color onto this LCh color and returns the result.
+pub fn blend(self: Lch, overlay: Rgba, mode: BlendMode) Lch {
+    return self.toRgb().blend(overlay, mode).toLch();
 }

--- a/src/color/Lms.zig
+++ b/src/color/Lms.zig
@@ -4,6 +4,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -98,9 +99,7 @@ pub fn toYcbcr(self: Lms) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this LMS color in-place.
-pub fn blend(self: *Lms, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toLms();
+/// Alpha blends the given RGBA color onto this LMS color and returns the result.
+pub fn blend(self: Lms, overlay: Rgba, mode: BlendMode) Lms {
+    return self.toRgb().blend(overlay, mode).toLms();
 }

--- a/src/color/Oklab.zig
+++ b/src/color/Oklab.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -99,9 +100,7 @@ pub fn toYcbcr(self: Oklab) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this Oklab color in-place.
-pub fn blend(self: *Oklab, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toOklab();
+/// Alpha blends the given RGBA color onto this Oklab color and returns the result.
+pub fn blend(self: Oklab, overlay: Rgba, mode: BlendMode) Oklab {
+    return self.toRgb().blend(overlay, mode).toOklab();
 }

--- a/src/color/Oklch.zig
+++ b/src/color/Oklch.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -99,9 +100,7 @@ pub fn toYcbcr(self: Oklch) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this Oklch color in-place.
-pub fn blend(self: *Oklch, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toOklch();
+/// Alpha blends the given RGBA color onto this Oklch color and returns the result.
+pub fn blend(self: Oklch, overlay: Rgba, mode: BlendMode) Oklch {
+    return self.toRgb().blend(overlay, mode).toOklch();
 }

--- a/src/color/Rgb.zig
+++ b/src/color/Rgb.zig
@@ -3,6 +3,8 @@
 
 const std = @import("std");
 
+const blendColors = @import("blending.zig").blendColors;
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -118,17 +120,14 @@ pub fn toXyb(self: Rgb) Xyb {
     return conversions.lmsToXyb(self.toLms());
 }
 
-/// Converts RGB to Ycbcr color space using ITU-R BT.601 coefficients.
+/// Converts RGB to YCbCr color space using ITU-R BT.601 coefficients.
 pub fn toYcbcr(self: Rgb) Ycbcr {
     return conversions.rgbToYcbcr(self);
 }
 
-/// Alpha blends the given RGBA color onto this RGB color in-place.
-pub fn blend(self: *Rgb, color: Rgba) void {
-    if (color.a == 0) return;
-
-    const a = @as(f32, @floatFromInt(color.a)) / 255;
-    self.r = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.r)), @as(f32, @floatFromInt(color.r)), a));
-    self.g = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.g)), @as(f32, @floatFromInt(color.g)), a));
-    self.b = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.b)), @as(f32, @floatFromInt(color.b)), a));
+/// Alpha blends the given RGBA color onto this RGB color using the specified blend mode.
+/// Returns a new blended color.
+pub fn blend(self: Rgb, overlay: Rgba, mode: BlendMode) Rgb {
+    const blended = blendColors(self.toRgba(255), overlay, mode);
+    return .{ .r = blended.r, .g = blended.g, .b = blended.b };
 }

--- a/src/color/Rgba.zig
+++ b/src/color/Rgba.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
+const blendColors = @import("blending.zig").blendColors;
+const BlendMode = @import("blending.zig").BlendMode;
 const Hsl = @import("Hsl.zig");
 const Hsv = @import("Hsv.zig");
 const Lab = @import("Lab.zig");
@@ -128,13 +130,9 @@ pub const Rgba = packed struct {
         };
     }
 
-    /// Alpha blends the given RGBA color onto this RGBA color in-place.
-    pub fn blend(self: *Rgba, color: Rgba) void {
-        if (color.a == 0) return;
-
-        const a = @as(f32, @floatFromInt(color.a)) / 255;
-        self.r = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.r)), @as(f32, @floatFromInt(color.r)), a));
-        self.g = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.g)), @as(f32, @floatFromInt(color.g)), a));
-        self.b = @intFromFloat(std.math.lerp(@as(f32, @floatFromInt(self.b)), @as(f32, @floatFromInt(color.b)), a));
+    /// Alpha blends the given RGBA color onto this RGBA color using the specified blend mode.
+    /// Returns a new blended color.
+    pub fn blend(self: Rgba, overlay: Rgba, mode: BlendMode) Rgba {
+        return blendColors(self, overlay, mode);
     }
 };

--- a/src/color/Xyb.zig
+++ b/src/color/Xyb.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 
+const BlendMode = @import("blending.zig").BlendMode;
 const conversions = @import("conversions.zig");
 const formatting = @import("formatting.zig");
 const Hsl = @import("Hsl.zig");
@@ -101,9 +102,7 @@ pub fn toYcbcr(self: Xyb) Ycbcr {
     return self.toRgb().toYcbcr();
 }
 
-/// Alpha blends the given RGBA color onto this XYB color in-place.
-pub fn blend(self: *Xyb, color: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(color);
-    self.* = rgb.toXyb();
+/// Alpha blends the given RGBA color onto this XYB color and returns the result.
+pub fn blend(self: Xyb, overlay: Rgba, mode: BlendMode) Xyb {
+    return self.toRgb().blend(overlay, mode).toXyb();
 }

--- a/src/color/Ycbcr.zig
+++ b/src/color/Ycbcr.zig
@@ -97,9 +97,7 @@ pub fn toGray(self: Ycbcr) u8 {
     return @intFromFloat(@max(0, @min(255, @round(self.y))));
 }
 
-/// Alpha blends this color with another RGBA color.
-pub fn blend(self: *Ycbcr, other: Rgba) void {
-    var rgb = self.toRgb();
-    rgb.blend(other);
-    self.* = conversions.rgbToYcbcr(rgb);
+/// Alpha blends this color with another RGBA color and returns the result.
+pub fn blend(self: Ycbcr, overlay: Rgba) Ycbcr {
+    return self.toRgb().blend(overlay).toYcbcr();
 }

--- a/src/color/blending.zig
+++ b/src/color/blending.zig
@@ -1,0 +1,433 @@
+//! Color blending modes and utilities
+//!
+//! This module provides various blending modes for compositing colors,
+//! similar to those found in image editing software.
+
+const std = @import("std");
+const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
+
+const Rgb = @import("Rgb.zig");
+const Rgba = @import("Rgba.zig").Rgba;
+
+/// Available blending modes for color composition
+pub const BlendMode = enum {
+    /// Standard alpha blending. The overlay color is painted on top of the base with transparency.
+    normal,
+
+    /// Darkens the base color by multiplying it with the overlay. White has no effect, black results in black.
+    /// Useful for creating shadows and darkening effects.
+    multiply,
+
+    /// Lightens the base color by inverting, multiplying, then inverting again. Black has no effect, white results in white.
+    /// Opposite of multiply, useful for creating highlights.
+    screen,
+
+    /// Combines multiply and screen. Dark colors multiply, light colors screen.
+    /// Increases contrast by making darks darker and lights lighter.
+    overlay,
+
+    /// Similar to overlay but gentler. Produces a subtle contrast adjustment.
+    /// Uses a smooth algorithm that avoids harsh transitions.
+    soft_light,
+
+    /// Like overlay but uses the overlay color to determine the blend mode.
+    /// More dramatic contrast adjustment than soft light.
+    hard_light,
+
+    /// Brightens the base color based on the overlay. The darker the overlay, the more intense the effect.
+    /// Can produce very bright results, useful for glowing effects.
+    color_dodge,
+
+    /// Darkens the base color based on the overlay. The lighter the overlay, the more intense the effect.
+    /// Opposite of color dodge, useful for creating deep shadows.
+    color_burn,
+
+    /// Selects the darker of the two colors for each channel.
+    /// Useful for removing white or creating silhouettes.
+    darken,
+
+    /// Selects the lighter of the two colors for each channel.
+    /// Useful for removing black or creating overlays.
+    lighten,
+
+    /// Subtracts the darker color from the lighter color.
+    /// Creates an inverted effect, useful for comparing images.
+    difference,
+
+    /// Similar to difference but with lower contrast.
+    /// Produces a softer inversion effect.
+    exclusion,
+};
+
+/// Blends two RGBA colors using the specified blend mode with proper alpha compositing.
+/// Both colors' alpha channels are taken into account for mathematically correct blending.
+/// Returns a new RGBA color with the blended result.
+pub fn blendColors(base: Rgba, overlay: Rgba, mode: BlendMode) Rgba {
+    // Early return for fully transparent overlay
+    if (overlay.a == 0) return base;
+
+    // Early return for fully opaque overlay with normal mode over transparent base
+    if (overlay.a == 255 and base.a == 0 and mode == .normal) return overlay;
+
+    // Calculate alpha values
+    const base_alpha = @as(f32, @floatFromInt(base.a)) / 255.0;
+    const overlay_alpha = @as(f32, @floatFromInt(overlay.a)) / 255.0;
+    const result_alpha = base_alpha + overlay_alpha * (1.0 - base_alpha);
+
+    // Handle case where both colors are fully transparent
+    if (result_alpha == 0) {
+        return .{ .r = 0, .g = 0, .b = 0, .a = 0 };
+    }
+
+    // Blend RGB components based on mode
+    const blended_rgb = switch (mode) {
+        .normal => blendNormal(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .multiply => blendMultiply(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .screen => blendScreen(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .overlay => blendOverlay(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .soft_light => blendSoftLight(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .hard_light => blendHardLight(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .color_dodge => blendColorDodge(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .color_burn => blendColorBurn(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .darken => blendDarken(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .lighten => blendLighten(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .difference => blendDifference(base, overlay, base_alpha, overlay_alpha, result_alpha),
+        .exclusion => blendExclusion(base, overlay, base_alpha, overlay_alpha, result_alpha),
+    };
+
+    return .{
+        .r = blended_rgb.r,
+        .g = blended_rgb.g,
+        .b = blended_rgb.b,
+        .a = @intFromFloat(result_alpha * 255.0),
+    };
+}
+
+// Helper function for proper alpha compositing of a single channel
+// This composites the already-blended overlay value with the base value
+fn compositeChannel(base_value: f32, blended_value: f32, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) f32 {
+    // When both are fully opaque, just return the blended value
+    if (base_alpha == 1.0 and overlay_alpha == 1.0) {
+        return blended_value;
+    }
+    // Simplified case when base is opaque - common for RGB blending onto opaque surface
+    if (base_alpha == 1.0) {
+        return std.math.lerp(base_value, blended_value, overlay_alpha);
+    }
+    // General alpha compositing using lerp
+    // (base_value * base_alpha + blended_value * overlay_alpha * (1.0 - base_alpha)) / result_alpha;
+    // The interpolation weight is the portion of the final alpha that comes from the overlay
+    const lerp_weight = overlay_alpha * (1.0 - base_alpha) / result_alpha;
+    return std.math.lerp(base_value, blended_value, lerp_weight);
+}
+
+fn blendNormal(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, overlay_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, overlay_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, overlay_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendMultiply(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = (base_r * overlay_r) / 255.0;
+    const blended_g = (base_g * overlay_g) / 255.0;
+    const blended_b = (base_b * overlay_b) / 255.0;
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendScreen(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = 255.0 - ((255.0 - base_r) * (255.0 - overlay_r) / 255.0);
+    const blended_g = 255.0 - ((255.0 - base_g) * (255.0 - overlay_g) / 255.0);
+    const blended_b = 255.0 - ((255.0 - base_b) * (255.0 - overlay_b) / 255.0);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn overlayChannel(base: f32, blend: f32) f32 {
+    if (base < 128.0) {
+        return (2.0 * base * blend) / 255.0;
+    } else {
+        return 255.0 - (2.0 * (255.0 - base) * (255.0 - blend) / 255.0);
+    }
+}
+
+fn blendOverlay(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = overlayChannel(base_r, overlay_r);
+    const blended_g = overlayChannel(base_g, overlay_g);
+    const blended_b = overlayChannel(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn softLightChannel(base: f32, blend: f32) f32 {
+    const b = blend / 255.0;
+    const a = base / 255.0;
+
+    if (b <= 0.5) {
+        return 255.0 * (a - (1.0 - 2.0 * b) * a * (1.0 - a));
+    } else {
+        const sqrt_a = @sqrt(a);
+        return 255.0 * (a + (2.0 * b - 1.0) * (sqrt_a - a));
+    }
+}
+
+fn blendSoftLight(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = softLightChannel(base_r, overlay_r);
+    const blended_g = softLightChannel(base_g, overlay_g);
+    const blended_b = softLightChannel(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendHardLight(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    // Hard light is overlay with base and overlay swapped
+    const blended_r = overlayChannel(overlay_r, base_r);
+    const blended_g = overlayChannel(overlay_g, base_g);
+    const blended_b = overlayChannel(overlay_b, base_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn colorDodgeChannel(base: f32, blend: f32) f32 {
+    if (blend >= 255.0) return 255.0;
+    const result = (base * 255.0) / (255.0 - blend);
+    return @min(255.0, result);
+}
+
+fn blendColorDodge(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = colorDodgeChannel(base_r, overlay_r);
+    const blended_g = colorDodgeChannel(base_g, overlay_g);
+    const blended_b = colorDodgeChannel(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn colorBurnChannel(base: f32, blend: f32) f32 {
+    if (blend <= 0.0) return 0.0;
+    const result = 255.0 - ((255.0 - base) * 255.0) / blend;
+    return @max(0.0, result);
+}
+
+fn blendColorBurn(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = colorBurnChannel(base_r, overlay_r);
+    const blended_g = colorBurnChannel(base_g, overlay_g);
+    const blended_b = colorBurnChannel(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendDarken(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = @min(base_r, overlay_r);
+    const blended_g = @min(base_g, overlay_g);
+    const blended_b = @min(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendLighten(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = @max(base_r, overlay_r);
+    const blended_g = @max(base_g, overlay_g);
+    const blended_b = @max(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn blendDifference(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = @abs(base_r - overlay_r);
+    const blended_g = @abs(base_g - overlay_g);
+    const blended_b = @abs(base_b - overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+fn exclusionChannel(base: f32, blend: f32) f32 {
+    return base + blend - 2.0 * base * blend / 255.0;
+}
+
+fn blendExclusion(base: Rgba, overlay: Rgba, base_alpha: f32, overlay_alpha: f32, result_alpha: f32) Rgb {
+    const base_r = @as(f32, @floatFromInt(base.r));
+    const base_g = @as(f32, @floatFromInt(base.g));
+    const base_b = @as(f32, @floatFromInt(base.b));
+    const overlay_r = @as(f32, @floatFromInt(overlay.r));
+    const overlay_g = @as(f32, @floatFromInt(overlay.g));
+    const overlay_b = @as(f32, @floatFromInt(overlay.b));
+
+    const blended_r = exclusionChannel(base_r, overlay_r);
+    const blended_g = exclusionChannel(base_g, overlay_g);
+    const blended_b = exclusionChannel(base_b, overlay_b);
+
+    return .{
+        .r = @intFromFloat(compositeChannel(base_r, blended_r, base_alpha, overlay_alpha, result_alpha)),
+        .g = @intFromFloat(compositeChannel(base_g, blended_g, base_alpha, overlay_alpha, result_alpha)),
+        .b = @intFromFloat(compositeChannel(base_b, blended_b, base_alpha, overlay_alpha, result_alpha)),
+    };
+}
+
+// Tests
+test "blend normal mode" {
+    const base = Rgba{ .r = 100, .g = 100, .b = 100, .a = 255 };
+    const blend = Rgba{ .r = 200, .g = 200, .b = 200, .a = 128 };
+
+    const result = blendColors(base, blend, .normal);
+
+    // Should be approximately halfway between base and blend
+    try expect(result.r > 140 and result.r < 160);
+    try expect(result.g > 140 and result.g < 160);
+    try expect(result.b > 140 and result.b < 160);
+}
+
+test "blend multiply mode" {
+    const white = Rgba{ .r = 255, .g = 255, .b = 255, .a = 255 };
+    const gray = Rgba{ .r = 128, .g = 128, .b = 128, .a = 255 };
+
+    const result = blendColors(white, gray, .multiply);
+
+    // With both colors opaque, multiply should darken white to gray
+    // But with alpha compositing, since both are opaque, only the overlay color matters
+    // Actually the blend formula gives us the multiply result
+    try expectEqual(result.r, 128);
+    try expectEqual(result.g, 128);
+    try expectEqual(result.b, 128);
+}
+
+test "blend screen mode" {
+    const black = Rgba{ .r = 0, .g = 0, .b = 0, .a = 255 };
+    const gray = Rgba{ .r = 128, .g = 128, .b = 128, .a = 255 };
+
+    const result = blendColors(black, gray, .screen);
+
+    // Screen with gray should lighten to gray
+    try expectEqual(result.r, 128);
+    try expectEqual(result.g, 128);
+    try expectEqual(result.b, 128);
+}
+
+test "blend with transparent" {
+    const base = Rgba{ .r = 100, .g = 100, .b = 100, .a = 255 };
+    const transparent = Rgba{ .r = 200, .g = 200, .b = 200, .a = 0 };
+
+    const result = blendColors(base, transparent, .normal);
+
+    // Should remain unchanged
+    try expectEqual(result, base);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,7 @@ pub const DrawMode = @import("canvas.zig").DrawMode;
 const color = @import("color.zig");
 pub const convertColor = color.convertColor;
 pub const isColor = color.isColor;
+pub const BlendMode = color.BlendMode;
 pub const Rgb = color.Rgb;
 pub const Rgba = color.Rgba;
 pub const Hsl = color.Hsl;


### PR DESCRIPTION
Refactors color blending logic into a new module (color/blending.zig). Color type .blend() methods now return a new color and require a BlendMode argument, instead of modifying in-place.

BREAKING CHANGE: .blend() methods on color types are no longer in-place and require a BlendMode. Update calls to 'color = color.blend(overlay, .normal)'.