### PR TITLE
build(python): include type stubs

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,2 +1,6 @@
 # Note: This package requires building from the full zignal project directory
 # to access build.zig and source files. No pre-built libraries are included.
+
+# Include Python type stub files
+include zignal/*.pyi
+include zignal/py.typed

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zignal-processing"
-version = "0.5.0.dev1"
+version = "0.5.0.dev110"
 description = "Zero-dependency image processing library"
 readme = "README.md"
 authors = [{name = "zignal contributors"}]
@@ -41,6 +41,9 @@ dev-dependencies = [
     "ruff",
     "numpy",
     "pdoc",
+    "setuptools>=45",
+    "wheel",
+    "build",
 ]
 
 [tool.ruff]

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -150,6 +150,18 @@ class ZigBuildExt(build_ext):
             file=sys.stderr,
         )
 
+        # Copy stub files if they exist in the source directory
+        source_package_dir = Path(__file__).parent / "zignal"
+        dest_package_dir = dest_dir.parent / "zignal"
+
+        stub_files = ["__init__.pyi", "_zignal.pyi", "py.typed"]
+        for stub_file in stub_files:
+            source_stub = source_package_dir / stub_file
+            if source_stub.exists():
+                dest_stub = dest_package_dir / stub_file
+                print(f"DEBUG: Copying stub {source_stub} -> {dest_stub}", file=sys.stderr)
+                shutil.copy2(source_stub, dest_stub)
+
 
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform tag."""


### PR DESCRIPTION
Adds .pyi files and py.typed marker to the Python package distribution, enabling static type checking for users.

Updates MANIFEST.in, setup.py, and pyproject.toml for proper inclusion and installation. Also bumps the development version and adds build dependencies.