### PR TITLE
refactor(python): streamline color bindings and validation

### DIFF
--- a/bindings/python/src/color_factory.zig
+++ b/bindings/python/src/color_factory.zig
@@ -46,23 +46,17 @@ pub fn ColorBinding(comptime ZigColorType: type) type {
         1 => extern struct {
             ob_base: c.PyObject,
             field0: fields[0].type,
-
-            pub const field_names = [_][]const u8{fields[0].name};
         },
         2 => extern struct {
             ob_base: c.PyObject,
             field0: fields[0].type,
             field1: fields[1].type,
-
-            pub const field_names = [_][]const u8{ fields[0].name, fields[1].name };
         },
         3 => extern struct {
             ob_base: c.PyObject,
             field0: fields[0].type,
             field1: fields[1].type,
             field2: fields[2].type,
-
-            pub const field_names = [_][]const u8{ fields[0].name, fields[1].name, fields[2].name };
         },
         4 => extern struct {
             ob_base: c.PyObject,
@@ -70,8 +64,6 @@ pub fn ColorBinding(comptime ZigColorType: type) type {
             field1: fields[1].type,
             field2: fields[2].type,
             field3: fields[3].type,
-
-            pub const field_names = [_][]const u8{ fields[0].name, fields[1].name, fields[2].name, fields[3].name };
         },
         else => @compileError("Color types with more than 4 fields not supported yet"),
     };

--- a/bindings/python/src/color_registry.zig
+++ b/bindings/python/src/color_registry.zig
@@ -22,14 +22,6 @@ pub const color_types = .{
     zignal.Ycbcr,
 };
 
-/// Check if a type is a supported color type
-pub fn isSupportedColor(comptime T: type) bool {
-    inline for (color_types) |ColorType| {
-        if (T == ColorType) return true;
-    }
-    return false;
-}
-
 /// Generic color component validation using type introspection
 /// This function determines validation rules based on the actual field types and semantics
 pub fn validateColorComponent(comptime ColorType: type, field_name: []const u8, value: anytype) bool {
@@ -60,12 +52,12 @@ pub fn validateColorComponent(comptime ColorType: type, field_name: []const u8, 
             return false;
         },
 
-        // Lab: L: 0-100, a/b: -200 to 200
+        // Lab: L: 0-100, a/b: -128 to 127
         zignal.Lab => {
             if (std.mem.eql(u8, field_name, "l")) {
                 return value >= 0.0 and value <= 100.0;
             } else if (std.mem.eql(u8, field_name, "a") or std.mem.eql(u8, field_name, "b")) {
-                return value >= -200.0 and value <= 200.0;
+                return value >= -128.0 and value <= 127.0;
             }
             return false;
         },
@@ -159,13 +151,13 @@ pub fn getValidationErrorMessage(comptime ColorType: type) []const u8 {
         zignal.Rgb, zignal.Rgba => "RGB values must be in range 0-255",
         zignal.Hsv => "HSV values must be in valid ranges (h: 0-360, s: 0-100, v: 0-100)",
         zignal.Hsl => "HSL values must be in valid ranges (h: 0-360, s: 0-100, l: 0-100)",
-        zignal.Lab => "Lab values must be in valid ranges (L: 0-100, a/b: typically -128 to 127)",
-        zignal.Xyz => "XYZ values must be non-negative",
-        zignal.Oklab => "Oklab values must be in valid ranges (l: 0-1, a/b: typically -0.5 to 0.5)",
+        zignal.Lab => "Lab values must be in valid ranges (L: 0-100, a/b: -128 to 127)",
+        zignal.Xyz => "XYZ values must be in range 0-150",
+        zignal.Oklab => "Oklab values must be in valid ranges (l: 0-1, a/b: -0.5 to 0.5)",
         zignal.Oklch => "Oklch values must be in valid ranges (l: 0-1, c: 0-0.5, h: 0-360)",
         zignal.Lch => "Lch values must be in valid ranges (l: 0-100, c: >=0, h: 0-360)",
-        zignal.Lms => "LMS values should be non-negative cone responses",
-        zignal.Xyb => "XYB values used in JPEG XL compression",
+        zignal.Lms => "LMS values must be in range 0-1000",
+        zignal.Xyb => "XYB values must be in range -1000 to 1000",
         zignal.Ycbcr => "YCbCr values must be in range 0-255",
         else => @compileError("Missing validation error message for color type '" ++ @typeName(ColorType) ++ "'. "),
     };

--- a/bindings/python/src/color_utils.zig
+++ b/bindings/python/src/color_utils.zig
@@ -5,31 +5,32 @@ const zignal = @import("zignal");
 const Rgb = zignal.Rgb;
 const Rgba = zignal.Rgba;
 
+/// Extract color component attribute from a Python object.
+/// This is a helper function used internally.
+/// Returns null if the attribute doesn't exist or isn't a valid integer.
+/// Note: This function does NOT set Python exceptions.
+fn extractColorAttribute(obj: *c.PyObject, name: [*c]const u8) ?c_long {
+    const attr = c.PyObject_GetAttrString(obj, name);
+    if (attr == null) return null;
+    defer c.Py_DECREF(attr);
+
+    const value = c.PyLong_AsLong(attr);
+    if (c.PyErr_Occurred() != null) {
+        return null;
+    }
+
+    return value;
+}
+
 /// Extract RGB values from a Python object with r,g,b attributes.
 /// This is a helper function used internally.
 /// Returns error.InvalidColor if the object doesn't have the required attributes
 /// or if the attribute values cannot be converted to integers.
 /// Note: This function does NOT set Python exceptions.
 fn extractRgbFromObject(obj: *c.PyObject) !Rgb {
-    const r_attr = c.PyObject_GetAttrString(obj, "r");
-    if (r_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(r_attr);
-
-    const g_attr = c.PyObject_GetAttrString(obj, "g");
-    if (g_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(g_attr);
-
-    const b_attr = c.PyObject_GetAttrString(obj, "b");
-    if (b_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(b_attr);
-
-    const r = c.PyLong_AsLong(r_attr);
-    const g = c.PyLong_AsLong(g_attr);
-    const b = c.PyLong_AsLong(b_attr);
-
-    if (c.PyErr_Occurred() != null) {
-        return error.InvalidColor;
-    }
+    const r = extractColorAttribute(obj, "r") orelse return error.InvalidColor;
+    const g = extractColorAttribute(obj, "g") orelse return error.InvalidColor;
+    const b = extractColorAttribute(obj, "b") orelse return error.InvalidColor;
 
     return Rgb{
         .r = @intCast(r),
@@ -44,30 +45,10 @@ fn extractRgbFromObject(obj: *c.PyObject) !Rgb {
 /// or if the attribute values cannot be converted to integers.
 /// Note: This function does NOT set Python exceptions.
 fn extractRgbaFromObject(obj: *c.PyObject) !Rgba {
-    const r_attr = c.PyObject_GetAttrString(obj, "r");
-    if (r_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(r_attr);
-
-    const g_attr = c.PyObject_GetAttrString(obj, "g");
-    if (g_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(g_attr);
-
-    const b_attr = c.PyObject_GetAttrString(obj, "b");
-    if (b_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(b_attr);
-
-    const a_attr = c.PyObject_GetAttrString(obj, "a");
-    if (a_attr == null) return error.InvalidColor;
-    defer c.Py_DECREF(a_attr);
-
-    const r = c.PyLong_AsLong(r_attr);
-    const g = c.PyLong_AsLong(g_attr);
-    const b = c.PyLong_AsLong(b_attr);
-    const a = c.PyLong_AsLong(a_attr);
-
-    if (c.PyErr_Occurred() != null) {
-        return error.InvalidColor;
-    }
+    const r = extractColorAttribute(obj, "r") orelse return error.InvalidColor;
+    const g = extractColorAttribute(obj, "g") orelse return error.InvalidColor;
+    const b = extractColorAttribute(obj, "b") orelse return error.InvalidColor;
+    const a = extractColorAttribute(obj, "a") orelse return error.InvalidColor;
 
     return .{
         .r = @intCast(r),


### PR DESCRIPTION
Remove redundant field_names from color binding structs and the unused isSupportedColor function. Introduce a new helper for cleaner color attribute extraction in RGB/RGBA parsing. Update validation ranges for Lab, XYZ, LMS, and XYB color types to improve accuracy.