### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - **Image Scaling Support**: Terminal graphics protocols now support image scaling
   - Sixel: Added optional `width` and `height` fields to `sixel.Options` for image scaling
   - Kitty: Added optional `width` and `height` fields to `kitty.Options` for image scaling
-  - Allows images to be scaled (perserving aspect-ratio) before transmission to terminal
+  - Allows images to be scaled (preserving aspect-ratio) before transmission to terminal
 
 ### Changed
 - **Terminal Architecture**: Refactored terminal state management
@@ -182,7 +182,7 @@ Comprehensive matrix operations:
 - **Example Applications**: Face alignment, data visualization
 
 ### Image Processing
-- **Feature distrubtion matching** for domain adaption
+- **Feature distribution matching** for domain adaption
 
 ### Procedural Generation
 - **Perlin Noise**: High-quality noise generation for textures and terrain

--- a/bindings/python/src/matrix.zig
+++ b/bindings/python/src/matrix.zig
@@ -517,7 +517,7 @@ fn matrix_from_numpy(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*
 
     // Create Matrix that references the numpy data
     const matrix_ptr = allocator.create(Matrix(f64)) catch {
-        // TODO: remove explcit cast when we don't use Python < 3.13
+        // TODO: remove explicit cast when we don't use Python < 3.13
         c.Py_DECREF(@as(?*c.PyObject, @ptrCast(self)));
         c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate Matrix");
         return null;

--- a/bindings/python/src/optimization.zig
+++ b/bindings/python/src/optimization.zig
@@ -240,7 +240,7 @@ const solve_assignment_problem_doc =
     \\
     \\for p in [OptimizationPolicy.MIN, OptimizationPolicy.MAX]:
     \\    result = solve_assignment_problem(matrix, p)
-    \\    print("minimum cost") if p == OptimizationPolicy.MIN else print("maxium profit")
+    \\    print("minimum cost") if p == OptimizationPolicy.MIN else print("maximum profit")
     \\    print(f"  - Total cost:  {result.total_cost}")
     \\    print(f"  - Assignments: {result.assignments}")
     \\```

--- a/src/geometry/Rectangle.zig
+++ b/src/geometry/Rectangle.zig
@@ -96,7 +96,7 @@ pub fn Rectangle(comptime T: type) type {
             return true;
         }
 
-        /// Grows the given rectangle by expaning its borders by `amount`.
+        /// Grows the given rectangle by expanding its borders by `amount`.
         pub fn grow(self: Self, amount: T) Self {
             return switch (@typeInfo(T)) {
                 .int => .{

--- a/src/matrix/svd.zig
+++ b/src/matrix/svd.zig
@@ -74,7 +74,7 @@ pub fn SvdResult(comptime T: type) type {
     };
 }
 
-/// Performs singular value decompostion. Code adapted from dlib's svd4, which is, in turn,
+/// Performs singular value decomposition. Code adapted from dlib's svd4, which is, in turn,
 /// translated to 'C' from the original Algol code in "Hanbook for Automatic Computation, vol. II,
 /// Linear Algebra", Springer-Verlag.  Note that this published algorithm is considered to be
 /// the best and numerically stable approach to computing the real-valued svd and is referenced

--- a/src/matrix/svd_static.zig
+++ b/src/matrix/svd_static.zig
@@ -77,7 +77,7 @@ pub fn SvdResult(
     };
 }
 
-/// Performs singular value decompostion. Code adapted from dlib's svd4, which is, in turn,
+/// Performs singular value decomposition. Code adapted from dlib's svd4, which is, in turn,
 /// translated to 'C' from the original Algol code in "Hanbook for Automatic Computation, vol. II,
 /// Linear Algebra", Springer-Verlag.  Note that this published algorithm is considered to be
 /// the best and numerically stable approach to computing the real-valued svd and is referenced


### PR DESCRIPTION
Found via `codespell -L paeth,te,bu`