### PR TITLE
feat(pixel-proxy): add color conversion and blend methods

### DIFF
--- a/bindings/python/src/color_factory.zig
+++ b/bindings/python/src/color_factory.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const zignal = @import("zignal");
 const isPacked = zignal.meta.isPacked;
 const getSimpleTypeName = zignal.meta.getSimpleTypeName;
+const comptimeLowercase = zignal.meta.comptimeLowercase;
 
 const c = @import("py_utils.zig").c;
 const color_types = @import("color_registry.zig").color_types;
@@ -14,15 +15,6 @@ const createColorPyObject = @import("color.zig").createColorPyObject;
 const getValidationErrorMessage = @import("color_registry.zig").getValidationErrorMessage;
 const validateColorComponent = @import("color_registry.zig").validateColorComponent;
 const convertToZigBlendMode = @import("blending.zig").convertToZigBlendMode;
-
-/// Convert string to lowercase at comptime
-pub fn comptimeLowercase(comptime input: []const u8) []const u8 {
-    comptime var result: [input.len]u8 = undefined;
-    inline for (input, 0..) |char, i| {
-        result[i] = std.ascii.toLower(char);
-    }
-    return result[0..];
-}
 
 /// Automatically generate documentation from type name for color conversion methods
 pub fn getConversionMethodDoc(comptime TargetColorType: type) []const u8 {

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -31,6 +31,11 @@ const image_class_doc =
     \\This object is iterable: iterating yields (row, col, pixel) in native
     \\dtype in row-major order.
     \\
+    \\Pixel access via indexing returns a proxy object that allows in-place 
+    \\modification. Use `.item()` on the proxy to extract the color value:
+    \\  pixel = img[row, col]  # Returns pixel proxy
+    \\  color = pixel.item()   # Extracts color object (Rgb/Rgba/int)
+    \\
     \\For bulk numeric work, prefer to_numpy().
 ;
 

--- a/bindings/python/src/pixel_proxy.zig
+++ b/bindings/python/src/pixel_proxy.zig
@@ -9,6 +9,7 @@ const py_utils = @import("py_utils.zig");
 const c = py_utils.c;
 const PyImageMod = @import("PyImage.zig");
 const PyImage = PyImageMod.PyImage;
+const blending = @import("blending.zig");
 
 // Proxy object layouts
 const RgbPixelProxy = extern struct {
@@ -193,6 +194,314 @@ fn PixelProxyBinding(comptime ColorType: type, comptime ProxyObjectType: type) t
             arr[fields.len] = c.PyGetSetDef{ .name = null, .get = null, .set = null, .doc = null, .closure = null };
             return arr;
         }
+
+        // __format__ method implementation
+        fn formatMethod(self_obj: ?*c.PyObject, args: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
+            var format_spec: [*c]const u8 = "";
+
+            if (c.PyArg_ParseTuple(args, "|s:__format__", &format_spec) == 0) {
+                return null;
+            }
+
+            const parent = Self.parentFromObj(self_obj) orelse {
+                c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                return null;
+            };
+
+            if (parent.py_image) |pimg| {
+                const proxy = @as(*ProxyObjectType, @ptrCast(self_obj.?));
+                const rgba = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
+
+                // Check format spec
+                if (format_spec[0] != 0) {
+                    const spec_len = std.mem.len(format_spec);
+                    const spec = format_spec[0..spec_len];
+                    if (std.mem.eql(u8, spec, "ansi")) {
+                        // ANSI color formatting
+                        var buf: [64]u8 = undefined;
+                        const formatted = std.fmt.bufPrint(&buf, "\x1b[48;2;{d};{d};{d}m  \x1b[0m", .{ rgba.r, rgba.g, rgba.b }) catch {
+                            c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to format ANSI color");
+                            return null;
+                        };
+                        return c.PyUnicode_FromStringAndSize(formatted.ptr, @intCast(formatted.len));
+                    }
+                }
+
+                // Default formatting (same as repr)
+                return Self.repr(self_obj);
+            }
+
+            c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+            return null;
+        }
+
+        // to_gray method implementation
+        fn toGrayMethod(self_obj: ?*c.PyObject, args: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
+            _ = args;
+            const parent = Self.parentFromObj(self_obj) orelse {
+                c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                return null;
+            };
+
+            if (parent.py_image) |pimg| {
+                const proxy = @as(*ProxyObjectType, @ptrCast(self_obj.?));
+                const rgba = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
+                const gray = rgba.toGray();
+                return c.PyLong_FromLong(@intCast(gray));
+            }
+
+            c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+            return null;
+        }
+
+        // item method implementation - extract the pixel value as a color object
+        fn itemMethod(self_obj: ?*c.PyObject, _: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
+            const parent = Self.parentFromObj(self_obj) orelse {
+                c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                return null;
+            };
+
+            if (parent.py_image) |pimg| {
+                const proxy = @as(*ProxyObjectType, @ptrCast(self_obj.?));
+                const rgba = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
+
+                // Return the color as the appropriate type
+                if (ColorType == zignal.Rgb) {
+                    const color_mod = @import("color.zig");
+                    const obj = c.PyType_GenericNew(@ptrCast(&color_mod.RgbType), null, null);
+                    if (obj == null) return null;
+                    const py_obj = @as(*color_mod.RgbBinding.PyObjectType, @ptrCast(obj));
+                    py_obj.field0 = rgba.r;
+                    py_obj.field1 = rgba.g;
+                    py_obj.field2 = rgba.b;
+                    return obj;
+                } else {
+                    const color_mod = @import("color.zig");
+                    const obj = c.PyType_GenericNew(@ptrCast(&color_mod.RgbaType), null, null);
+                    if (obj == null) return null;
+                    const py_obj = @as(*color_mod.RgbaBinding.PyObjectType, @ptrCast(obj));
+                    py_obj.field0 = rgba.r;
+                    py_obj.field1 = rgba.g;
+                    py_obj.field2 = rgba.b;
+                    py_obj.field3 = rgba.a;
+                    return obj;
+                }
+            }
+
+            c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+            return null;
+        }
+
+        // blend method implementation
+        fn blendMethod(self_obj: ?*c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
+            var overlay_obj: ?*c.PyObject = null;
+            var mode_obj: ?*c.PyObject = null;
+
+            var kwlist = [_:null]?[*:0]const u8{ "overlay", "mode", null };
+            if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O|O:blend", @ptrCast(&kwlist), &overlay_obj, &mode_obj) == 0) {
+                return null;
+            }
+
+            const parent = Self.parentFromObj(self_obj) orelse {
+                c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                return null;
+            };
+
+            if (parent.py_image) |pimg| {
+                const proxy = @as(*ProxyObjectType, @ptrCast(self_obj.?));
+
+                // Parse overlay color
+                const overlay = color_utils.parseColorTo(zignal.Rgba, overlay_obj) catch {
+                    // Error already set by parseColorTo
+                    return null;
+                };
+
+                // Parse blend mode
+                const mode = if (mode_obj != null)
+                    blending.convertToZigBlendMode(mode_obj.?) catch {
+                        // Error already set
+                        return null;
+                    }
+                else
+                    zignal.BlendMode.normal;
+
+                // Get current pixel, blend, and write back
+                const current = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
+                const blended = current.blend(overlay, mode);
+                pimg.setPixelRgba(@intCast(proxy.row), @intCast(proxy.col), blended);
+
+                // Return the new blended color as an Rgb or Rgba object
+                if (ColorType == zignal.Rgb) {
+                    const color_mod = @import("color.zig");
+                    const obj = c.PyType_GenericNew(@ptrCast(&color_mod.RgbType), null, null);
+                    if (obj == null) return null;
+                    const py_obj = @as(*color_mod.RgbBinding.PyObjectType, @ptrCast(obj));
+                    py_obj.field0 = blended.r;
+                    py_obj.field1 = blended.g;
+                    py_obj.field2 = blended.b;
+                    return obj;
+                } else {
+                    const color_mod = @import("color.zig");
+                    const obj = c.PyType_GenericNew(@ptrCast(&color_mod.RgbaType), null, null);
+                    if (obj == null) return null;
+                    const py_obj = @as(*color_mod.RgbaBinding.PyObjectType, @ptrCast(obj));
+                    py_obj.field0 = blended.r;
+                    py_obj.field1 = blended.g;
+                    py_obj.field2 = blended.b;
+                    py_obj.field3 = blended.a;
+                    return obj;
+                }
+            }
+
+            c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+            return null;
+        }
+
+        // Generate conversion method for a specific target color type
+        fn generateConversionMethod(comptime TargetColorType: type) c.PyCFunction {
+            return struct {
+                fn method(self_obj: ?*c.PyObject, args: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
+                    const parent = Self.parentFromObj(self_obj) orelse {
+                        c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                        return null;
+                    };
+
+                    if (parent.py_image) |pimg| {
+                        const proxy = @as(*ProxyObjectType, @ptrCast(self_obj.?));
+                        const rgba = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
+
+                        // Special handling for to_rgba which accepts optional alpha
+                        if (TargetColorType == zignal.Rgba) {
+                            var alpha: u8 = rgba.a;
+                            if (c.PyArg_ParseTuple(args, "|B:to_rgba", &alpha) == 0) {
+                                return null;
+                            }
+
+                            // For RGBA, just return the current value with potentially new alpha
+                            const result = zignal.Rgba{ .r = rgba.r, .g = rgba.g, .b = rgba.b, .a = alpha };
+
+                            // Get the RgbaType and create new object
+                            const color_mod = @import("color.zig");
+                            const obj = c.PyType_GenericNew(@ptrCast(&color_mod.RgbaType), null, null);
+                            if (obj == null) return null;
+                            const py_obj = @as(*color_mod.RgbaBinding.PyObjectType, @ptrCast(obj));
+                            py_obj.field0 = result.r;
+                            py_obj.field1 = result.g;
+                            py_obj.field2 = result.b;
+                            py_obj.field3 = result.a;
+                            return obj;
+                        }
+
+                        // Convert from RGBA/RGB to target type using generic convertColor
+                        const source_color = if (ColorType == zignal.Rgb)
+                            zignal.Rgb{ .r = rgba.r, .g = rgba.g, .b = rgba.b }
+                        else
+                            rgba;
+
+                        const converted = zignal.convertColor(TargetColorType, source_color);
+
+                        // Create and return new Python object using the factory
+                        const factory_mod = @import("color_factory.zig");
+                        const factory = factory_mod.ColorBinding(TargetColorType);
+                        const color_mod = @import("color.zig");
+                        const type_obj = switch (TargetColorType) {
+                            zignal.Hsl => &color_mod.HslType,
+                            zignal.Hsv => &color_mod.HsvType,
+                            zignal.Lab => &color_mod.LabType,
+                            zignal.Lch => &color_mod.LchType,
+                            zignal.Lms => &color_mod.LmsType,
+                            zignal.Oklab => &color_mod.OklabType,
+                            zignal.Oklch => &color_mod.OklchType,
+                            zignal.Xyb => &color_mod.XybType,
+                            zignal.Xyz => &color_mod.XyzType,
+                            zignal.Ycbcr => &color_mod.YcbcrType,
+                            zignal.Rgb => &color_mod.RgbType,
+                            zignal.Rgba => &color_mod.RgbaType,
+                            else => unreachable,
+                        };
+                        return factory.createPyObject(converted, @ptrCast(type_obj));
+                    }
+
+                    c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
+                    return null;
+                }
+            }.method;
+        }
+
+        // Helper to get conversion method name as a comptime string
+        fn getConversionMethodName(comptime TargetType: type) []const u8 {
+            const type_name = zignal.meta.getSimpleTypeName(TargetType);
+            return "to_" ++ zignal.meta.comptimeLowercase(type_name);
+        }
+
+        // Generate methods array
+        // Note: +4 for __format__, blend, to_gray, item, +1 for null terminator, -1 because we skip self-conversion
+        pub fn generateMethods() [color_registry.color_types.len + 4]c.PyMethodDef {
+            var methods: [color_registry.color_types.len + 4]c.PyMethodDef = undefined;
+            var index: usize = 0;
+
+            // Add __format__ method
+            methods[index] = c.PyMethodDef{
+                .ml_name = "__format__",
+                .ml_meth = @ptrCast(&formatMethod),
+                .ml_flags = c.METH_VARARGS,
+                .ml_doc = "Format the pixel with optional format specifier (supports 'ansi')",
+            };
+            index += 1;
+
+            // Add blend method
+            methods[index] = c.PyMethodDef{
+                .ml_name = "blend",
+                .ml_meth = @ptrCast(&blendMethod),
+                .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS,
+                .ml_doc = "Blend with another color using the specified blend mode",
+            };
+            index += 1;
+
+            // Add to_gray method
+            methods[index] = c.PyMethodDef{
+                .ml_name = "to_gray",
+                .ml_meth = @ptrCast(&toGrayMethod),
+                .ml_flags = c.METH_NOARGS,
+                .ml_doc = "Convert to grayscale value (0-255)",
+            };
+            index += 1;
+
+            // Add item method
+            methods[index] = c.PyMethodDef{
+                .ml_name = "item",
+                .ml_meth = @ptrCast(&itemMethod),
+                .ml_flags = c.METH_NOARGS,
+                .ml_doc = "Extract the pixel value as a color object",
+            };
+            index += 1;
+
+            // Generate conversion methods for each color type
+            inline for (color_registry.color_types) |TargetColorType| {
+                // Skip self-conversion - use .item() instead
+                if (TargetColorType == ColorType) continue;
+                
+                const method_name = comptime getConversionMethodName(TargetColorType);
+
+                methods[index] = c.PyMethodDef{
+                    .ml_name = method_name.ptr,
+                    .ml_meth = generateConversionMethod(TargetColorType),
+                    .ml_flags = if (TargetColorType == zignal.Rgba) c.METH_VARARGS else c.METH_NOARGS,
+                    .ml_doc = "Convert to " ++ @typeName(TargetColorType),
+                };
+                index += 1;
+            }
+
+            // Null terminator
+            methods[index] = c.PyMethodDef{
+                .ml_name = null,
+                .ml_meth = null,
+                .ml_flags = 0,
+                .ml_doc = null,
+            };
+
+            return methods;
+        }
     };
 }
 
@@ -201,6 +510,8 @@ const RgbaProxyBinding = PixelProxyBinding(zignal.Rgba, RgbaPixelProxy);
 
 var rgb_proxy_getset = RgbProxyBinding.generateGetSet();
 var rgba_proxy_getset = RgbaProxyBinding.generateGetSet();
+var rgb_proxy_methods = RgbProxyBinding.generateMethods();
+var rgba_proxy_methods = RgbaProxyBinding.generateMethods();
 
 pub var RgbPixelProxyType = c.PyTypeObject{
     .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
@@ -210,6 +521,7 @@ pub var RgbPixelProxyType = c.PyTypeObject{
     .tp_repr = RgbProxyBinding.repr,
     .tp_flags = c.Py_TPFLAGS_DEFAULT,
     .tp_doc = "Proxy object for RGB pixel access",
+    .tp_methods = @ptrCast(&rgb_proxy_methods),
     .tp_getset = @ptrCast(&rgb_proxy_getset),
     .tp_richcompare = RgbProxyBinding.richcompare,
 };
@@ -222,6 +534,7 @@ pub var RgbaPixelProxyType = c.PyTypeObject{
     .tp_repr = RgbaProxyBinding.repr,
     .tp_flags = c.Py_TPFLAGS_DEFAULT,
     .tp_doc = "Proxy object for RGBA pixel access",
+    .tp_methods = @ptrCast(&rgba_proxy_methods),
     .tp_getset = @ptrCast(&rgba_proxy_getset),
     .tp_richcompare = RgbaProxyBinding.richcompare,
 };

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -84,3 +84,57 @@ class TestImageSmoke:
         assert gray_pixel != 128
         # Should still be grayscale (single value)
         assert isinstance(gray_pixel, int)
+
+    def test_pixel_proxy_methods(self):
+        """Test that pixel proxy objects have color methods"""
+        # Create RGB image
+        img = zignal.Image(10, 10, (255, 0, 0), dtype=zignal.Rgb)
+        pixel = img[0, 0]
+        assert isinstance(pixel.item(), zignal.Rgb)
+
+        # Test to_gray
+        gray = pixel.to_gray()
+        assert isinstance(gray, int)
+        assert 0 <= gray <= 255
+
+        # Test color conversion
+        hsl = pixel.to_hsl()
+        assert isinstance(hsl, zignal.Hsl)
+
+        lab = pixel.to_lab()
+        assert isinstance(lab, zignal.Lab)
+
+        # Test blend - modifies pixel in place and returns new color
+        blended = pixel.blend((0, 255, 0, 128))
+        assert isinstance(blended, zignal.Rgb)
+        # Pixel should be modified in the image
+        assert img[0, 0].g > 0  # Green component added
+
+        # Test format
+        repr_str = repr(pixel)
+        assert "Rgb" in repr_str
+
+        ansi_str = format(pixel, "ansi")
+        assert "\x1b[" in ansi_str  # ANSI escape sequence
+
+    def test_rgba_pixel_proxy_methods(self):
+        """Test RGBA pixel proxy has all methods"""
+        img = zignal.Image(10, 10, (255, 0, 0, 200), dtype=zignal.Rgba)
+        pixel = img[0, 0]
+        assert isinstance(pixel.item(), zignal.Rgba)
+
+        # Component access
+        assert pixel.r == 255
+        assert pixel.a == 200
+
+        # Methods
+        gray = pixel.to_gray()
+        assert isinstance(gray, int)
+
+        hsl = pixel.to_hsl()
+        assert isinstance(hsl, zignal.Hsl)
+
+        # to_rgb conversion
+        rgb = pixel.to_rgb()
+        assert isinstance(rgb, zignal.Rgb)
+        assert rgb.r == 255

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -56,3 +56,14 @@ pub inline fn getSimpleTypeName(comptime T: type) []const u8 {
     }
     return full_name;
 }
+
+/// Converts a comptime string to lowercase.
+/// e.g., "RGB" -> "rgb", "OkLab" -> "oklab"
+pub inline fn comptimeLowercase(comptime input: []const u8) []const u8 {
+    const std = @import("std");
+    comptime var result: [input.len]u8 = undefined;
+    inline for (input, 0..) |char, i| {
+        result[i] = std.ascii.toLower(char);
+    }
+    return result[0..];
+}


### PR DESCRIPTION
Implement `__format__`, `to_gray`, `blend`, and various `to_<color_type>` methods for pixel proxy objects. This allows direct color operations and conversions on individual pixels.