### PR TITLE
feat(image): add blend method for image compositing

### DIFF
--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -102,7 +102,7 @@ fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
     // Initialize based on image format
     if (image.py_image) |pimg| {
         switch (pimg.data) {
-            .gray => |imgv| {
+            .grayscale => |imgv| {
                 const cptr = allocator.create(Canvas(u8)) catch {
                     c.Py_DECREF(image_obj.?);
                     c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate Canvas");

--- a/bindings/python/src/pixel_iterator.zig
+++ b/bindings/python/src/pixel_iterator.zig
@@ -74,7 +74,7 @@ fn pixel_iterator_next(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     row = self.index / pimg.cols();
     col = self.index % pimg.cols();
     switch (pimg.data) {
-        .gray => |img| {
+        .grayscale => |img| {
             const v = img.at(row, col).*;
             pixel_obj = c.PyLong_FromLong(@intCast(v));
         },

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -62,3 +62,25 @@ class TestImageSmoke:
         assert (out.rows, out.cols) == (5, 5)
         with pytest.raises(ValueError):
             img.gaussian_blur(0.0)
+
+    def test_blend_api(self):
+        # Test RGBA base blending
+        base = zignal.Image(5, 5, (255, 0, 0), dtype=zignal.Rgba)
+        overlay = zignal.Image(5, 5, (0, 0, 255, 128), dtype=zignal.Rgba)
+        # Blend modifies in place and returns None
+        result = base.blend(overlay, zignal.BlendMode.NORMAL)
+        assert result is None
+        # Basic check that blending occurred
+        pixel = base[2, 2]
+        assert pixel.r < 255  # Red reduced
+        assert pixel.b > 0  # Blue added
+
+        # Test grayscale base blending
+        gray_base = zignal.Image(5, 5, 128, dtype=zignal.Grayscale)
+        overlay = zignal.Image(5, 5, (255, 0, 0, 128), dtype=zignal.Rgba)
+        gray_base.blend(overlay)
+        gray_pixel = gray_base[2, 2]
+        # Grayscale value should have changed from pure 128
+        assert gray_pixel != 128
+        # Should still be grayscale (single value)
+        assert isinstance(gray_pixel, int)


### PR DESCRIPTION
Introduces the `blend` method to the Python `Image` class, allowing in-place compositing of an overlay image onto the base image using various blend modes. The overlay image must be RGBA.

Also renames the internal `gray` image variant to `grayscale` for improved clarity and consistency across the Python bindings.