### PR TITLE
feat(python): add iteration and equality comparison

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -62,6 +62,21 @@ img[10, 22] = (255, 0, 0, 128)             # RGBA tuple
 img[10, 23] = zignal.Hsv(180, 100, 100)    # Any color object
 ```
 
+### Iterating Pixels
+
+```python
+# Image is iterable: yields (row, col, Rgba)
+for r, c, px in img:
+    if (r + c) % 1000 == 0:
+        print(r, c, px.r, px.g, px.b, px.a)
+
+# Build a list of pixels (allocates):
+pixels = [px for _, _, px in img]
+
+# For bulk numeric ops, use NumPy:
+arr = img.to_numpy()  # shape: (rows, cols, 4)
+```
+
 ### Color Spaces
 
 ```python

--- a/bindings/python/scripts/build_docs.py
+++ b/bindings/python/scripts/build_docs.py
@@ -166,7 +166,6 @@ def main():
             count = zignal_html_content.count(pattern)
             validation_errors.append(f"{message} ({count} occurrence{'s' if count != 1 else ''})")
 
-
     # Match function definitions and check if they have return type annotations
     func_pattern = r'<span class="def">def</span>\s*<span class="name">([^<]+)</span><span class="signature[^"]*">([^<]+)</span>'
     func_matches = re.finditer(func_pattern, zignal_html_content)

--- a/bindings/python/src/main.zig
+++ b/bindings/python/src/main.zig
@@ -9,11 +9,11 @@ const convex_hull = @import("convex_hull.zig");
 const fdm = @import("fdm.zig");
 const image = @import("image.zig");
 const interpolation = @import("interpolation.zig");
+const pixel_iterator = @import("pixel_iterator.zig");
 const py_utils = @import("py_utils.zig");
+const c = py_utils.c;
 const rectangle = @import("rectangle.zig");
 const stub_metadata = @import("stub_metadata.zig");
-
-const c = py_utils.c;
 
 // ============================================================================
 // MODULE FUNCTIONS
@@ -43,6 +43,13 @@ pub export fn PyInit__zignal() ?*c.PyObject {
     // Register Image type
     py_utils.registerType(@ptrCast(m), "Image", @ptrCast(&image.ImageType)) catch |err| {
         std.log.err("Failed to register Image: {}", .{err});
+        c.Py_DECREF(m);
+        return null;
+    };
+
+    // Register PixelIterator type
+    py_utils.registerType(@ptrCast(m), "PixelIterator", @ptrCast(&pixel_iterator.PixelIteratorType)) catch |err| {
+        std.log.err("Failed to register PixelIterator: {}", .{err});
         c.Py_DECREF(m);
         return null;
     };

--- a/bindings/python/src/pixel_iterator.zig
+++ b/bindings/python/src/pixel_iterator.zig
@@ -1,0 +1,128 @@
+const std = @import("std");
+
+const zignal = @import("zignal");
+const Rgba = zignal.Rgba;
+
+const ImageObject = @import("image.zig").ImageObject;
+const py_utils = @import("py_utils.zig");
+const c = py_utils.c;
+
+pub const PixelIteratorObject = extern struct {
+    ob_base: c.PyObject,
+    image_ref: ?*c.PyObject,
+    index: usize,
+};
+
+const pixel_iterator_doc =
+    \\
+    \\Iterator over image pixels yielding (row, col, Rgba).
+    \\
+    \\This iterator walks the image in row-major order (top-left to bottom-right).
+    \\For views, iteration respects the view bounds and the underlying stride, so
+    \\you only traverse the visible sub-rectangle without copying.
+    \\
+    \\## Examples
+    \\
+    \\```python
+    \\image = Image(2, 3)
+    \\for r, c, px in img:
+    \\    print(f"image.at({r}, {c}) = {px:ansi}")
+    \\```
+    \\
+    \\## Notes
+    \\- Returned by `iter(Image)` / `Image.__iter__()`\n
+    \\- Use `Image.to_numpy()` when you need bulk numeric processing for best performance.
+;
+
+fn pixel_iterator_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
+    const self = @as(*PixelIteratorObject, @ptrCast(self_obj.?));
+    if (self.image_ref) |ref| c.Py_XDECREF(ref);
+    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+}
+
+fn pixel_iterator_iter(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = self_obj.?;
+    c.Py_INCREF(self);
+    return self;
+}
+
+fn pixel_iterator_next(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*PixelIteratorObject, @ptrCast(self_obj.?));
+    if (self.image_ref == null) {
+        c.PyErr_SetNone(c.PyExc_StopIteration);
+        return null;
+    }
+
+    const img_py = @as(*ImageObject, @ptrCast(self.image_ref.?));
+    const img = img_py.image_ptr orelse {
+        c.PyErr_SetNone(c.PyExc_StopIteration);
+        return null;
+    };
+
+    const total = img.rows * img.cols;
+    if (self.index >= total) {
+        c.PyErr_SetNone(c.PyExc_StopIteration);
+        return null;
+    }
+
+    const row: usize = self.index / img.cols;
+    const col: usize = self.index % img.cols;
+    const pixel_index = row * img.stride + col;
+    const pixel = img.data[pixel_index];
+
+    // Create Python Rgba object
+    const color_module = @import("color.zig");
+    const rgba_obj = c.PyType_GenericAlloc(@ptrCast(&color_module.RgbaType), 0) orelse return null;
+    const rgba = @as(*color_module.RgbaBinding.PyObjectType, @ptrCast(rgba_obj));
+    rgba.field0 = pixel.r;
+    rgba.field1 = pixel.g;
+    rgba.field2 = pixel.b;
+    rgba.field3 = pixel.a;
+
+    // Build tuple (row, col, rgba)
+    const result = c.Py_BuildValue("(nnO)", @as(c.Py_ssize_t, @intCast(row)), @as(c.Py_ssize_t, @intCast(col)), rgba_obj) orelse {
+        c.Py_DECREF(rgba_obj);
+        return null;
+    };
+
+    self.index += 1;
+    return result;
+}
+
+pub var PixelIteratorType = c.PyTypeObject{
+    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
+    .tp_name = "zignal.PixelIterator",
+    .tp_basicsize = @sizeOf(PixelIteratorObject),
+    .tp_dealloc = pixel_iterator_dealloc,
+    .tp_flags = c.Py_TPFLAGS_DEFAULT,
+    .tp_doc = pixel_iterator_doc,
+    .tp_iter = pixel_iterator_iter,
+    .tp_iternext = pixel_iterator_next,
+};
+
+/// Create a new iterator bound to the given Image PyObject
+pub fn new(image_obj: ?*c.PyObject) ?*c.PyObject {
+    if (c.PyType_Ready(&PixelIteratorType) < 0) return null;
+    const it_obj = @as(?*PixelIteratorObject, @ptrCast(c.PyType_GenericAlloc(&PixelIteratorType, 0)));
+    if (it_obj == null) return null;
+    if (image_obj) |img| c.Py_INCREF(img);
+    it_obj.?.image_ref = image_obj;
+    it_obj.?.index = 0;
+    return @ptrCast(it_obj);
+}
+
+// Stub metadata for PixelIterator
+pub const pixel_iterator_special_methods_metadata = [_]@import("stub_metadata.zig").MethodInfo{
+    .{
+        .name = "__iter__",
+        .params = "self",
+        .returns = "PixelIterator",
+        .doc = "Return self as an iterator.",
+    },
+    .{
+        .name = "__next__",
+        .params = "self",
+        .returns = "tuple[int, int, Rgba]",
+        .doc = "Return the next (row, col, Rgba) tuple.",
+    },
+};

--- a/bindings/python/tests/test_bitmap_font.py
+++ b/bindings/python/tests/test_bitmap_font.py
@@ -1,4 +1,5 @@
 import pytest
+
 import zignal
 
 
@@ -17,100 +18,56 @@ def test_bitmap_font_load_not_found():
 
 def test_draw_text_with_default_font():
     """Test drawing text with default font."""
-    import numpy as np
-
-    # Create an image
-    img = zignal.Image.from_numpy(np.zeros((100, 200, 4), dtype=np.uint8))
-    canvas = img.canvas()
-
-    # Get default font
+    image = zignal.Image(100, 200)
+    original = image.copy()
+    canvas = image.canvas()
+    canvas.draw_text("Default", (10, 90), (128, 128, 255))
     font = zignal.BitmapFont.font8x8()
-
-    # Draw text - basic call
-    canvas.draw_text("Hello", (10, 10), (255, 255, 255), font)
-
-    # Draw text with scale
+    canvas.draw_text("Hello", (10, 10), 255, font)
     canvas.draw_text("Big", (10, 30), (255, 0, 0), font, scale=2.0)
-
-    # Draw text with different colors
     canvas.draw_text("RGB", (10, 50), (255, 0, 0), font)
     canvas.draw_text("RGBA", (50, 50), (0, 255, 0, 128), font)
     canvas.draw_text("Color", (10, 70), zignal.Rgb(0, 0, 255), font)
-
-    # Test default font by omitting font parameter
-    canvas.draw_text("Default", (10, 90), (128, 128, 255))
-
-    # Verify image was modified
-    result = img.to_numpy()
-    assert np.any(result > 0)
+    assert not image == original
 
 
 def test_draw_text_modes():
     """Test different drawing modes for text."""
-    import numpy as np
-
-    img = zignal.Image.from_numpy(np.zeros((50, 100, 4), dtype=np.uint8))
-    canvas = img.canvas()
+    image = zignal.Image(50, 100, 0)
+    original = image.copy()
+    canvas = image.canvas()
     font = zignal.BitmapFont.font8x8()
-
-    # Test both drawing modes
-    canvas.draw_text("Fast", (5, 5), (255, 255, 255), font, mode=zignal.DrawMode.FAST)
-    canvas.draw_text("Soft", (5, 20), (255, 255, 255), font, mode=zignal.DrawMode.SOFT)
+    canvas.draw_text("Fast", (5, 5), 255, font, mode=zignal.DrawMode.FAST)
+    canvas.draw_text("Soft", (5, 20), 255, font, mode=zignal.DrawMode.SOFT)
+    assert not image == original
 
 
 def test_draw_text_invalid_params():
     """Test error handling for invalid parameters."""
-    import numpy as np
-
-    img = zignal.Image.from_numpy(np.zeros((50, 50, 4), dtype=np.uint8))
-    canvas = img.canvas()
+    canvas = zignal.Image(50, 50).canvas()
     font = zignal.BitmapFont.font8x8()
-
     # Invalid font type
     with pytest.raises(TypeError):
-        canvas.draw_text("Hello", (10, 10), (255, 255, 255), "not a font")
-
+        canvas.draw_text("Hello", (10, 10), 255, "not a font")
     # Invalid position
     with pytest.raises(TypeError):
-        canvas.draw_text("Hello", "invalid", (255, 255, 255), font)
-
+        canvas.draw_text("Hello", "invalid", 255, font)
     # Invalid text
     with pytest.raises(TypeError):
-        canvas.draw_text(123, (10, 10), (255, 255, 255), font)
-
-
-def test_draw_text_default_font():
-    """Test drawing text with default font by omitting font parameter."""
-    import numpy as np
-
-    img = zignal.Image.from_numpy(np.zeros((50, 100, 4), dtype=np.uint8))
-    canvas = img.canvas()
-
-    # Draw text without specifying font - should use default
-    canvas.draw_text("No Font", (5, 5), (255, 255, 255))
-    canvas.draw_text("Scaled", (5, 20), (255, 0, 0), scale=1.5)
-    canvas.draw_text("Smooth", (5, 35), (0, 255, 0), mode=zignal.DrawMode.SOFT)
-
-    # Verify image was modified
-    result = img.to_numpy()
-    assert np.any(result > 0)
+        canvas.draw_text(123, (10, 10), 255, font)
 
 
 def test_draw_text_font_validation():
     """Test font parameter validation with improved error messages."""
-    import numpy as np
-
-    img = zignal.Image.from_numpy(np.zeros((50, 50, 4), dtype=np.uint8))
-    canvas = img.canvas()
-
+    canvas = zignal.Image(50, 50).canvas()
     # Test with non-BitmapFont object should fail with clear error
     with pytest.raises(TypeError, match="font must be a BitmapFont instance or None"):
-        canvas.draw_text("Test", (5, 5), (255, 255, 255), "not a font")
+        canvas.draw_text("Test", (5, 5), 255, "not a font")
 
     # Test with integer should fail
     with pytest.raises(TypeError, match="font must be a BitmapFont instance or None"):
-        canvas.draw_text("Test", (5, 5), (255, 255, 255), 123)
+        canvas.draw_text("Test", (5, 5), 255, 123)
 
     # Test with dict should fail
     with pytest.raises(TypeError, match="font must be a BitmapFont instance or None"):
-        canvas.draw_text("Test", (5, 5), (255, 255, 255), {"font": "invalid"})
+        canvas.draw_text("Test", (5, 5), 255, {"font": "invalid"})

--- a/bindings/python/tests/test_blending.py
+++ b/bindings/python/tests/test_blending.py
@@ -145,28 +145,3 @@ def test_blend_with_tuple():
     assert result.r == base.r
     assert result.g == base.g
     assert result.b == base.b
-
-
-if __name__ == "__main__":
-    test_blend_mode_enum()
-    print("✓ BlendMode enum tests passed")
-
-    test_blend_method_exists()
-    print("✓ Blend method existence tests passed")
-
-    test_blend_basic()
-    print("✓ Basic blend tests passed")
-
-    test_blend_modes()
-    print("✓ Blend mode tests passed")
-
-    test_blend_transparent()
-    print("✓ Transparent blend tests passed")
-
-    test_blend_type_preservation()
-    print("✓ Type preservation tests passed")
-
-    test_blend_with_tuple()
-    print("✓ Tuple overlay tests passed")
-
-    print("\nAll blending tests passed!")

--- a/bindings/python/tests/test_image_iter.py
+++ b/bindings/python/tests/test_image_iter.py
@@ -1,0 +1,67 @@
+import pytest
+
+try:
+    import numpy as np
+
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+
+import zignal
+
+pytestmark = pytest.mark.skipif(not HAS_NUMPY, reason="NumPy is not installed")
+
+
+def test_image_iteration_count_and_order():
+    # 2x3 image with 4 channels, values easy to assert
+    arr = np.arange(2 * 3 * 4, dtype=np.uint8).reshape(2, 3, 4)
+    img = zignal.Image.from_numpy(arr)
+
+    triples = list(img)
+    assert len(triples) == 2 * 3
+
+    # First pixel
+    r, c, px = triples[0]
+    assert (r, c) == (0, 0)
+    exp = arr[0, 0]
+    assert (px.r, px.g, px.b, px.a) == (int(exp[0]), int(exp[1]), int(exp[2]), int(exp[3]))
+
+    # Last pixel
+    r, c, px = triples[-1]
+    assert (r, c) == (1, 2)
+    exp = arr[1, 2]
+    assert (px.r, px.g, px.b, px.a) == (int(exp[0]), int(exp[1]), int(exp[2]), int(exp[3]))
+
+
+def test_image_iteration_matches_getitem():
+    rows, cols = 5, 7
+    arr = np.random.randint(0, 256, (rows, cols, 4), dtype=np.uint8)
+    img = zignal.Image.from_numpy(arr)
+
+    count = 0
+    for r, c, px in img:
+        assert img[r, c] == px
+        count += 1
+
+    assert count == len(img)
+
+
+def test_view_iteration_stride_and_bounds():
+    rows, cols = 6, 8
+    arr = np.arange(rows * cols * 4, dtype=np.uint8).reshape(rows, cols, 4)
+    img = zignal.Image.from_numpy(arr)
+
+    # Create a view rectangle (left, top, right, bottom)
+    left, top, right, bottom = 2, 1, 6, 5  # width=4, height=4
+    rect = zignal.Rectangle(left, top, right, bottom)
+    view = img.view(rect)
+
+    triples = list(view)
+    assert len(triples) == (bottom - top) * (right - left)
+
+    # Ensure local (r,c) are relative to the view and values match the parent
+    for r, c, px in triples:
+        assert 0 <= r < (bottom - top)
+        assert 0 <= c < (right - left)
+        parent_px = img[top + r, left + c]
+        assert (px.r, px.g, px.b, px.a) == (parent_px.r, parent_px.g, parent_px.b, parent_px.a)

--- a/bindings/python/zignal/__init__.py
+++ b/bindings/python/zignal/__init__.py
@@ -1,64 +1,18 @@
 """zero-dependency image processing library."""
 
-import importlib.util
 import os
 
-# Try the import
+# Import the native extension placed by `zig build python-bindings` or `uv pip install .`
 try:
-    from ._zignal import *
-except ImportError as e:
-    # Try alternative import methods for development/debugging
+    from ._zignal import *  # type: ignore
+    from ._zignal import __version__  # type: ignore
+except Exception as e:  # pragma: no cover - clearer error for missing build
     pkg_dir = os.path.dirname(__file__)
-
-    # Debug: List all files in the package directory
-    try:
-        all_files = os.listdir(pkg_dir)
-    except Exception:
-        all_files = []
-
-    # Find the actual extension file
-    zignal_path = None
-    for file in all_files:
-        if file.startswith("_zignal") and (
-            file.endswith(".so") or file.endswith(".pyd") or file.endswith(".dylib")
-        ):
-            zignal_path = os.path.join(pkg_dir, file)
-            break
-
-    if zignal_path and os.path.exists(zignal_path):
-        try:
-            spec = importlib.util.spec_from_file_location("_zignal", zignal_path)
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                # Import everything from the module
-                for name in dir(module):
-                    if not name.startswith("_"):
-                        globals()[name] = getattr(module, name)
-            else:
-                raise ImportError("Could not create module spec")
-        except Exception as manual_e:
-            raise ImportError(f"Failed to load _zignal extension: {manual_e}") from e
-    else:
-        # Provide detailed error information for debugging
-        extension_files = [f for f in all_files if f.startswith("_zignal")]
-        all_extensions = [f for f in all_files if f.endswith((".so", ".pyd", ".dylib"))]
-        raise ImportError(
-            f"_zignal extension not found in {pkg_dir}. "
-            f"Files starting with '_zignal': {extension_files}. "
-            f"All extension files: {all_extensions}. "
-            f"All files: {all_files}"
-        ) from e
-
-# Get version from the native module
-try:
-    from ._zignal import __version__
-except ImportError:
-    __version__ = "unknown"
+    raise ImportError(
+        "Failed to import zignal native extension.\n"
+        "Build it with: `zig build python-bindings` (dev) or install with `uv pip install .`.\n"
+        f"Expected extension next to this file: {pkg_dir}/_zignal.*"
+    ) from e
 
 # Dynamically populate __all__ from the native module
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("_") and name not in ["importlib", "os", "sys", "spec", "module"]
-]
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/build.zig
+++ b/build.zig
@@ -165,6 +165,12 @@ pub fn build(b: *Build) void {
     // Make python-bindings depend on stub generation so stubs are always up to date
     py_bindings_step.dependOn(&run_stub_generator.step);
     py_bindings_step.dependOn(&install_py_module.step);
+
+    // Also copy the built extension into the source package directory for local development
+    const pkg_dir = b.pathJoin(&.{ b.build_root.path.?, "bindings/python/zignal" });
+    const wf = b.addWriteFiles();
+    _ = wf.addCopyFile(py_module.getEmittedBin(), b.fmt("{s}/_zignal{s}", .{ pkg_dir, extension }));
+    py_bindings_step.dependOn(&wf.step);
 }
 
 const Build = blk: {


### PR DESCRIPTION
Image objects are now iterable, yielding (row, col, Rgba) tuples. Adds __eq__ and __ne__ for direct comparison of images by content.

Also updates README, improves generated stubs, and refactors Python tests. Simplifies Python package import logic and local development build.