### PR TITLE
refactor(geometry): move color conversion to Point methods

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -95,17 +95,7 @@ pub const BitmapFont = font.BitmapFont;
 
 // PCA (Principal Component Analysis) system
 const pca = @import("pca.zig");
-pub const PrincipalComponentAnalysis = pca.PrincipalComponentAnalysis; // Legacy alias
-
-// Color conversion utilities
-pub const colorToPoint = pca.colorToPoint;
-pub const pointToColor = pca.pointToColor;
-
-// Image-to-points conversion functions
-pub const imageToColorPoints = pca.imageToColorPoints;
-pub const colorPointsToImage = pca.colorPointsToImage;
-pub const imageToIntensityPoints = pca.imageToIntensityPoints;
-pub const intensityPointsToImage = pca.intensityPointsToImage;
+pub const PrincipalComponentAnalysis = pca.PrincipalComponentAnalysis;
 
 // Feature detection and description
 const features = @import("features.zig");


### PR DESCRIPTION
Relocates color-to-point and point-to-color logic from pca.zig to Point.zig as Point.fromColor and Point.toColor methods. This makes the Point type self-contained for color conversions and removes redundant utilities from the pca module. Updates PCA tests to use the new Point methods.