### PR TITLE
refactor(image)!: rename image constructors

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -171,7 +171,7 @@ fn image_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) ca
     // Create grayscale or RGBA depending on requested format
     if (_use_gray) {
         // Grayscale path
-        var gimg = Image(u8).initAlloc(allocator, validated_rows, validated_cols) catch {
+        var gimg = Image(u8).init(allocator, validated_rows, validated_cols) catch {
             c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
             return -1;
         };
@@ -190,7 +190,7 @@ fn image_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) ca
         return 0;
     } else if (_use_rgb) {
         // RGB path
-        var rimg = Image(Rgb).initAlloc(allocator, validated_rows, validated_cols) catch {
+        var rimg = Image(Rgb).init(allocator, validated_rows, validated_cols) catch {
             c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
             return -1;
         };
@@ -208,7 +208,7 @@ fn image_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) ca
         return 0;
     } else {
         // RGBA path (explicit)
-        var image = Image(Rgba).initAlloc(allocator, validated_rows, validated_cols) catch {
+        var image = Image(Rgba).init(allocator, validated_rows, validated_cols) catch {
             c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
             return -1;
         };
@@ -1063,7 +1063,7 @@ fn image_convert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.Py
             .gray => |*img| {
                 if (target_gray) {
                     // Same format: copy
-                    var out = Image(u8).initAlloc(allocator, img.rows, img.cols) catch {
+                    var out = Image(u8).init(allocator, img.rows, img.cols) catch {
                         c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                         return null;
                     };
@@ -1142,7 +1142,7 @@ fn image_convert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.Py
                     out_self.parent_ref = null;
                     return py;
                 } else if (target_rgb) {
-                    var out = Image(Rgb).initAlloc(allocator, img.rows, img.cols) catch {
+                    var out = Image(Rgb).init(allocator, img.rows, img.cols) catch {
                         c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                         return null;
                     };
@@ -1221,7 +1221,7 @@ fn image_convert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.Py
                     out_self.parent_ref = null;
                     return py;
                 } else if (target_rgba) {
-                    var out = Image(Rgba).initAlloc(allocator, img.rows, img.cols) catch {
+                    var out = Image(Rgba).init(allocator, img.rows, img.cols) catch {
                         c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                         return null;
                     };
@@ -1511,7 +1511,7 @@ fn image_reshape(self: *ImageObject, rows: usize, cols: usize, method: Interpola
     if (self.py_image) |pimg| {
         switch (pimg.data) {
             .gray => |*img| {
-                var out = Image(u8).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(u8).init(allocator, rows, cols) catch return error.OutOfMemory;
                 img.resize(allocator, out, method) catch return error.OutOfMemory;
                 const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
                 const result = @as(*ImageObject, @ptrCast(py_obj));
@@ -1527,7 +1527,7 @@ fn image_reshape(self: *ImageObject, rows: usize, cols: usize, method: Interpola
                 return result;
             },
             .rgb => |*img| {
-                var out = Image(Rgb).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(Rgb).init(allocator, rows, cols) catch return error.OutOfMemory;
                 img.resize(allocator, out, method) catch return error.OutOfMemory;
                 const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
                 const result = @as(*ImageObject, @ptrCast(py_obj));
@@ -1543,7 +1543,7 @@ fn image_reshape(self: *ImageObject, rows: usize, cols: usize, method: Interpola
                 return result;
             },
             .rgba => |*img| {
-                var out = Image(Rgba).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(Rgba).init(allocator, rows, cols) catch return error.OutOfMemory;
                 img.resize(allocator, out, method) catch return error.OutOfMemory;
                 const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
                 const result = @as(*ImageObject, @ptrCast(py_obj));
@@ -1723,7 +1723,7 @@ fn image_letterbox_square(self: *ImageObject, size: usize, method: Interpolation
         const result = @as(*ImageObject, @ptrCast(py_obj));
         switch (pimg.data) {
             .gray => |img| {
-                var out = Image(u8).initAlloc(allocator, size, size) catch return error.OutOfMemory;
+                var out = Image(u8).init(allocator, size, size) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch return error.OutOfMemory;
                 const pnew = allocator.create(PyImage) catch {
                     out.deinit(allocator);
@@ -1734,7 +1734,7 @@ fn image_letterbox_square(self: *ImageObject, size: usize, method: Interpolation
                 result.py_image = pnew;
             },
             .rgb => |img| {
-                var out = Image(Rgb).initAlloc(allocator, size, size) catch return error.OutOfMemory;
+                var out = Image(Rgb).init(allocator, size, size) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch return error.OutOfMemory;
                 const pnew = allocator.create(PyImage) catch {
                     out.deinit(allocator);
@@ -1745,7 +1745,7 @@ fn image_letterbox_square(self: *ImageObject, size: usize, method: Interpolation
                 result.py_image = pnew;
             },
             .rgba => |img| {
-                var out = Image(Rgba).initAlloc(allocator, size, size) catch return error.OutOfMemory;
+                var out = Image(Rgba).init(allocator, size, size) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch {
                     out.deinit(allocator);
                     return error.OutOfMemory;
@@ -1772,7 +1772,7 @@ fn image_letterbox_shape(self: *ImageObject, rows: usize, cols: usize, method: I
         const result = @as(*ImageObject, @ptrCast(py_obj));
         switch (pimg.data) {
             .gray => |img| {
-                var out = Image(u8).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(u8).init(allocator, rows, cols) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch return error.OutOfMemory;
                 const pnew = allocator.create(PyImage) catch {
                     out.deinit(allocator);
@@ -1783,7 +1783,7 @@ fn image_letterbox_shape(self: *ImageObject, rows: usize, cols: usize, method: I
                 result.py_image = pnew;
             },
             .rgb => |img| {
-                var out = Image(Rgb).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(Rgb).init(allocator, rows, cols) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch return error.OutOfMemory;
                 const pnew = allocator.create(PyImage) catch {
                     out.deinit(allocator);
@@ -1794,7 +1794,7 @@ fn image_letterbox_shape(self: *ImageObject, rows: usize, cols: usize, method: I
                 result.py_image = pnew;
             },
             .rgba => |img| {
-                var out = Image(Rgba).initAlloc(allocator, rows, cols) catch return error.OutOfMemory;
+                var out = Image(Rgba).init(allocator, rows, cols) catch return error.OutOfMemory;
                 _ = img.letterbox(allocator, &out, method) catch {
                     out.deinit(allocator);
                     return error.OutOfMemory;
@@ -2769,7 +2769,7 @@ fn image_crop(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObj
         const result = @as(*ImageObject, @ptrCast(py_obj));
         switch (pimg.data) {
             .gray => |*img| {
-                var out = Image(u8).initAlloc(allocator, img.rows, img.cols) catch {
+                var out = Image(u8).init(allocator, img.rows, img.cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
                     return null;
@@ -2790,7 +2790,7 @@ fn image_crop(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObj
                 result.py_image = pnew;
             },
             .rgb => |*img| {
-                var out = Image(Rgb).initAlloc(allocator, img.rows, img.cols) catch {
+                var out = Image(Rgb).init(allocator, img.rows, img.cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
                     return null;
@@ -2811,7 +2811,7 @@ fn image_crop(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObj
                 result.py_image = pnew;
             },
             .rgba => |*img| {
-                var out = Image(Rgba).initAlloc(allocator, img.rows, img.cols) catch {
+                var out = Image(Rgba).init(allocator, img.rows, img.cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                     return null;
@@ -2957,7 +2957,7 @@ fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject)
         const result = @as(*ImageObject, @ptrCast(py_obj));
         switch (pimg.data) {
             .gray => |img| {
-                var out = Image(u8).initAlloc(allocator, out_rows, out_cols) catch {
+                var out = Image(u8).init(allocator, out_rows, out_cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                     return null;
@@ -2972,7 +2972,7 @@ fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject)
                 result.py_image = pnew;
             },
             .rgb => |img| {
-                var out = Image(Rgb).initAlloc(allocator, out_rows, out_cols) catch {
+                var out = Image(Rgb).init(allocator, out_rows, out_cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                     return null;
@@ -2987,7 +2987,7 @@ fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject)
                 result.py_image = pnew;
             },
             .rgba => |img| {
-                var out = Image(Rgba).initAlloc(allocator, out_rows, out_cols) catch {
+                var out = Image(Rgba).init(allocator, out_rows, out_cols) catch {
                     c.Py_DECREF(py_obj);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
                     return null;

--- a/examples/src/face_alignment.zig
+++ b/examples/src/face_alignment.zig
@@ -124,7 +124,7 @@ pub export fn extract_aligned_face(
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const image: Image(Rgba) = .init(rows, cols, rgba_ptr[0 .. rows * cols]);
+    const image: Image(Rgba) = .initFromSlice(rows, cols, rgba_ptr[0 .. rows * cols]);
 
     const landmarks: []const Point = blk: {
         var array: std.ArrayList(Point) = .empty;
@@ -142,7 +142,7 @@ pub export fn extract_aligned_face(
     };
     defer allocator.free(landmarks);
 
-    var aligned: Image(Rgba) = .init(out_rows, out_cols, out_ptr[0 .. out_rows * out_cols]);
+    var aligned: Image(Rgba) = .initFromSlice(out_rows, out_cols, out_ptr[0 .. out_rows * out_cols]);
     extractAlignedFace(Rgba, allocator, image, landmarks, padding, blurring, &aligned) catch {
         std.log.err("Ran out of memory while extracting the aligned face", .{});
         @panic("OOM");

--- a/examples/src/fdm.zig
+++ b/examples/src/fdm.zig
@@ -51,8 +51,8 @@ pub export fn fdm(
     const src_size = source_rows * source_cols;
     const ref_size = target_rows * target_cols;
 
-    const src_img: Image(Rgba) = .init(source_rows, source_cols, source_ptr[0..src_size]);
-    const ref_img: Image(Rgba) = .init(target_rows, target_cols, target_ptr[0..ref_size]);
+    const src_img: Image(Rgba) = .initFromSlice(source_rows, source_cols, source_ptr[0..src_size]);
+    const ref_img: Image(Rgba) = .initFromSlice(target_rows, target_cols, target_ptr[0..ref_size]);
 
     // Apply FDM using new API
     var matcher = FeatureDistributionMatching(Rgba).init(allocator);

--- a/examples/src/image_demo.zig
+++ b/examples/src/image_demo.zig
@@ -11,18 +11,18 @@ pub fn main() !void {
     var image: Image(Rgba) = try .load(gpa, "../assets/liza.jpg");
     defer image.deinit(gpa);
 
-    var edges: Image(u8) = try .initAlloc(gpa, image.rows, image.cols);
+    var edges: Image(u8) = try .init(gpa, image.rows, image.cols);
     defer edges.deinit(gpa);
 
     try image.sobel(gpa, &edges);
     try edges.save(gpa, "liza-sobel.png");
 
-    var blurred: Image(Rgba) = try .initAlloc(gpa, image.rows, image.cols);
+    var blurred: Image(Rgba) = try .init(gpa, image.rows, image.cols);
     defer blurred.deinit(gpa);
     try image.gaussianBlur(gpa, 5.0, &blurred);
     try blurred.save(gpa, "liza-gaussian.png");
 
-    var resized: Image(Rgba) = try .initAlloc(gpa, image.rows / 2, image.cols / 2);
+    var resized: Image(Rgba) = try .init(gpa, image.rows / 2, image.cols / 2);
     defer resized.deinit(gpa);
     try image.resize(gpa, resized, .nearest_neighbor);
     try resized.save(gpa, "liza-resized-nearest.png");

--- a/examples/src/make_logo.zig
+++ b/examples/src/make_logo.zig
@@ -18,7 +18,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Create a 512x512 image for the logo
-    var image = try Image(Rgb).initAlloc(allocator, 512, 512);
+    var image = try Image(Rgb).init(allocator, 512, 512);
     defer image.deinit(allocator);
 
     // Create canvas for drawing

--- a/examples/src/orb_demo.zig
+++ b/examples/src/orb_demo.zig
@@ -137,7 +137,7 @@ pub fn main() !void {
     // Create visualization: concatenate images side by side
     const combined_width = original.cols + rotated.cols;
     const combined_height = @max(original.rows, rotated.rows);
-    var match_viz = try Image(Rgb).initAlloc(allocator, combined_height, combined_width);
+    var match_viz = try Image(Rgb).init(allocator, combined_height, combined_width);
     defer match_viz.deinit(allocator);
 
     // Fill with black

--- a/examples/src/pca_example.zig
+++ b/examples/src/pca_example.zig
@@ -190,7 +190,7 @@ pub fn main() !void {
     defer gpa.free(original_points);
 
     // 2. Create original visualization
-    var original_image: Image(Rgb) = try .initAlloc(gpa, canvas_size, canvas_size);
+    var original_image: Image(Rgb) = try .init(gpa, canvas_size, canvas_size);
     defer original_image.deinit(gpa);
 
     const original_canvas: Canvas(Rgb) = .init(gpa, original_image);
@@ -214,7 +214,7 @@ pub fn main() !void {
     const aligned_points = try projectAndAlign(gpa, pca, original_points);
     defer gpa.free(aligned_points);
 
-    var aligned_image = try Image(Rgb).initAlloc(gpa, canvas_size, canvas_size);
+    var aligned_image = try Image(Rgb).init(gpa, canvas_size, canvas_size);
     defer aligned_image.deinit(gpa);
 
     const aligned_canvas = Canvas(Rgb).init(gpa, aligned_image);

--- a/examples/src/perlin_noise.zig
+++ b/examples/src/perlin_noise.zig
@@ -45,7 +45,7 @@ pub export fn set_lacunarity(val: f32) void {
 
 pub export fn generate(rgba_ptr: [*]Rgba, rows: usize, cols: usize) void {
     const size = rows * cols;
-    const image: Image(Rgba) = .init(rows, cols, rgba_ptr[0..size]);
+    const image: Image(Rgba) = .initFromSlice(rows, cols, rgba_ptr[0..size]);
     for (0..image.rows) |r| {
         const y: f32 = @as(f32, @floatFromInt(r)) / @as(f32, @floatFromInt(image.rows));
         for (0..image.cols) |c| {

--- a/examples/src/png_example.zig
+++ b/examples/src/png_example.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
     // ========================================================================
     std.log.info("\n📸 1. RGB Image Creation & Round-trip Testing", .{});
 
-    var rgb_image = try Image(Rgb).initAlloc(gpa, height, width);
+    var rgb_image = try Image(Rgb).init(gpa, height, width);
     defer rgb_image.deinit(gpa);
 
     // Create a colorful test pattern
@@ -64,7 +64,7 @@ pub fn main() !void {
     // ========================================================================
     std.log.info("\n🎭 2. RGBA with Transparency", .{});
 
-    var rgba_image = try Image(Rgba).initAlloc(gpa, height, width);
+    var rgba_image = try Image(Rgba).init(gpa, height, width);
     defer rgba_image.deinit(gpa);
 
     for (0..height) |y| {
@@ -99,7 +99,7 @@ pub fn main() !void {
     // ========================================================================
     std.log.info("\n⚫ 3. Grayscale Images", .{});
 
-    var gray_image = try Image(u8).initAlloc(gpa, height, width);
+    var gray_image = try Image(u8).init(gpa, height, width);
     defer gray_image.deinit(gpa);
 
     // Create a pattern with various gray levels
@@ -146,7 +146,7 @@ pub fn main() !void {
     std.log.info("\n🌈 5. Custom Color Space Support", .{});
 
     // Create HSL image and save as PNG (automatic conversion to RGB)
-    var hsl_image = try Image(Hsl).initAlloc(gpa, height / 2, width / 2);
+    var hsl_image = try Image(Hsl).init(gpa, height / 2, width / 2);
     defer hsl_image.deinit(gpa);
 
     for (0..height / 2) |y| {
@@ -173,7 +173,7 @@ pub fn main() !void {
     std.log.info("\n🧪 6. Edge Cases & Validation", .{});
 
     // Test 1x1 pixel image
-    var tiny_image = try Image(Rgb).initAlloc(gpa, 1, 1);
+    var tiny_image = try Image(Rgb).init(gpa, 1, 1);
     defer tiny_image.deinit(gpa);
     tiny_image.data[0] = Rgb{ .r = 255, .g = 0, .b = 128 };
 
@@ -186,7 +186,7 @@ pub fn main() !void {
 
     // Test large-ish image (performance test)
     const large_size = 128;
-    var large_image = try Image(Rgb).initAlloc(gpa, large_size, large_size);
+    var large_image = try Image(Rgb).init(gpa, large_size, large_size);
     defer large_image.deinit(gpa);
 
     for (0..large_size) |y| {

--- a/examples/src/seam_carving.zig
+++ b/examples/src/seam_carving.zig
@@ -97,7 +97,7 @@ pub fn removeSeam(comptime T: type, image: *Image(T), seam: []const usize) void 
 pub export fn seam_carve(rgba_ptr: [*]Rgba, rows: usize, cols: usize, extra_ptr: ?[*]u8, extra_len: usize, seam_ptr: [*]usize, seam_size: usize) void {
     assert(seam_size == rows);
     const size = rows * cols;
-    var image: Image(Rgba) = .init(rows, cols, rgba_ptr[0..size]);
+    var image: Image(Rgba) = .initFromSlice(rows, cols, rgba_ptr[0..size]);
 
     const allocator: std.mem.Allocator = blk: {
         if (extra_ptr) |ptr| {
@@ -114,11 +114,11 @@ pub export fn seam_carve(rgba_ptr: [*]Rgba, rows: usize, cols: usize, extra_ptr:
         }
     };
 
-    var edges = Image(u8).initAlloc(allocator, rows, cols) catch @panic("OOM");
+    var edges = Image(u8).init(allocator, rows, cols) catch @panic("OOM");
     defer edges.deinit(allocator);
     image.sobel(allocator, &edges) catch @panic("OOM");
 
-    var energy_map = Image(u32).initAlloc(allocator, image.rows, image.cols) catch @panic("OOM");
+    var energy_map = Image(u32).init(allocator, image.rows, image.cols) catch @panic("OOM");
     defer energy_map.deinit(allocator);
     computeEnergy(edges, &energy_map);
 

--- a/examples/src/whitebalance.zig
+++ b/examples/src/whitebalance.zig
@@ -152,7 +152,7 @@ fn whitebalanceSimd(pixels: []Rgba, w: RgbGains) void {
 pub export fn whitebalance(rgba_ptr: [*]Rgba, rows: usize, cols: usize, r: u8, g: u8, b: u8) void {
     const color: Rgb = .{ .r = r, .g = g, .b = b };
     std.log.info("color: {}, {}, {}\n", color);
-    const image: Image(Rgba) = .init(rows, cols, rgba_ptr[0 .. rows * cols]);
+    const image: Image(Rgba) = .initFromSlice(rows, cols, rgba_ptr[0 .. rows * cols]);
     const w = estimateIlluminant(image, color, 0.7);
     whitebalanceSimd(image.data, w);
 }

--- a/src/canvas/tests/arcs.zig
+++ b/src/canvas/tests/arcs.zig
@@ -12,7 +12,7 @@ test "arc drawing - basic angles" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgb).initAlloc(allocator, width, height);
+    var img = try Image(Rgb).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgb).init(allocator, img);
@@ -66,7 +66,7 @@ test "arc drawing - full circle optimization" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgb).initAlloc(allocator, width, height);
+    var img = try Image(Rgb).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgb).init(allocator, img);
@@ -97,9 +97,9 @@ test "arc drawing - angle wrapping" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img1 = try Image(Rgb).initAlloc(allocator, width, height);
+    var img1 = try Image(Rgb).init(allocator, width, height);
     defer img1.deinit(allocator);
-    var img2 = try Image(Rgb).initAlloc(allocator, width, height);
+    var img2 = try Image(Rgb).init(allocator, width, height);
     defer img2.deinit(allocator);
 
     const canvas1 = Canvas(Rgb).init(allocator, img1);
@@ -139,7 +139,7 @@ test "fillArc - pie slices" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgb).initAlloc(allocator, width, height);
+    var img = try Image(Rgb).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgb).init(allocator, img);
@@ -183,9 +183,9 @@ test "arc drawing - soft vs fast mode" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img_fast = try Image(Rgba).initAlloc(allocator, width, height);
+    var img_fast = try Image(Rgba).init(allocator, width, height);
     defer img_fast.deinit(allocator);
-    var img_soft = try Image(Rgba).initAlloc(allocator, width, height);
+    var img_soft = try Image(Rgba).init(allocator, width, height);
     defer img_soft.deinit(allocator);
 
     const canvas_fast = Canvas(Rgba).init(allocator, img_fast);
@@ -228,7 +228,7 @@ test "arc drawing - zero and negative radius" {
     const allocator = testing.allocator;
     const width = 100;
     const height = 100;
-    var img = try Image(Rgb).initAlloc(allocator, width, height);
+    var img = try Image(Rgb).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgb).init(allocator, img);
@@ -253,7 +253,7 @@ test "arc drawing - NaN and Inf angles" {
     const allocator = testing.allocator;
     const width = 100;
     const height = 100;
-    var img = try Image(Rgb).initAlloc(allocator, width, height);
+    var img = try Image(Rgb).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgb).init(allocator, img);

--- a/src/canvas/tests/drawing.zig
+++ b/src/canvas/tests/drawing.zig
@@ -13,7 +13,7 @@ test "line endpoints are connected" {
     const allocator = testing.allocator;
     const width = 100;
     const height = 100;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     // Fill with white
@@ -74,7 +74,7 @@ test "thick lines have correct width" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);
@@ -125,7 +125,7 @@ test "filled circle has correct radius" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);
@@ -181,7 +181,7 @@ test "circle outline has correct thickness" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);
@@ -229,7 +229,7 @@ test "filled rectangle has correct area" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);
@@ -269,7 +269,7 @@ test "polygon fill respects convexity" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);
@@ -313,9 +313,9 @@ test "antialiased vs solid fill coverage" {
     const allocator = testing.allocator;
     const width = 100;
     const height = 100;
-    var img_solid = try Image(Rgba).initAlloc(allocator, width, height);
+    var img_solid = try Image(Rgba).init(allocator, width, height);
     defer img_solid.deinit(allocator);
-    var img_smooth = try Image(Rgba).initAlloc(allocator, width, height);
+    var img_smooth = try Image(Rgba).init(allocator, width, height);
     defer img_smooth.deinit(allocator);
 
     const canvas_solid = Canvas(Rgba).init(allocator, img_solid);
@@ -354,7 +354,7 @@ test "bezier curve smoothness" {
     const allocator = testing.allocator;
     const width = 200;
     const height = 200;
-    var img = try Image(Rgba).initAlloc(allocator, width, height);
+    var img = try Image(Rgba).init(allocator, width, height);
     defer img.deinit(allocator);
 
     const canvas = Canvas(Rgba).init(allocator, img);

--- a/src/canvas/tests/regression.zig
+++ b/src/canvas/tests/regression.zig
@@ -185,7 +185,7 @@ test "MD5 checksum regression tests" {
     const height = 100;
 
     for (md5_checksums) |test_case| {
-        var img = try Image(Rgba).initAlloc(allocator, width, height);
+        var img = try Image(Rgba).init(allocator, width, height);
         defer img.deinit(allocator);
 
         // White background

--- a/src/fdm.zig
+++ b/src/fdm.zig
@@ -459,7 +459,7 @@ test "FDM mean and covariance matching" {
     const allocator = testing.allocator;
 
     // Create source image with known statistics
-    var source_img = try Image(Rgb).initAlloc(allocator, 50, 50);
+    var source_img = try Image(Rgb).init(allocator, 50, 50);
     defer source_img.deinit(allocator);
     for (source_img.data, 0..) |*pixel, i| {
         // Create specific pattern for known covariance structure
@@ -473,7 +473,7 @@ test "FDM mean and covariance matching" {
     }
 
     // Create target image with different known statistics
-    var target_img = try Image(Rgb).initAlloc(allocator, 50, 50);
+    var target_img = try Image(Rgb).init(allocator, 50, 50);
     defer target_img.deinit(allocator);
     for (target_img.data, 0..) |*pixel, i| {
         const x = i % 50;
@@ -564,7 +564,7 @@ test "FDM grayscale mean and variance matching" {
     const allocator = testing.allocator;
 
     // Create source image with known statistics
-    var source_img = try Image(u8).initAlloc(allocator, 100, 1);
+    var source_img = try Image(u8).init(allocator, 100, 1);
     defer source_img.deinit(allocator);
 
     // Fill with values 0-99 for known mean=49.5, variance
@@ -573,7 +573,7 @@ test "FDM grayscale mean and variance matching" {
     }
 
     // Create target image with different known statistics
-    var target_img = try Image(u8).initAlloc(allocator, 100, 1);
+    var target_img = try Image(u8).init(allocator, 100, 1);
     defer target_img.deinit(allocator);
 
     // Fill with values 100-199 for known mean=149.5
@@ -602,7 +602,7 @@ test "FDM batch processing with reused target" {
     const allocator = testing.allocator;
 
     // Create a target style image
-    var target_img = try Image(Rgb).initAlloc(allocator, 20, 20);
+    var target_img = try Image(Rgb).init(allocator, 20, 20);
     defer target_img.deinit(allocator);
     for (target_img.data, 0..) |*pixel, i| {
         // Warm color palette
@@ -616,7 +616,7 @@ test "FDM batch processing with reused target" {
     // Create multiple source images to transform
     var source_images: [3]Image(Rgb) = undefined;
     for (&source_images, 0..) |*img, idx| {
-        img.* = try Image(Rgb).initAlloc(allocator, 20, 20);
+        img.* = try Image(Rgb).init(allocator, 20, 20);
         for (img.data, 0..) |*pixel, i| {
             // Different cool color patterns
             pixel.* = Rgb{
@@ -673,14 +673,14 @@ test "FDM error handling" {
     try testing.expectError(error.NoTargetSet, fdm.update());
 
     // Set target but not source
-    var target_img = try Image(Rgb).initAlloc(allocator, 10, 10);
+    var target_img = try Image(Rgb).init(allocator, 10, 10);
     defer target_img.deinit(allocator);
     try fdm.setTarget(target_img);
 
     try testing.expectError(error.NoSourceSet, fdm.update());
 
     // Now it should work
-    var source_img = try Image(Rgb).initAlloc(allocator, 10, 10);
+    var source_img = try Image(Rgb).init(allocator, 10, 10);
     defer source_img.deinit(allocator);
     try fdm.setSource(source_img);
     try fdm.update(); // Should succeed

--- a/src/features/Fast.zig
+++ b/src/features/Fast.zig
@@ -271,7 +271,7 @@ test "FAST detector on synthetic corner" {
     const allocator = std.testing.allocator;
 
     // Create a simple image with a corner pattern
-    var image = try Image(u8).initAlloc(allocator, 20, 20);
+    var image = try Image(u8).init(allocator, 20, 20);
     defer image.deinit(allocator);
 
     // Fill with gray
@@ -321,7 +321,7 @@ test "FAST non-maximal suppression" {
     const allocator = std.testing.allocator;
 
     // Create a simple image
-    var image = try Image(u8).initAlloc(allocator, 50, 50);
+    var image = try Image(u8).init(allocator, 50, 50);
     defer image.deinit(allocator);
 
     // Fill with gradient pattern that will create many corners

--- a/src/features/Orb.zig
+++ b/src/features/Orb.zig
@@ -344,7 +344,7 @@ test "ORB detect and compute on synthetic image" {
     const allocator = std.testing.allocator;
 
     // Create test image with strong corner patterns
-    var image = try Image(u8).initAlloc(allocator, 100, 100);
+    var image = try Image(u8).init(allocator, 100, 100);
     defer image.deinit(allocator);
 
     // Fill with mid-gray

--- a/src/features/test_orb_integration.zig
+++ b/src/features/test_orb_integration.zig
@@ -239,7 +239,7 @@ test "ORB kNN matching" {
 // Helper functions to create test images
 
 fn createTestImage(allocator: Allocator, rows: usize, cols: usize, seed: u64) !Image(u8) {
-    var image = try Image(u8).initAlloc(allocator, rows, cols);
+    var image = try Image(u8).init(allocator, rows, cols);
 
     var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
@@ -270,7 +270,7 @@ fn createTestImage(allocator: Allocator, rows: usize, cols: usize, seed: u64) !I
 }
 
 fn createPatternImage(allocator: Allocator, rows: usize, cols: usize) !Image(u8) {
-    var image = try Image(u8).initAlloc(allocator, rows, cols);
+    var image = try Image(u8).init(allocator, rows, cols);
 
     // Fill with gray
     for (0..rows) |r| {
@@ -299,7 +299,7 @@ fn createPatternImage(allocator: Allocator, rows: usize, cols: usize) !Image(u8)
 }
 
 fn createRotatedPatternImage(allocator: Allocator, rows: usize, cols: usize) !Image(u8) {
-    var image = try Image(u8).initAlloc(allocator, rows, cols);
+    var image = try Image(u8).init(allocator, rows, cols);
 
     // Fill with gray
     for (0..rows) |r| {

--- a/src/features/test_pyramid.zig
+++ b/src/features/test_pyramid.zig
@@ -67,7 +67,7 @@ pub fn Filter(comptime T: type) type {
         pub fn boxBlur(self: Image(T), allocator: Allocator, blurred: *Image(T), radius: usize) !void {
             _ = radius;
             if (blurred.rows == 0) {
-                blurred.* = try Image(T).initAlloc(allocator, self.rows, self.cols);
+                blurred.* = try Image(T).init(allocator, self.rows, self.cols);
             }
 
             // Simple box blur (just copy for testing)
@@ -138,7 +138,7 @@ pub fn ImagePyramid(comptime T: type) type {
                 const radius = @as(usize, @intFromFloat(blur_sigma * 2));
                 try Filter(T).boxBlur(prev_level, allocator, &blurred, radius);
 
-                levels[i] = try Image(T).initAlloc(allocator, new_rows, new_cols);
+                levels[i] = try Image(T).init(allocator, new_rows, new_cols);
 
                 const blur_to_use = if (blurred.rows > 0) blurred else prev_level;
                 try blur_to_use.resize(allocator, levels[i], .bilinear);
@@ -174,7 +174,7 @@ const expectApproxEqAbs = std.testing.expectApproxEqAbs;
 test "ImagePyramid construction and scaling" {
     const allocator = std.testing.allocator;
 
-    var image = try Image(u8).initAlloc(allocator, 640, 480);
+    var image = try Image(u8).init(allocator, 640, 480);
     defer image.deinit(allocator);
 
     // Fill with test pattern

--- a/src/image/PixelIterator.zig
+++ b/src/image/PixelIterator.zig
@@ -62,7 +62,7 @@ test "PixelIterator basic functionality" {
     const allocator = std.testing.allocator;
 
     // Create a simple 3x3 image
-    var img = try Image(u8).initAlloc(allocator, 3, 3);
+    var img = try Image(u8).init(allocator, 3, 3);
     defer img.deinit(allocator);
 
     // Fill with sequential values
@@ -96,7 +96,7 @@ test "PixelIterator with views" {
     const allocator = std.testing.allocator;
 
     // Create a 4x4 image
-    var img: Image(u8) = try .initAlloc(allocator, 4, 4);
+    var img: Image(u8) = try .init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Fill with sequential values
@@ -141,13 +141,13 @@ test "PixelIterator reuse with init" {
     const allocator = std.testing.allocator;
 
     // Create two different images
-    var img1: Image(u8) = try .initAlloc(allocator, 2, 2);
+    var img1: Image(u8) = try .init(allocator, 2, 2);
     defer img1.deinit(allocator);
     for (0..4) |i| {
         img1.data[i] = @intCast(i * 10); // 0, 10, 20, 30
     }
 
-    var img2: Image(u8) = try .initAlloc(allocator, 3, 3);
+    var img2: Image(u8) = try .init(allocator, 3, 3);
     defer img2.deinit(allocator);
     for (0..9) |i| {
         img2.data[i] = @intCast(i); // 0, 1, 2, ..., 8

--- a/src/image/filtering.zig
+++ b/src/image/filtering.zig
@@ -37,7 +37,7 @@ pub fn Filter(comptime T: type) type {
         /// This function is optimized using SIMD instructions for performance where applicable.
         pub fn boxBlur(self: Self, allocator: std.mem.Allocator, blurred: *Self, radius: usize) !void {
             if (!self.hasSameShape(blurred.*)) {
-                blurred.* = try .initAlloc(allocator, self.rows, self.cols);
+                blurred.* = try .init(allocator, self.rows, self.cols);
             }
             if (radius == 0) {
                 self.copy(blurred.*);
@@ -179,7 +179,7 @@ pub fn Filter(comptime T: type) type {
         /// increases the contrast at edges. SIMD optimizations are used for performance where applicable.
         pub fn sharpen(self: Self, allocator: std.mem.Allocator, sharpened: *Self, radius: usize) !void {
             if (!self.hasSameShape(sharpened.*)) {
-                sharpened.* = try .initAlloc(allocator, self.rows, self.cols);
+                sharpened.* = try .init(allocator, self.rows, self.cols);
             }
             if (radius == 0) {
                 self.copy(sharpened.*);
@@ -508,7 +508,7 @@ pub fn Filter(comptime T: type) type {
             const kernel_width = @typeInfo(outer_array.child).array.len;
 
             if (!self.hasSameShape(out.*)) {
-                out.* = try .initAlloc(allocator, self.rows, self.cols);
+                out.* = try .init(allocator, self.rows, self.cols);
             }
 
             // Generate specialized implementation for this kernel size
@@ -966,7 +966,7 @@ pub fn Filter(comptime T: type) type {
             sat: *Image(if (meta.isScalar(T)) f32 else [Self.channels()]f32),
         ) !void {
             if (!self.hasSameShape(sat.*)) {
-                sat.* = try .initAlloc(allocator, self.rows, self.cols);
+                sat.* = try .init(allocator, self.rows, self.cols);
             }
 
             switch (@typeInfo(T)) {
@@ -1027,11 +1027,11 @@ pub fn Filter(comptime T: type) type {
         pub fn convolveSeparable(self: Self, allocator: Allocator, kernel_x: []const f32, kernel_y: []const f32, out: *Self, border_mode: BorderMode) !void {
             // Ensure output is properly allocated
             if (out.rows == 0 or out.cols == 0 or !self.hasSameShape(out.*)) {
-                out.* = try .initAlloc(allocator, self.rows, self.cols);
+                out.* = try .init(allocator, self.rows, self.cols);
             }
 
             // Allocate temporary buffer for intermediate result
-            var temp = try Self.initAlloc(allocator, self.rows, self.cols);
+            var temp = try Self.init(allocator, self.rows, self.cols);
             defer temp.deinit(allocator);
 
             const half_x = kernel_x.len / 2;
@@ -1296,7 +1296,7 @@ pub fn Filter(comptime T: type) type {
 
             // Ensure output is allocated
             if (!self.hasSameShape(out.*)) {
-                out.* = try .initAlloc(allocator, self.rows, self.cols);
+                out.* = try .init(allocator, self.rows, self.cols);
             }
 
             // Calculate kernel sizes for both sigmas
@@ -1334,9 +1334,9 @@ pub fn Filter(comptime T: type) type {
             }
 
             // Allocate temporary buffers for the two blurred results
-            var blur1 = try Self.initAlloc(allocator, self.rows, self.cols);
+            var blur1 = try Self.init(allocator, self.rows, self.cols);
             defer blur1.deinit(allocator);
-            var blur2 = try Self.initAlloc(allocator, self.rows, self.cols);
+            var blur2 = try Self.init(allocator, self.rows, self.cols);
             defer blur2.deinit(allocator);
 
             // Apply both Gaussian blurs using separable convolution
@@ -1402,7 +1402,7 @@ pub fn Filter(comptime T: type) type {
         /// - `out`: An out-parameter pointer to an `Image(u8)` that will be filled with the Sobel magnitude image.
         pub fn sobel(self: Self, allocator: Allocator, out: *Image(u8)) !void {
             if (!self.hasSameShape(out.*)) {
-                out.* = try .initAlloc(allocator, self.rows, self.cols);
+                out.* = try .init(allocator, self.rows, self.cols);
             }
 
             // For now, use float path for all types to ensure correctness
@@ -1423,7 +1423,7 @@ pub fn Filter(comptime T: type) type {
                 var gray_float: Image(f32) = undefined;
                 const needs_conversion = !isScalar(T) or @typeInfo(T) != .float;
                 if (needs_conversion) {
-                    gray_float = try .initAlloc(allocator, self.rows, self.cols);
+                    gray_float = try .init(allocator, self.rows, self.cols);
                     for (0..self.rows) |r| {
                         for (0..self.cols) |c| {
                             gray_float.at(r, c).* = as(f32, convertColor(u8, self.at(r, c).*));

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -88,7 +88,7 @@ pub fn ImagePyramid(comptime T: type) type {
                 }
 
                 // Allocate and resize to create the new level
-                levels[i] = try Image(T).initAlloc(allocator, new_rows, new_cols);
+                levels[i] = try Image(T).init(allocator, new_rows, new_cols);
 
                 // Use bilinear interpolation for downsampling
                 const blur_to_use = if (blurred.rows > 0) blurred else prev_level;
@@ -174,7 +174,7 @@ test "ImagePyramid basic construction" {
     const allocator = std.testing.allocator;
 
     // Create a test image
-    var image = try Image(u8).initAlloc(allocator, 640, 480);
+    var image = try Image(u8).init(allocator, 640, 480);
     defer image.deinit(allocator);
 
     // Fill with test pattern
@@ -208,7 +208,7 @@ test "ImagePyramid basic construction" {
 test "ImagePyramid scale calculations" {
     const allocator = std.testing.allocator;
 
-    var image = try Image(u8).initAlloc(allocator, 100, 100);
+    var image = try Image(u8).init(allocator, 100, 100);
     defer image.deinit(allocator);
 
     var pyramid = try ImagePyramid(u8).build(allocator, image, 4, 1.2, 1.0);
@@ -234,7 +234,7 @@ test "ImagePyramid truncation for small images" {
     const allocator = std.testing.allocator;
 
     // Start with a small image
-    var image = try Image(u8).initAlloc(allocator, 32, 32);
+    var image = try Image(u8).init(allocator, 32, 32);
     defer image.deinit(allocator);
 
     // Request many levels but expect truncation
@@ -253,7 +253,7 @@ test "ImagePyramid truncation for small images" {
 test "ImagePyramid memory usage" {
     const allocator = std.testing.allocator;
 
-    var image = try Image(u8).initAlloc(allocator, 256, 256);
+    var image = try Image(u8).init(allocator, 256, 256);
     defer image.deinit(allocator);
 
     var pyramid = try ImagePyramid(u8).build(allocator, image, 4, 1.5, 1.0);

--- a/src/image/tests/display.zig
+++ b/src/image/tests/display.zig
@@ -10,7 +10,7 @@ test "image format function" {
     const Rgb = color.Rgb;
 
     // Create a small 2x2 RGB image
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 2, 2);
+    var image = try Image(Rgb).init(std.testing.allocator, 2, 2);
     defer image.deinit(std.testing.allocator);
 
     // Set up a pattern: red, green, blue, white
@@ -39,7 +39,7 @@ test "image format ansi_blocks" {
     const Rgb = color.Rgb;
 
     // Create a small 2x2 RGB image
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 2, 2);
+    var image = try Image(Rgb).init(std.testing.allocator, 2, 2);
     defer image.deinit(std.testing.allocator);
 
     // Set up a pattern: red, green, blue, white
@@ -67,7 +67,7 @@ test "image format ansi_blocks odd rows" {
     const Rgb = color.Rgb;
 
     // Create a 3x2 RGB image (odd number of rows)
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 3, 2);
+    var image = try Image(Rgb).init(std.testing.allocator, 3, 2);
     defer image.deinit(std.testing.allocator);
 
     // Set up colors
@@ -98,7 +98,7 @@ test "image format braille" {
     const Rgb = color.Rgb;
 
     // Create a 4x4 RGB image (perfect for one Braille character)
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 4, 2);
+    var image = try Image(Rgb).init(std.testing.allocator, 4, 2);
     defer image.deinit(std.testing.allocator);
 
     // Create a diagonal pattern
@@ -135,7 +135,7 @@ test "image format braille custom threshold" {
     const Rgb = color.Rgb;
 
     // Create a 4x2 grayscale gradient image
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 4, 2);
+    var image = try Image(Rgb).init(std.testing.allocator, 4, 2);
     defer image.deinit(std.testing.allocator);
 
     // Create a gradient from black to white
@@ -169,7 +169,7 @@ test "image format braille large image" {
     const Rgb = color.Rgb;
 
     // Create an 8x4 image (2x2 Braille characters)
-    var image = try Image(Rgb).initAlloc(std.testing.allocator, 8, 4);
+    var image = try Image(Rgb).init(std.testing.allocator, 8, 4);
     defer image.deinit(std.testing.allocator);
 
     // Fill with checkerboard pattern

--- a/src/image/tests/filters.zig
+++ b/src/image/tests/filters.zig
@@ -10,7 +10,7 @@ const Rectangle = @import("../../geometry.zig").Rectangle;
 const Image = @import("../Image.zig").Image;
 
 test "boxBlur radius 0 with views" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 6, 8);
+    var image: Image(u8) = try .init(std.testing.allocator, 6, 8);
     defer image.deinit(std.testing.allocator);
 
     // Fill with pattern
@@ -37,7 +37,7 @@ test "boxBlur radius 0 with views" {
 }
 
 test "view" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     const rect: Rectangle(usize) = .{ .l = 0, .t = 0, .r = 8, .b = 10 };
     const view = image.view(rect);
@@ -48,7 +48,7 @@ test "view" {
 
 test "boxBlur basic functionality" {
     // Test with uniform image - should remain unchanged
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Fill with uniform value
@@ -65,7 +65,7 @@ test "boxBlur basic functionality" {
 }
 
 test "boxBlur zero radius" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Initialize with pattern
@@ -89,7 +89,7 @@ test "boxBlur zero radius" {
 
 test "boxBlur border effects" {
     // Create a small image to test border handling
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Initialize with a pattern where center is 255, edges are 0
@@ -116,7 +116,7 @@ test "boxBlur border effects" {
 }
 
 test "boxBlur struct type" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Initialize with different colors
@@ -152,7 +152,7 @@ test "boxBlur border area calculations" {
     const radius = 3;
 
     // Test with uniform image - all pixels should have the same value after blur
-    var uniform_image: Image(u8) = try .initAlloc(std.testing.allocator, test_size, test_size);
+    var uniform_image: Image(u8) = try .init(std.testing.allocator, test_size, test_size);
     defer uniform_image.deinit(std.testing.allocator);
 
     for (uniform_image.data) |*pixel| pixel.* = 200;
@@ -169,7 +169,7 @@ test "boxBlur border area calculations" {
     }
 
     // Test with gradient - area calculations should be smooth
-    var gradient_image: Image(u8) = try .initAlloc(std.testing.allocator, test_size, test_size);
+    var gradient_image: Image(u8) = try .init(std.testing.allocator, test_size, test_size);
     defer gradient_image.deinit(std.testing.allocator);
 
     for (0..test_size) |r| {
@@ -197,7 +197,7 @@ test "boxBlur struct type comprehensive" {
     // Test RGBA with both large images (SIMD) and small images (scalar)
     for ([_]usize{ 8, 32 }) |test_size| { // Small and large
         for ([_]usize{ 1, 3 }) |radius| {
-            var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, test_size, test_size);
+            var image: Image(color.Rgba) = try .init(std.testing.allocator, test_size, test_size);
             defer image.deinit(std.testing.allocator);
 
             // Create a red-to-blue gradient
@@ -237,7 +237,7 @@ test "boxBlur struct type comprehensive" {
 }
 
 test "sharpen basic functionality" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Create an edge pattern: left half dark, right half bright
@@ -264,7 +264,7 @@ test "sharpen basic functionality" {
 }
 
 test "sharpen zero radius" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Initialize with pattern
@@ -287,7 +287,7 @@ test "sharpen zero radius" {
 }
 
 test "sharpen uniform image" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 4, 4);
+    var image: Image(u8) = try .init(std.testing.allocator, 4, 4);
     defer image.deinit(std.testing.allocator);
 
     // Fill with uniform value
@@ -305,7 +305,7 @@ test "sharpen uniform image" {
 }
 
 test "sharpen struct type" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Create a simple pattern with a bright center
@@ -330,7 +330,7 @@ test "sharpen struct type" {
 }
 
 test "convolve identity kernel" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Initialize with pattern
@@ -360,7 +360,7 @@ test "convolve identity kernel" {
 }
 
 test "convolve blur kernel" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Create sharp edge pattern
@@ -387,7 +387,7 @@ test "convolve blur kernel" {
 }
 
 test "convolve border modes" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Initialize center to 255, edges to 0
@@ -429,7 +429,7 @@ test "convolve border modes" {
 }
 
 test "convolveSeparable Gaussian approximation" {
-    var image: Image(f32) = try .initAlloc(std.testing.allocator, 7, 7);
+    var image: Image(f32) = try .init(std.testing.allocator, 7, 7);
     defer image.deinit(std.testing.allocator);
 
     // Create impulse in center
@@ -453,7 +453,7 @@ test "convolveSeparable Gaussian approximation" {
 }
 
 test "gaussianBlur basic" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 11, 11);
+    var image: Image(u8) = try .init(std.testing.allocator, 11, 11);
     defer image.deinit(std.testing.allocator);
 
     // Create a white square in center
@@ -481,7 +481,7 @@ test "gaussianBlur basic" {
 }
 
 test "gaussianBlur sigma variations" {
-    var image: Image(f32) = try .initAlloc(std.testing.allocator, 15, 15);
+    var image: Image(f32) = try .init(std.testing.allocator, 15, 15);
     defer image.deinit(std.testing.allocator);
 
     // Single bright pixel in center
@@ -508,7 +508,7 @@ test "gaussianBlur sigma variations" {
 }
 
 test "sobel with new convolution" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Create vertical edge
@@ -532,7 +532,7 @@ test "sobel with new convolution" {
 
 test "convolve3x3 optimization" {
     // This test verifies that 3x3 convolution uses the optimized path
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 10, 10);
+    var image: Image(u8) = try .init(std.testing.allocator, 10, 10);
     defer image.deinit(std.testing.allocator);
 
     // Fill with random-ish pattern
@@ -560,7 +560,7 @@ test "convolve3x3 optimization" {
 
 test "convolve preserves color channels" {
     // Test that RGB convolution processes each channel independently
-    var image: Image(Rgb) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(Rgb) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     // Create distinct patterns in each channel
@@ -599,7 +599,7 @@ test "convolve preserves color channels" {
 
 test "convolve into view (stride-safe)" {
     // Create a base image with a larger stride than the view width
-    var base_src: Image(u8) = try .initAlloc(std.testing.allocator, 6, 8);
+    var base_src: Image(u8) = try .init(std.testing.allocator, 6, 8);
     defer base_src.deinit(std.testing.allocator);
     for (0..base_src.rows) |r| {
         for (0..base_src.cols) |c| {
@@ -608,7 +608,7 @@ test "convolve into view (stride-safe)" {
     }
 
     // Create a destination base initialized to a sentinel value
-    var base_dst: Image(u8) = try .initAlloc(std.testing.allocator, 6, 8);
+    var base_dst: Image(u8) = try .init(std.testing.allocator, 6, 8);
     defer base_dst.deinit(std.testing.allocator);
     for (base_dst.data) |*p| p.* = 0xAA;
 
@@ -644,7 +644,7 @@ test "convolve into view (stride-safe)" {
 
 test "convolveSeparable into view (stride-safe)" {
     // Create a base image and a matching destination base
-    var base_src: Image(u8) = try .initAlloc(std.testing.allocator, 7, 9);
+    var base_src: Image(u8) = try .init(std.testing.allocator, 7, 9);
     defer base_src.deinit(std.testing.allocator);
     for (0..base_src.rows) |r| {
         for (0..base_src.cols) |c| {
@@ -652,7 +652,7 @@ test "convolveSeparable into view (stride-safe)" {
         }
     }
 
-    var base_dst: Image(u8) = try .initAlloc(std.testing.allocator, 7, 9);
+    var base_dst: Image(u8) = try .init(std.testing.allocator, 7, 9);
     defer base_dst.deinit(std.testing.allocator);
     for (base_dst.data) |*p| p.* = 0x55;
 
@@ -683,7 +683,7 @@ test "convolveSeparable into view (stride-safe)" {
 
 test "differenceOfGaussians basic functionality" {
     // Test basic DoG functionality with a simple edge pattern
-    var image: Image(f32) = try .initAlloc(std.testing.allocator, 11, 11);
+    var image: Image(f32) = try .init(std.testing.allocator, 11, 11);
     defer image.deinit(std.testing.allocator);
 
     // Create a white square in the center
@@ -723,7 +723,7 @@ test "differenceOfGaussians basic functionality" {
 
 test "differenceOfGaussians edge detection" {
     // Test DoG for edge detection with vertical edge
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 7, 7);
+    var image: Image(u8) = try .init(std.testing.allocator, 7, 7);
     defer image.deinit(std.testing.allocator);
 
     // Create a vertical edge
@@ -747,7 +747,7 @@ test "differenceOfGaussians edge detection" {
 }
 
 test "differenceOfGaussians invalid parameters" {
-    var image: Image(f32) = try .initAlloc(std.testing.allocator, 5, 5);
+    var image: Image(f32) = try .init(std.testing.allocator, 5, 5);
     defer image.deinit(std.testing.allocator);
 
     var result: Image(f32) = .empty;
@@ -761,7 +761,7 @@ test "differenceOfGaussians invalid parameters" {
 
 test "differenceOfGaussians with RGB" {
     // Test DoG with color images
-    var image: Image(Rgb) = try .initAlloc(std.testing.allocator, 9, 9);
+    var image: Image(Rgb) = try .init(std.testing.allocator, 9, 9);
     defer image.deinit(std.testing.allocator);
 
     // Create a colored square in the center
@@ -790,7 +790,7 @@ test "differenceOfGaussians with RGB" {
 
 test "differenceOfGaussians approximates manual subtraction" {
     // Test that DoG(sigma1, sigma2) ≈ blur(sigma1) - blur(sigma2)
-    var image: Image(f32) = try .initAlloc(std.testing.allocator, 15, 15);
+    var image: Image(f32) = try .init(std.testing.allocator, 15, 15);
     defer image.deinit(std.testing.allocator);
 
     // Create a test pattern
@@ -818,7 +818,7 @@ test "differenceOfGaussians approximates manual subtraction" {
     defer blur2.deinit(std.testing.allocator);
 
     // Manual subtraction
-    var manual_result: Image(f32) = try .initAlloc(std.testing.allocator, image.rows, image.cols);
+    var manual_result: Image(f32) = try .init(std.testing.allocator, image.rows, image.cols);
     defer manual_result.deinit(std.testing.allocator);
     for (0..image.rows) |r| {
         for (0..image.cols) |c| {
@@ -839,7 +839,7 @@ test "differenceOfGaussians approximates manual subtraction" {
 
 test "gaussianBlur preserves color" {
     // Test that Gaussian blur on RGB images maintains color information
-    var image: Image(Rgb) = try .initAlloc(std.testing.allocator, 7, 7);
+    var image: Image(Rgb) = try .init(std.testing.allocator, 7, 7);
     defer image.deinit(std.testing.allocator);
 
     // Create a red square in the center

--- a/src/image/tests/integral.zig
+++ b/src/image/tests/integral.zig
@@ -6,7 +6,7 @@ const Image = @import("../Image.zig").Image;
 const color = @import("../../color.zig");
 
 test "integral image scalar" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(u8) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     for (image.data) |*i| i.* = 1;
     var integral: Image(f32) = undefined;
@@ -24,7 +24,7 @@ test "integral image scalar" {
 }
 
 test "integral image view scalar" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(u8) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     for (image.data) |*i| i.* = 1;
     const view = image.view(.{ .l = 2, .t = 3, .r = 8, .b = 10 });
@@ -42,7 +42,7 @@ test "integral image view scalar" {
 }
 
 test "integral image struct" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     for (image.data) |*i| i.* = .{ .r = 1, .g = 1, .b = 1, .a = 1 };
     var integral: Image([4]f32) = undefined;
@@ -67,11 +67,11 @@ test "integral image RGB vs RGBA with full alpha produces same RGB values" {
     const test_size = 10;
 
     // Create RGB image
-    var rgb_img = try Image(Rgb).initAlloc(std.testing.allocator, test_size, test_size);
+    var rgb_img = try Image(Rgb).init(std.testing.allocator, test_size, test_size);
     defer rgb_img.deinit(std.testing.allocator);
 
     // Create RGBA image
-    var rgba_img = try Image(color.Rgba).initAlloc(std.testing.allocator, test_size, test_size);
+    var rgba_img = try Image(color.Rgba).init(std.testing.allocator, test_size, test_size);
     defer rgba_img.deinit(std.testing.allocator);
 
     // Fill both with identical RGB values

--- a/src/image/tests/interpolation.zig
+++ b/src/image/tests/interpolation.zig
@@ -10,7 +10,7 @@ const color = @import("../../color.zig");
 
 // Helper function to create a simple gradient test image
 fn createGradientImage(allocator: std.mem.Allocator, rows: usize, cols: usize) !Image(u8) {
-    var img = try Image(u8).initAlloc(allocator, rows, cols);
+    var img = try Image(u8).init(allocator, rows, cols);
     for (0..rows) |r| {
         for (0..cols) |c| {
             // Create a diagonal gradient from top-left (0) to bottom-right (255)
@@ -23,7 +23,7 @@ fn createGradientImage(allocator: std.mem.Allocator, rows: usize, cols: usize) !
 
 // Helper function to create a checkerboard pattern
 fn createCheckerboard(allocator: std.mem.Allocator, rows: usize, cols: usize) !Image(u8) {
-    var img = try Image(u8).initAlloc(allocator, rows, cols);
+    var img = try Image(u8).init(allocator, rows, cols);
     for (0..rows) |r| {
         for (0..cols) |c| {
             img.at(r, c).* = if ((r + c) % 2 == 0) 0 else 255;
@@ -83,7 +83,7 @@ test "bilinear interpolation - exact pixels" {
 
 test "bilinear interpolation - midpoints" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 3, 3);
+    var img = try Image(u8).init(allocator, 3, 3);
     defer img.deinit(allocator);
 
     // Create a simple 3x3 pattern
@@ -240,7 +240,7 @@ test "RGB image interpolation" {
     const allocator = std.testing.allocator;
     const Rgb = color.Rgb;
 
-    var img = try Image(Rgb).initAlloc(allocator, 4, 4);
+    var img = try Image(Rgb).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Create a color gradient
@@ -276,7 +276,7 @@ test "resize preserves value range" {
     const allocator = std.testing.allocator;
 
     // Create a simple gradient image
-    var src = try Image(u8).initAlloc(allocator, 4, 4);
+    var src = try Image(u8).init(allocator, 4, 4);
     defer src.deinit(allocator);
 
     // Fill with values from 0 to 240
@@ -286,7 +286,7 @@ test "resize preserves value range" {
         }
     }
 
-    var dst = try Image(u8).initAlloc(allocator, 8, 8);
+    var dst = try Image(u8).init(allocator, 8, 8);
     defer dst.deinit(allocator);
 
     // Test resize with bilinear interpolation
@@ -311,7 +311,7 @@ test "resize preserves value range" {
 
 test "catmull-rom no overshoot property" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 5, 5);
+    var img = try Image(u8).init(allocator, 5, 5);
     defer img.deinit(allocator);
 
     // Create an image with values between 50 and 200
@@ -337,7 +337,7 @@ test "catmull-rom no overshoot property" {
 
 test "float image interpolation" {
     const allocator = std.testing.allocator;
-    var img = try Image(f32).initAlloc(allocator, 4, 4);
+    var img = try Image(f32).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Create a float gradient
@@ -359,7 +359,7 @@ test "float image interpolation" {
 
 test "clamping stress test - sharp edge with bicubic" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 6, 6);
+    var img = try Image(u8).init(allocator, 6, 6);
     defer img.deinit(allocator);
 
     // Create a sharp edge that would cause overshoot
@@ -390,7 +390,7 @@ test "clamping stress test - sharp edge with bicubic" {
 
 test "clamping stress test - all kernel methods" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 8, 8);
+    var img = try Image(u8).init(allocator, 8, 8);
     defer img.deinit(allocator);
 
     // Create extreme contrast pattern
@@ -426,7 +426,7 @@ test "clamping stress test - all kernel methods" {
 
 test "bilinear exact linear interpolation" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 2, 2);
+    var img = try Image(u8).init(allocator, 2, 2);
     defer img.deinit(allocator);
 
     // Create a simple 2x2 grid
@@ -455,7 +455,7 @@ test "bilinear exact linear interpolation" {
 
 test "nearest neighbor discontinuity" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 2, 2);
+    var img = try Image(u8).init(allocator, 2, 2);
     defer img.deinit(allocator);
 
     img.at(0, 0).* = 0;
@@ -476,7 +476,7 @@ test "nearest neighbor discontinuity" {
 
 test "interpolation symmetry" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 5, 5);
+    var img = try Image(u8).init(allocator, 5, 5);
     defer img.deinit(allocator);
 
     // Create symmetric pattern
@@ -499,7 +499,7 @@ test "interpolation symmetry" {
 
 test "mitchell parameter effects" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 6, 6);
+    var img = try Image(u8).init(allocator, 6, 6);
     defer img.deinit(allocator);
 
     // Create a pattern with both smooth and sharp features
@@ -535,7 +535,7 @@ test "mitchell parameter effects" {
 
 test "lanczos weight normalization" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 8, 8);
+    var img = try Image(u8).init(allocator, 8, 8);
     defer img.deinit(allocator);
 
     // Fill with constant value
@@ -554,7 +554,7 @@ test "lanczos weight normalization" {
 
 test "extreme value edge cases" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 4, 4);
+    var img = try Image(u8).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Fill with extreme values
@@ -591,7 +591,7 @@ test "extreme value edge cases" {
 
 test "single pixel image handling" {
     const allocator = std.testing.allocator;
-    var img = try Image(u8).initAlloc(allocator, 1, 1);
+    var img = try Image(u8).init(allocator, 1, 1);
     defer img.deinit(allocator);
 
     img.at(0, 0).* = 42;
@@ -611,7 +611,7 @@ test "single pixel image handling" {
 test "RGB clamping stress test" {
     const allocator = std.testing.allocator;
     const Rgb = color.Rgb;
-    var img = try Image(Rgb).initAlloc(allocator, 4, 4);
+    var img = try Image(Rgb).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Create extreme RGB values

--- a/src/image/tests/psnr.zig
+++ b/src/image/tests/psnr.zig
@@ -12,13 +12,13 @@ const Image = @import("../Image.zig").Image;
 
 test "PSNR identical images returns inf" {
     // Test with u8 scalar type
-    var img1 = try Image(u8).initAlloc(std.testing.allocator, 10, 10);
+    var img1 = try Image(u8).init(std.testing.allocator, 10, 10);
     defer img1.deinit(std.testing.allocator);
     for (img1.data) |*pixel| {
         pixel.* = 128;
     }
 
-    var img2 = try Image(u8).initAlloc(std.testing.allocator, 10, 10);
+    var img2 = try Image(u8).init(std.testing.allocator, 10, 10);
     defer img2.deinit(std.testing.allocator);
     for (img2.data) |*pixel| {
         pixel.* = 128;
@@ -29,24 +29,24 @@ test "PSNR identical images returns inf" {
 }
 
 test "PSNR dimension mismatch error" {
-    var img1 = try Image(u8).initAlloc(std.testing.allocator, 10, 10);
+    var img1 = try Image(u8).init(std.testing.allocator, 10, 10);
     defer img1.deinit(std.testing.allocator);
 
-    var img2 = try Image(u8).initAlloc(std.testing.allocator, 10, 20);
+    var img2 = try Image(u8).init(std.testing.allocator, 10, 20);
     defer img2.deinit(std.testing.allocator);
 
     try expectError(error.DimensionMismatch, img1.psnr(img2));
 }
 
 test "PSNR with known values for u8" {
-    var img1 = try Image(u8).initAlloc(std.testing.allocator, 2, 2);
+    var img1 = try Image(u8).init(std.testing.allocator, 2, 2);
     defer img1.deinit(std.testing.allocator);
     img1.at(0, 0).* = 100;
     img1.at(0, 1).* = 150;
     img1.at(1, 0).* = 200;
     img1.at(1, 1).* = 250;
 
-    var img2 = try Image(u8).initAlloc(std.testing.allocator, 2, 2);
+    var img2 = try Image(u8).init(std.testing.allocator, 2, 2);
     defer img2.deinit(std.testing.allocator);
     img2.at(0, 0).* = 110; // diff = 10
     img2.at(0, 1).* = 140; // diff = -10
@@ -60,11 +60,11 @@ test "PSNR with known values for u8" {
 }
 
 test "PSNR with RGB struct type" {
-    var img1 = try Image(Rgb).initAlloc(std.testing.allocator, 2, 2);
+    var img1 = try Image(Rgb).init(std.testing.allocator, 2, 2);
     defer img1.deinit(std.testing.allocator);
     img1.fill(Rgb{ .r = 100, .g = 150, .b = 200 });
 
-    var img2 = try Image(Rgb).initAlloc(std.testing.allocator, 2, 2);
+    var img2 = try Image(Rgb).init(std.testing.allocator, 2, 2);
     defer img2.deinit(std.testing.allocator);
     img2.fill(Rgb{ .r = 110, .g = 140, .b = 205 });
 
@@ -77,12 +77,12 @@ test "PSNR with RGB struct type" {
 }
 
 test "PSNR with RGBA struct type" {
-    var img1 = try Image(Rgba).initAlloc(std.testing.allocator, 1, 2);
+    var img1 = try Image(Rgba).init(std.testing.allocator, 1, 2);
     defer img1.deinit(std.testing.allocator);
     img1.at(0, 0).* = Rgba{ .r = 255, .g = 0, .b = 0, .a = 255 };
     img1.at(0, 1).* = Rgba{ .r = 0, .g = 255, .b = 0, .a = 255 };
 
-    var img2 = try Image(Rgba).initAlloc(std.testing.allocator, 1, 2);
+    var img2 = try Image(Rgba).init(std.testing.allocator, 1, 2);
     defer img2.deinit(std.testing.allocator);
     img2.at(0, 0).* = Rgba{ .r = 250, .g = 5, .b = 0, .a = 255 }; // diffs: 5, 5, 0, 0
     img2.at(0, 1).* = Rgba{ .r = 0, .g = 250, .b = 5, .a = 255 }; // diffs: 0, 5, 5, 0
@@ -94,14 +94,14 @@ test "PSNR with RGBA struct type" {
 }
 
 test "PSNR with f32 scalar type" {
-    var img1 = try Image(f32).initAlloc(std.testing.allocator, 2, 2);
+    var img1 = try Image(f32).init(std.testing.allocator, 2, 2);
     defer img1.deinit(std.testing.allocator);
     img1.at(0, 0).* = 0.5;
     img1.at(0, 1).* = 0.7;
     img1.at(1, 0).* = 0.3;
     img1.at(1, 1).* = 0.9;
 
-    var img2 = try Image(f32).initAlloc(std.testing.allocator, 2, 2);
+    var img2 = try Image(f32).init(std.testing.allocator, 2, 2);
     defer img2.deinit(std.testing.allocator);
     img2.at(0, 0).* = 0.4; // diff = 0.1
     img2.at(0, 1).* = 0.8; // diff = -0.1
@@ -115,12 +115,12 @@ test "PSNR with f32 scalar type" {
 }
 
 test "PSNR with array type [3]u8" {
-    var img1 = try Image([3]u8).initAlloc(std.testing.allocator, 1, 2);
+    var img1 = try Image([3]u8).init(std.testing.allocator, 1, 2);
     defer img1.deinit(std.testing.allocator);
     img1.at(0, 0).* = .{ 100, 150, 200 };
     img1.at(0, 1).* = .{ 50, 100, 150 };
 
-    var img2 = try Image([3]u8).initAlloc(std.testing.allocator, 1, 2);
+    var img2 = try Image([3]u8).init(std.testing.allocator, 1, 2);
     defer img2.deinit(std.testing.allocator);
     img2.at(0, 0).* = .{ 105, 145, 195 }; // diffs: 5, -5, -5
     img2.at(0, 1).* = .{ 45, 105, 155 }; // diffs: -5, 5, 5
@@ -132,13 +132,13 @@ test "PSNR with array type [3]u8" {
 }
 
 test "PSNR extreme case: black vs white" {
-    var img1 = try Image(u8).initAlloc(std.testing.allocator, 10, 10);
+    var img1 = try Image(u8).init(std.testing.allocator, 10, 10);
     defer img1.deinit(std.testing.allocator);
     for (img1.data) |*pixel| {
         pixel.* = 0; // All black
     }
 
-    var img2 = try Image(u8).initAlloc(std.testing.allocator, 10, 10);
+    var img2 = try Image(u8).init(std.testing.allocator, 10, 10);
     defer img2.deinit(std.testing.allocator);
     for (img2.data) |*pixel| {
         pixel.* = 255; // All white
@@ -151,13 +151,13 @@ test "PSNR extreme case: black vs white" {
 }
 
 test "PSNR with slight noise" {
-    var img1 = try Image(u8).initAlloc(std.testing.allocator, 100, 100);
+    var img1 = try Image(u8).init(std.testing.allocator, 100, 100);
     defer img1.deinit(std.testing.allocator);
     for (img1.data) |*pixel| {
         pixel.* = 128;
     }
 
-    var img2 = try Image(u8).initAlloc(std.testing.allocator, 100, 100);
+    var img2 = try Image(u8).init(std.testing.allocator, 100, 100);
     defer img2.deinit(std.testing.allocator);
     for (img2.data) |*pixel| {
         pixel.* = 128;

--- a/src/image/tests/resize.zig
+++ b/src/image/tests/resize.zig
@@ -13,7 +13,7 @@ test "letterbox maintains aspect ratio with padding" {
     // Test 1: Wide image to square - should add vertical padding
     {
         // Create 8x4 image (2:1 aspect ratio)
-        var src: Image(u8) = try .initAlloc(allocator, 4, 8);
+        var src: Image(u8) = try .init(allocator, 4, 8);
         defer src.deinit(allocator);
 
         // Fill with gradient to verify content preservation
@@ -24,7 +24,7 @@ test "letterbox maintains aspect ratio with padding" {
         }
 
         // Letterbox to 6x6 square
-        var output: Image(u8) = try .initAlloc(allocator, 6, 6);
+        var output: Image(u8) = try .init(allocator, 6, 6);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .bilinear);
@@ -50,7 +50,7 @@ test "letterbox maintains aspect ratio with padding" {
     // Test 2: Tall image to wide - should add horizontal padding
     {
         // Create 3x9 image (1:3 aspect ratio)
-        var src: Image(color.Rgb) = try .initAlloc(allocator, 9, 3);
+        var src: Image(color.Rgb) = try .init(allocator, 9, 3);
         defer src.deinit(allocator);
 
         // Fill with distinct colors
@@ -66,7 +66,7 @@ test "letterbox maintains aspect ratio with padding" {
         }
 
         // Letterbox to 12x4 (3:1 aspect ratio)
-        var output: Image(color.Rgb) = try .initAlloc(allocator, 4, 12);
+        var output: Image(color.Rgb) = try .init(allocator, 4, 12);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .nearest_neighbor);
@@ -96,19 +96,19 @@ test "letterbox edge cases" {
 
     // Test zero dimension handling
     {
-        var src: Image(u8) = try .initAlloc(allocator, 5, 5);
+        var src: Image(u8) = try .init(allocator, 5, 5);
         defer src.deinit(allocator);
 
-        var output: Image(u8) = .init(0, 10, &[_]u8{});
+        var output: Image(u8) = .initFromSlice(0, 10, &[_]u8{});
         try expectError(error.InvalidDimensions, src.letterbox(allocator, &output, .nearest_neighbor));
 
-        var output2: Image(u8) = .init(10, 0, &[_]u8{});
+        var output2: Image(u8) = .initFromSlice(10, 0, &[_]u8{});
         try expectError(error.InvalidDimensions, src.letterbox(allocator, &output2, .nearest_neighbor));
     }
 
     // Test same aspect ratio - no padding needed
     {
-        var src: Image(f32) = try .initAlloc(allocator, 4, 6);
+        var src: Image(f32) = try .init(allocator, 4, 6);
         defer src.deinit(allocator);
 
         // Fill with test values
@@ -119,7 +119,7 @@ test "letterbox edge cases" {
         }
 
         // Scale to 8x12 (same 3:2 aspect ratio)
-        var output: Image(f32) = try .initAlloc(allocator, 8, 12);
+        var output: Image(f32) = try .init(allocator, 8, 12);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .bicubic);
@@ -133,11 +133,11 @@ test "letterbox edge cases" {
 
     // Test 1x1 source image
     {
-        var src: Image(u8) = try .initAlloc(allocator, 1, 1);
+        var src: Image(u8) = try .init(allocator, 1, 1);
         defer src.deinit(allocator);
         src.at(0, 0).* = 128;
 
-        var output: Image(u8) = try .initAlloc(allocator, 10, 10);
+        var output: Image(u8) = try .init(allocator, 10, 10);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .nearest_neighbor);
@@ -159,7 +159,7 @@ test "letterbox interpolation methods comparison" {
     const allocator = std.testing.allocator;
 
     // Create a gradient pattern to ensure interpolation produces intermediate values
-    var src: Image(u8) = try .initAlloc(allocator, 3, 3);
+    var src: Image(u8) = try .init(allocator, 3, 3);
     defer src.deinit(allocator);
 
     // Create gradient from 0 to 255
@@ -182,7 +182,7 @@ test "letterbox interpolation methods comparison" {
     };
 
     for (methods) |method| {
-        var output: Image(u8) = try .initAlloc(allocator, 10, 10);
+        var output: Image(u8) = try .init(allocator, 10, 10);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, method);
@@ -198,14 +198,14 @@ test "letterbox extreme aspect ratios" {
 
     // Test very wide image (16:1)
     {
-        var src: Image(u8) = try .initAlloc(allocator, 2, 32);
+        var src: Image(u8) = try .init(allocator, 2, 32);
         defer src.deinit(allocator);
         for (0..src.data.len) |i| {
             src.data[i] = 200;
         }
 
         // Letterbox to square
-        var output: Image(u8) = try .initAlloc(allocator, 64, 64);
+        var output: Image(u8) = try .init(allocator, 64, 64);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .bilinear);
@@ -224,14 +224,14 @@ test "letterbox extreme aspect ratios" {
 
     // Test very tall image (1:16)
     {
-        var src: Image(u8) = try .initAlloc(allocator, 32, 2);
+        var src: Image(u8) = try .init(allocator, 32, 2);
         defer src.deinit(allocator);
         for (0..src.data.len) |i| {
             src.data[i] = 100;
         }
 
         // Letterbox to square
-        var output: Image(u8) = try .initAlloc(allocator, 64, 64);
+        var output: Image(u8) = try .init(allocator, 64, 64);
         defer output.deinit(allocator);
 
         const rect = try src.letterbox(allocator, &output, .bicubic);
@@ -253,7 +253,7 @@ test "scale image" {
     const allocator = std.testing.allocator;
 
     // Create a test image
-    var img = try Image(u8).initAlloc(allocator, 100, 100);
+    var img = try Image(u8).init(allocator, 100, 100);
     defer img.deinit(allocator);
 
     // Fill with some pattern
@@ -286,7 +286,7 @@ test "scale image" {
     try expectError(error.InvalidScaleFactor, img.scale(allocator, -1, .bilinear));
 
     // Test very small scale that would result in 0 dimensions
-    var tiny_img = try Image(u8).initAlloc(allocator, 2, 2);
+    var tiny_img = try Image(u8).init(allocator, 2, 2);
     defer tiny_img.deinit(allocator);
     try expectError(error.InvalidDimensions, tiny_img.scale(allocator, 0.1, .bilinear));
 }

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -8,7 +8,7 @@ const color = @import("../../color.zig");
 const Rectangle = @import("../../geometry.zig").Rectangle;
 
 test "getRectangle" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     const rect = image.getRectangle();
     try expectEqual(rect.width(), image.cols);
@@ -16,7 +16,7 @@ test "getRectangle" {
 }
 
 test "copy function with views" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 5, 7);
+    var image: Image(u8) = try .init(std.testing.allocator, 5, 7);
     defer image.deinit(std.testing.allocator);
 
     // Fill with pattern
@@ -30,7 +30,7 @@ test "copy function with views" {
     const view = image.view(.{ .l = 1, .t = 1, .r = 4, .b = 3 });
 
     // Copy view to new image
-    var copied: Image(u8) = try .initAlloc(std.testing.allocator, view.rows, view.cols);
+    var copied: Image(u8) = try .init(std.testing.allocator, view.rows, view.cols);
     defer copied.deinit(std.testing.allocator);
 
     view.copy(copied);
@@ -43,7 +43,7 @@ test "copy function with views" {
     }
 
     // Test copy from regular image to view
-    var target: Image(u8) = try .initAlloc(std.testing.allocator, 6, 8);
+    var target: Image(u8) = try .init(std.testing.allocator, 6, 8);
     defer target.deinit(std.testing.allocator);
 
     // Fill target with different pattern
@@ -72,7 +72,7 @@ test "copy function with views" {
 }
 
 test "copy function in-place behavior" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 3);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 3);
     defer image.deinit(std.testing.allocator);
 
     // Fill with pattern
@@ -101,7 +101,7 @@ test "copy function in-place behavior" {
     }
 }
 test "view" {
-    var image: Image(color.Rgba) = try .initAlloc(std.testing.allocator, 21, 13);
+    var image: Image(color.Rgba) = try .init(std.testing.allocator, 21, 13);
     defer image.deinit(std.testing.allocator);
     const rect: Rectangle(usize) = .{ .l = 0, .t = 0, .r = 8, .b = 10 };
     const view = image.view(rect);
@@ -113,7 +113,7 @@ test "view" {
 }
 
 test "view with getRectangle returns full image" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 100, 200);
+    var image: Image(u8) = try .init(std.testing.allocator, 100, 200);
     defer image.deinit(std.testing.allocator);
 
     // Fill image with test pattern
@@ -154,7 +154,7 @@ test "view with getRectangle returns full image" {
 }
 
 test "rotateBounds" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 100, 200);
+    var image: Image(u8) = try .init(std.testing.allocator, 100, 200);
     defer image.deinit(std.testing.allocator);
 
     // Test 0 degrees - should be same size
@@ -184,7 +184,7 @@ test "rotateBounds" {
 }
 
 test "rotate orthogonal fast paths" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 3, 4);
+    var image: Image(u8) = try .init(std.testing.allocator, 3, 4);
     defer image.deinit(std.testing.allocator);
 
     // Create a pattern to verify correct rotation
@@ -239,7 +239,7 @@ test "rotate orthogonal fast paths" {
 }
 
 test "rotate arbitrary angle" {
-    var image: Image(u8) = try .initAlloc(std.testing.allocator, 10, 10);
+    var image: Image(u8) = try .init(std.testing.allocator, 10, 10);
     defer image.deinit(std.testing.allocator);
 
     // Fill with pattern
@@ -261,7 +261,7 @@ test "rotate arbitrary angle" {
 
 test "extract rotated rectangle basic and 90deg" {
     const allocator = std.testing.allocator;
-    var image: Image(u8) = try .initAlloc(allocator, 5, 5);
+    var image: Image(u8) = try .init(allocator, 5, 5);
     defer image.deinit(allocator);
 
     // Fill with simple row*10 + col pattern
@@ -275,7 +275,7 @@ test "extract rotated rectangle basic and 90deg" {
     const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 3, .b = 3 };
 
     // Output 3x3 buffer
-    var out0: Image(u8) = try .initAlloc(allocator, 3, 3);
+    var out0: Image(u8) = try .init(allocator, 3, 3);
     defer out0.deinit(allocator);
 
     // Angle 0: should match the submatrix directly
@@ -292,7 +292,7 @@ test "extract rotated rectangle basic and 90deg" {
     try expectEqual(@as(u8, 33), out0.at(2, 2).*);
 
     // Angle 90 degrees CCW: should be rotated version of the submatrix
-    var out90: Image(u8) = try .initAlloc(allocator, 3, 3);
+    var out90: Image(u8) = try .init(allocator, 3, 3);
     defer out90.deinit(allocator);
 
     image.extract(rect, std.math.pi / 2.0, out90, .nearest_neighbor);
@@ -310,7 +310,7 @@ test "extract rotated rectangle basic and 90deg" {
 
 test "extract single-pixel axis handling centers correctly" {
     const allocator = std.testing.allocator;
-    var image: Image(u8) = try .initAlloc(allocator, 5, 5);
+    var image: Image(u8) = try .init(allocator, 5, 5);
     defer image.deinit(allocator);
 
     // Fill pattern row*10 + col
@@ -323,13 +323,13 @@ test "extract single-pixel axis handling centers correctly" {
     const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 3, .b = 3 }; // 3x3
 
     // 1x1 output should sample rectangle center -> source (2,2) => 22
-    var out1: Image(u8) = try .initAlloc(allocator, 1, 1);
+    var out1: Image(u8) = try .init(allocator, 1, 1);
     defer out1.deinit(allocator);
     image.extract(rect, 0.0, out1, .nearest_neighbor);
     try expectEqual(@as(u8, 22), out1.at(0, 0).*);
 
     // 1x3: rows==1 should sample center row (y=2), cols span left-to-right
-    var out_row1: Image(u8) = try .initAlloc(allocator, 1, 3);
+    var out_row1: Image(u8) = try .init(allocator, 1, 3);
     defer out_row1.deinit(allocator);
     image.extract(rect, 0.0, out_row1, .nearest_neighbor);
     try expectEqual(@as(u8, 21), out_row1.at(0, 0).*);
@@ -337,7 +337,7 @@ test "extract single-pixel axis handling centers correctly" {
     try expectEqual(@as(u8, 23), out_row1.at(0, 2).*);
 
     // 3x1: cols==1 should sample center col (x=2), rows span top-to-bottom
-    var out_col1: Image(u8) = try .initAlloc(allocator, 3, 1);
+    var out_col1: Image(u8) = try .init(allocator, 3, 1);
     defer out_col1.deinit(allocator);
     image.extract(rect, 0.0, out_col1, .nearest_neighbor);
     try expectEqual(@as(u8, 12), out_col1.at(0, 0).*);
@@ -349,7 +349,7 @@ test "insert and extract inverse relationship" {
     const allocator = std.testing.allocator;
 
     // Create source with gradient pattern
-    var source = try Image(u8).initAlloc(allocator, 64, 64);
+    var source = try Image(u8).init(allocator, 64, 64);
     defer source.deinit(allocator);
     for (0..source.rows) |r| {
         for (0..source.cols) |c| {
@@ -371,12 +371,12 @@ test "insert and extract inverse relationship" {
 
     for (cases) |tc| {
         // Extract region
-        var extracted = try Image(u8).initAlloc(allocator, tc.size, tc.size);
+        var extracted = try Image(u8).init(allocator, tc.size, tc.size);
         defer extracted.deinit(allocator);
         source.extract(tc.rect, tc.angle, extracted, tc.method);
 
         // Insert back into blank canvas
-        var canvas = try Image(u8).initAlloc(allocator, 64, 64);
+        var canvas = try Image(u8).init(allocator, 64, 64);
         defer canvas.deinit(allocator);
         @memset(canvas.data, 0);
         canvas.insert(extracted, tc.rect, tc.angle, tc.method);

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -1818,7 +1818,7 @@ pub fn load(comptime T: type, allocator: Allocator, file_path: []const u8) !Imag
     defer decoder.deinit();
 
     // Create output image
-    var img = try Image(T).initAlloc(allocator, decoder.height, decoder.width);
+    var img = try Image(T).init(allocator, decoder.height, decoder.width);
     errdefer img.deinit(allocator);
 
     // Complete block-based pipeline:

--- a/src/kitty.zig
+++ b/src/kitty.zig
@@ -220,7 +220,7 @@ test "imageToKitty basic functionality" {
     const allocator = testing.allocator;
 
     // Create a small test image
-    var img = try Image(Rgb).initAlloc(allocator, 2, 2);
+    var img = try Image(Rgb).init(allocator, 2, 2);
     defer img.deinit(allocator);
 
     // Fill with test colors
@@ -251,7 +251,7 @@ test "imageToKitty with options" {
     const allocator = testing.allocator;
 
     // Create a small test image
-    var img = try Image(u8).initAlloc(allocator, 1, 1);
+    var img = try Image(u8).init(allocator, 1, 1);
     defer img.deinit(allocator);
     img.at(0, 0).* = 128;
 

--- a/src/pca.zig
+++ b/src/pca.zig
@@ -380,7 +380,7 @@ pub fn imageToColorPoints(comptime ColorType: type, allocator: Allocator, image:
 pub fn colorPointsToImage(comptime ColorType: type, allocator: Allocator, points: []const @Vector(std.meta.fields(ColorType).len, f64), rows: usize, cols: usize) !Image(ColorType) {
     assert(points.len == rows * cols);
 
-    var image = try Image(ColorType).initAlloc(allocator, rows, cols);
+    var image = try Image(ColorType).init(allocator, rows, cols);
 
     for (points, 0..) |point, i| {
         image.data[i] = pointToColor(ColorType, point);
@@ -406,7 +406,7 @@ pub fn imageToIntensityPoints(allocator: Allocator, image: Image(u8)) ![]@Vector
 pub fn intensityPointsToImage(allocator: Allocator, points: []const @Vector(1, f64), rows: usize, cols: usize) !Image(u8) {
     assert(points.len == rows * cols);
 
-    var image = try Image(u8).initAlloc(allocator, rows, cols);
+    var image = try Image(u8).init(allocator, rows, cols);
 
     for (points, 0..) |point, i| {
         const intensity = std.math.clamp(point[0] * 255.0, 0, 255);
@@ -494,7 +494,7 @@ test "Generic image to color points conversion" {
     const allocator = std.testing.allocator;
 
     // Create a simple 2x2 RGB image
-    var image = try Image(Rgb).initAlloc(allocator, 2, 2);
+    var image = try Image(Rgb).init(allocator, 2, 2);
     defer image.deinit(allocator);
 
     image.data[0] = Rgb{ .r = 255, .g = 0, .b = 0 }; // Red
@@ -530,7 +530,7 @@ test "PCA on image color data" {
     const allocator = std.testing.allocator;
 
     // Create a simple gradient image
-    var image = try Image(Rgb).initAlloc(allocator, 2, 2);
+    var image = try Image(Rgb).init(allocator, 2, 2);
     defer image.deinit(allocator);
 
     image.data[0] = Rgb{ .r = 0, .g = 0, .b = 0 }; // Black

--- a/src/png.zig
+++ b/src/png.zig
@@ -501,7 +501,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .rgba = Image(Rgba).init(height, width, output_data) };
+                return .{ .rgba = .initFromSlice(height, width, output_data) };
             } else {
                 // Create grayscale image when no transparency
                 const total_pixels = @as(u64, width) * @as(u64, height);
@@ -522,7 +522,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .grayscale = Image(u8).init(height, width, output_data) };
+                return .{ .grayscale = .initFromSlice(height, width, output_data) };
             }
         },
         .rgb => {
@@ -546,7 +546,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .rgba = Image(Rgba).init(height, width, output_data) };
+                return .{ .rgba = .initFromSlice(height, width, output_data) };
             } else {
                 // Create RGB image when no transparency
                 const total_pixels = @as(u64, width) * @as(u64, height);
@@ -567,7 +567,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .rgb = Image(Rgb).init(height, width, output_data) };
+                return .{ .rgb = .initFromSlice(height, width, output_data) };
             }
         },
         .rgba => {
@@ -604,7 +604,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                 }
             }
 
-            return .{ .rgba = Image(Rgba).init(height, width, output_data) };
+            return .{ .rgba = .initFromSlice(height, width, output_data) };
         },
         .palette => {
             // Convert palette to RGB or RGBA (if transparency present)
@@ -657,7 +657,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .rgba = Image(Rgba).init(height, width, output_data) };
+                return .{ .rgba = .initFromSlice(height, width, output_data) };
             } else {
                 // No transparency - convert to RGB
                 var output_data = try allocator.alloc(Rgb, @intCast(total_pixels));
@@ -693,7 +693,7 @@ pub fn toNativeImage(allocator: Allocator, png_image: PngImage) !union(enum) {
                     }
                 }
 
-                return .{ .rgb = Image(Rgb).init(height, width, output_data) };
+                return .{ .rgb = .initFromSlice(height, width, output_data) };
             }
         },
     }
@@ -946,7 +946,7 @@ pub fn encodeImage(comptime T: type, allocator: Allocator, image: Image(T), opti
         },
         else => {
             // Convert unsupported type to RGB
-            var rgb_image = try Image(Rgb).initAlloc(allocator, image.rows, image.cols);
+            var rgb_image = try Image(Rgb).init(allocator, image.rows, image.cols);
             defer rgb_image.deinit(allocator);
 
             // Convert each pixel to RGB
@@ -1683,7 +1683,7 @@ test "PNG round-trip encoding/decoding" {
     defer allocator.free(owned_data);
     @memcpy(owned_data, &test_data);
 
-    const original_image = Image(Rgb).init(height, width, owned_data);
+    const original_image: Image(Rgb) = .initFromSlice(height, width, owned_data);
 
     // Encode to PNG
     const png_data = try encodeImage(Rgb, allocator, original_image, .default);
@@ -1827,7 +1827,7 @@ test "PNG encode with color management chunks" {
         Rgb{ .r = 255, .g = 0, .b = 0 }, Rgb{ .r = 0, .g = 255, .b = 0 },
         Rgb{ .r = 0, .g = 0, .b = 255 }, Rgb{ .r = 255, .g = 255, .b = 0 },
     };
-    const test_image = Image(Rgb).init(2, 2, &test_data);
+    const test_image: Image(Rgb) = .initFromSlice(2, 2, &test_data);
 
     // Test encoding with sRGB chunk
     const srgb_options: EncodeOptions = .{ .srgb_intent = .perceptual };

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -169,7 +169,7 @@ pub fn fromImage(
             working_img = try image.convert(Rgb, gpa);
         } else {
             // Scaling needed - use interpolation
-            working_img = try Image(Rgb).initAlloc(gpa, height, width);
+            working_img = try Image(Rgb).init(gpa, height, width);
 
             // Copy scaled image data to working image
             for (0..height) |row| {
@@ -857,7 +857,7 @@ test "basic sixel encoding - 2x2 image" {
     const allocator = std.testing.allocator;
 
     // Create a 2x2 test image with distinct colors
-    var img = try Image(Rgb).initAlloc(allocator, 2, 2);
+    var img = try Image(Rgb).init(allocator, 2, 2);
     defer img.deinit(allocator);
 
     img.at(0, 0).* = .{ .r = 255, .g = 0, .b = 0 }; // Red
@@ -887,7 +887,7 @@ test "basic sixel encoding - verify palette format" {
     const allocator = std.testing.allocator;
 
     // Create a 4x4 test image
-    var img = try Image(Rgb).initAlloc(allocator, 4, 4);
+    var img = try Image(Rgb).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     // Fill with a single color to ensure it appears in palette
@@ -913,7 +913,7 @@ test "palette mode - fixed 6x7x6 color mapping" {
     const allocator = std.testing.allocator;
 
     // Create image with colors that map to specific palette indices
-    var img = try Image(Rgb).initAlloc(allocator, 1, 3);
+    var img = try Image(Rgb).init(allocator, 1, 3);
     defer img.deinit(allocator);
 
     // Colors chosen to map to specific 6x7x6 palette entries
@@ -938,7 +938,7 @@ test "palette mode - adaptive with color reduction" {
     const allocator = std.testing.allocator;
 
     // Create image with 8 distinct colors
-    var img = try Image(Rgb).initAlloc(allocator, 4, 4);
+    var img = try Image(Rgb).init(allocator, 4, 4);
     defer img.deinit(allocator);
 
     const colors = [_]Rgb{
@@ -981,7 +981,7 @@ test "palette mode - adaptive with color reduction" {
 test "edge case - single pixel image" {
     const allocator = std.testing.allocator;
 
-    var img = try Image(Rgb).initAlloc(allocator, 1, 1);
+    var img = try Image(Rgb).init(allocator, 1, 1);
     defer img.deinit(allocator);
 
     img.at(0, 0).* = .{ .r = 128, .g = 128, .b = 128 };
@@ -1003,7 +1003,7 @@ test "edge case - single pixel image" {
 test "edge case - uniform color image" {
     const allocator = std.testing.allocator;
 
-    var img = try Image(Rgb).initAlloc(allocator, 8, 8);
+    var img = try Image(Rgb).init(allocator, 8, 8);
     defer img.deinit(allocator);
 
     // Fill entire image with same color


### PR DESCRIPTION
Renames `Image.init` to `Image.initFromSlice` for views and `Image.initAlloc` to `Image.init` for owned, allocated images. This clarifies memory ownership.

BREAKING CHANGE: `Image.init` and `Image.initAlloc` were renamed. Use `Image.initFromSlice` for views and `Image.init` for owned images.