### PR TITLE
feat(numeric): generalize matrix and assignment types

### DIFF
--- a/src/features/OptimalMatcher.zig
+++ b/src/features/OptimalMatcher.zig
@@ -77,7 +77,7 @@ pub fn match(
     }
 
     // Solve assignment problem (minimize cost)
-    var assignment = try optimization.solveAssignmentProblem(allocator, cost_matrix, .min);
+    var assignment = try optimization.solveAssignmentProblem(f32, allocator, cost_matrix, .min);
     defer assignment.deinit();
 
     // Convert assignments to Match structs, filtering by max_distance

--- a/src/matrix/OpsBuilder.zig
+++ b/src/matrix/OpsBuilder.zig
@@ -25,7 +25,6 @@ const Matrix = @import("Matrix.zig").Matrix;
 
 /// Builder for chaining matrix operations with in-place modifications
 pub fn OpsBuilder(comptime T: type) type {
-    assert(@typeInfo(T) == .float);
     return struct {
         const Self = @This();
 


### PR DESCRIPTION
The `Matrix` and `OpsBuilder` types are no longer restricted to floats, allowing for integer matrices. The Hungarian assignment algorithm now accepts integer cost matrices directly. For float matrices, it performs internal scaling to integers for improved precision.