### PR TITLE
feat(warp): add Image.warp and python transforms

### DIFF
--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -385,22 +385,22 @@ fn makeDrawMethodWithWidth(
 
             // Call the appropriate method based on parameter types
             if (comptime std.mem.eql(u8, name, "draw_line")) {
-                const p1 = py_utils.parsePointTuple(@ptrCast(param_objs[0])) catch return null;
-                const p2 = py_utils.parsePointTuple(@ptrCast(param_objs[1])) catch return null;
+                const p1 = py_utils.parsePointTuple(f32, @ptrCast(param_objs[0])) catch return null;
+                const p2 = py_utils.parsePointTuple(f32, @ptrCast(param_objs[1])) catch return null;
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.drawLine(p1, p2, common.color_gray, common.width, common.mode),
                     .rgb => common.canvas_rgb.?.drawLine(p1, p2, common.color_rgb, common.width, common.mode),
                     .rgba => common.canvas_rgba.?.drawLine(p1, p2, common.color_rgba, common.width, common.mode),
                 }
             } else if (comptime std.mem.eql(u8, name, "draw_rectangle")) {
-                const rect = py_utils.parseRectangle(@ptrCast(param_objs[0])) catch return null;
+                const rect = py_utils.parseRectangle(f32, @ptrCast(param_objs[0])) catch return null;
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.drawRectangle(rect, common.color_gray, common.width, common.mode),
                     .rgb => common.canvas_rgb.?.drawRectangle(rect, common.color_rgb, common.width, common.mode),
                     .rgba => common.canvas_rgba.?.drawRectangle(rect, common.color_rgba, common.width, common.mode),
                 }
             } else if (comptime std.mem.eql(u8, name, "draw_polygon")) {
-                const points = py_utils.parsePointList(@ptrCast(param_objs[0])) catch return null;
+                const points = py_utils.parsePointList(f32, @ptrCast(param_objs[0])) catch return null;
                 defer allocator.free(points);
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.drawPolygon(points, common.color_gray, common.width, common.mode),
@@ -408,7 +408,7 @@ fn makeDrawMethodWithWidth(
                     .rgba => common.canvas_rgba.?.drawPolygon(points, common.color_rgba, common.width, common.mode),
                 }
             } else if (comptime std.mem.eql(u8, name, "draw_circle")) {
-                const center = py_utils.parsePointTuple(@ptrCast(param_objs[0])) catch return null;
+                const center = py_utils.parsePointTuple(f32, @ptrCast(param_objs[0])) catch return null;
                 const radius = py_utils.validateNonNegative(f32, @as(*f64, @ptrCast(@alignCast(parse_args[1]))).*, "Radius") catch return null;
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.drawCircle(center, radius, common.color_gray, common.width, common.mode),
@@ -488,14 +488,14 @@ fn makeFillMethod(
 
             // Call the appropriate method based on parameter types
             if (comptime std.mem.eql(u8, name, "fill_rectangle")) {
-                const rect = py_utils.parseRectangle(@ptrCast(param_objs[0])) catch return null;
+                const rect = py_utils.parseRectangle(f32, @ptrCast(param_objs[0])) catch return null;
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.fillRectangle(rect, common.color_gray, common.mode),
                     .rgb => common.canvas_rgb.?.fillRectangle(rect, common.color_rgb, common.mode),
                     .rgba => common.canvas_rgba.?.fillRectangle(rect, common.color_rgba, common.mode),
                 }
             } else if (comptime std.mem.eql(u8, name, "fill_polygon")) {
-                const points = py_utils.parsePointList(@ptrCast(param_objs[0])) catch return null;
+                const points = py_utils.parsePointList(f32, @ptrCast(param_objs[0])) catch return null;
                 defer allocator.free(points);
                 if (has_error_handling) {
                     switch (common.kind) {
@@ -520,7 +520,7 @@ fn makeFillMethod(
                     }
                 }
             } else if (comptime std.mem.eql(u8, name, "fill_circle")) {
-                const center = py_utils.parsePointTuple(@ptrCast(param_objs[0])) catch return null;
+                const center = py_utils.parsePointTuple(f32, @ptrCast(param_objs[0])) catch return null;
                 const radius = py_utils.validateNonNegative(f32, @as(*f64, @ptrCast(@alignCast(parse_args[1]))).*, "Radius") catch return null;
                 switch (common.kind) {
                     .gray => common.canvas_gray.?.fillCircle(center, radius, common.color_gray, common.mode),
@@ -681,9 +681,9 @@ fn canvas_draw_quadratic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds
     const common = parseDrawArgs(self, color_obj, width, mode) catch return null;
 
     // Convert arguments
-    const p0 = py_utils.parsePointTuple(@ptrCast(p0_obj)) catch return null;
-    const p1 = py_utils.parsePointTuple(@ptrCast(p1_obj)) catch return null;
-    const p2 = py_utils.parsePointTuple(@ptrCast(p2_obj)) catch return null;
+    const p0 = py_utils.parsePointTuple(f32, @ptrCast(p0_obj)) catch return null;
+    const p1 = py_utils.parsePointTuple(f32, @ptrCast(p1_obj)) catch return null;
+    const p2 = py_utils.parsePointTuple(f32, @ptrCast(p2_obj)) catch return null;
 
     switch (common.kind) {
         .gray => common.canvas_gray.?.drawQuadraticBezier(p0, p1, p2, common.color_gray, common.width, common.mode),
@@ -716,10 +716,10 @@ fn canvas_draw_cubic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*
     const common = parseDrawArgs(self, color_obj, width, mode) catch return null;
 
     // Convert arguments
-    const p0 = py_utils.parsePointTuple(@ptrCast(p0_obj)) catch return null;
-    const p1 = py_utils.parsePointTuple(@ptrCast(p1_obj)) catch return null;
-    const p2 = py_utils.parsePointTuple(@ptrCast(p2_obj)) catch return null;
-    const p3 = py_utils.parsePointTuple(@ptrCast(p3_obj)) catch return null;
+    const p0 = py_utils.parsePointTuple(f32, @ptrCast(p0_obj)) catch return null;
+    const p1 = py_utils.parsePointTuple(f32, @ptrCast(p1_obj)) catch return null;
+    const p2 = py_utils.parsePointTuple(f32, @ptrCast(p2_obj)) catch return null;
+    const p3 = py_utils.parsePointTuple(f32, @ptrCast(p3_obj)) catch return null;
 
     switch (common.kind) {
         .gray => common.canvas_gray.?.drawCubicBezier(p0, p1, p2, p3, common.color_gray, common.width, common.mode),
@@ -751,7 +751,7 @@ fn canvas_draw_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: 
     const tension_val = py_utils.validateRange(f32, tension, 0.0, 1.0, "Tension") catch return null;
 
     // Parse points
-    const points = py_utils.parsePointList(@ptrCast(points_obj)) catch return null;
+    const points = py_utils.parsePointList(f32, @ptrCast(points_obj)) catch return null;
     defer allocator.free(points);
 
     switch (common.kind) {
@@ -783,7 +783,7 @@ fn canvas_fill_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: 
     const tension_val = py_utils.validateRange(f32, tension, 0.0, 1.0, "Tension") catch return null;
 
     // Parse points
-    const points = py_utils.parsePointList(@ptrCast(points_obj)) catch return null;
+    const points = py_utils.parsePointList(f32, @ptrCast(points_obj)) catch return null;
     defer allocator.free(points);
 
     switch (common.kind) {
@@ -826,7 +826,7 @@ fn canvas_draw_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
     const common = parseDrawArgs(self, color_obj, width, mode) catch return null;
 
     // Convert arguments
-    const center = py_utils.parsePointTuple(@ptrCast(center_obj)) catch return null;
+    const center = py_utils.parsePointTuple(f32, @ptrCast(center_obj)) catch return null;
     const radius_val = @as(f32, @floatCast(radius));
     const start_angle_val = @as(f32, @floatCast(start_angle));
     const end_angle_val = @as(f32, @floatCast(end_angle));
@@ -870,7 +870,7 @@ fn canvas_fill_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
     const common = parseFillArgs(self, color_obj, mode) catch return null;
 
     // Convert arguments
-    const center = py_utils.parsePointTuple(@ptrCast(center_obj)) catch return null;
+    const center = py_utils.parsePointTuple(f32, @ptrCast(center_obj)) catch return null;
     // Allow negative radius - the Zig library will handle it gracefully (no-op)
     const radius_val = @as(f32, @floatCast(radius));
     const start_angle_val = @as(f32, @floatCast(start_angle));
@@ -918,7 +918,7 @@ fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     };
     const text = std.mem.span(text_cstr);
 
-    const position = py_utils.parsePointTuple(position_obj) catch return null;
+    const position = py_utils.parsePointTuple(f32, position_obj) catch return null;
 
     const rgba = color_utils.parseColorTo(Rgba, @ptrCast(color_obj)) catch return null;
 

--- a/bindings/python/src/convex_hull.zig
+++ b/bindings/python/src/convex_hull.zig
@@ -93,7 +93,7 @@ fn convex_hull_find(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c
     }
 
     // Parse the point list
-    const points = py_utils.parsePointList(points_obj) catch {
+    const points = py_utils.parsePointList(f32, points_obj) catch {
         // Error already set by parsePointList
         return null;
     };

--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -20,6 +20,7 @@ const bitmap_font_module = @import("bitmap_font.zig");
 const blending_module = @import("blending.zig");
 const interpolation_module = @import("interpolation.zig");
 const optimization_module = @import("optimization.zig");
+const transforms_module = @import("transforms.zig");
 
 const GeneratedStub = struct {
     content: std.ArrayList(u8),
@@ -550,6 +551,46 @@ fn generateStubFile(gpa: std.mem.Allocator) ![]u8 {
         .special_methods = &convex_hull_module.convex_hull_special_methods_metadata,
     });
 
+    // Generate Transform classes from metadata
+    // SimilarityTransform
+    const similarity_methods = transforms_module.similarity_methods_metadata;
+    const similarity_properties = transforms_module.similarity_properties_metadata;
+    const similarity_doc = std.mem.span(transforms_module.SimilarityTransformType.tp_doc);
+    try generateClassFromMetadata(&stub, .{
+        .name = "SimilarityTransform",
+        .doc = similarity_doc,
+        .methods = &similarity_methods,
+        .properties = &similarity_properties,
+        .bases = &.{},
+        .special_methods = null,
+    });
+
+    // AffineTransform
+    const affine_methods = transforms_module.affine_methods_metadata;
+    const affine_properties = transforms_module.affine_properties_metadata;
+    const affine_doc = std.mem.span(transforms_module.AffineTransformType.tp_doc);
+    try generateClassFromMetadata(&stub, .{
+        .name = "AffineTransform",
+        .doc = affine_doc,
+        .methods = &affine_methods,
+        .properties = &affine_properties,
+        .bases = &.{},
+        .special_methods = null,
+    });
+
+    // ProjectiveTransform
+    const projective_methods = transforms_module.projective_methods_metadata;
+    const projective_properties = transforms_module.projective_properties_metadata;
+    const projective_doc = std.mem.span(transforms_module.ProjectiveTransformType.tp_doc);
+    try generateClassFromMetadata(&stub, .{
+        .name = "ProjectiveTransform",
+        .doc = projective_doc,
+        .methods = &projective_methods,
+        .properties = &projective_properties,
+        .bases = &.{},
+        .special_methods = null,
+    });
+
     // Generate module-level functions from metadata
     const module_functions = stub_metadata.extractFunctionInfo(&main_module.module_functions_metadata);
     try generateModuleFunctionsFromMetadata(&stub, &module_functions);
@@ -594,6 +635,9 @@ fn generateInitStub(gpa: std.mem.Allocator) ![]u8 {
     try stub.write("    Assignment as Assignment,\n");
     try stub.write("    FeatureDistributionMatching as FeatureDistributionMatching,\n");
     try stub.write("    ConvexHull as ConvexHull,\n");
+    try stub.write("    SimilarityTransform as SimilarityTransform,\n");
+    try stub.write("    AffineTransform as AffineTransform,\n");
+    try stub.write("    ProjectiveTransform as ProjectiveTransform,\n");
     try stub.write("    solve_assignment_problem as solve_assignment_problem,\n");
     try stub.write("    # Type aliases\n");
     try stub.write("    Point as Point,\n");

--- a/bindings/python/src/main.zig
+++ b/bindings/python/src/main.zig
@@ -19,6 +19,7 @@ const py_utils = @import("py_utils.zig");
 const c = py_utils.c;
 const rectangle = @import("rectangle.zig");
 const stub_metadata = @import("stub_metadata.zig");
+const transforms = @import("transforms.zig");
 
 // ============================================================================
 // MODULE FUNCTIONS
@@ -165,6 +166,25 @@ pub export fn PyInit__zignal() ?*c.PyObject {
     // Register Grayscale sentinel type
     grayscale_format.registerGrayscaleType(@ptrCast(m)) catch |err| {
         std.log.err("Failed to register Grayscale type: {}", .{err});
+        c.Py_DECREF(m);
+        return null;
+    };
+
+    // Register transform types
+    py_utils.registerType(@ptrCast(m), "SimilarityTransform", @ptrCast(&transforms.SimilarityTransformType)) catch |err| {
+        std.log.err("Failed to register SimilarityTransform: {}", .{err});
+        c.Py_DECREF(m);
+        return null;
+    };
+
+    py_utils.registerType(@ptrCast(m), "AffineTransform", @ptrCast(&transforms.AffineTransformType)) catch |err| {
+        std.log.err("Failed to register AffineTransform: {}", .{err});
+        c.Py_DECREF(m);
+        return null;
+    };
+
+    py_utils.registerType(@ptrCast(m), "ProjectiveTransform", @ptrCast(&transforms.ProjectiveTransformType)) catch |err| {
+        std.log.err("Failed to register ProjectiveTransform: {}", .{err});
         c.Py_DECREF(m);
         return null;
     };

--- a/bindings/python/src/rectangle.zig
+++ b/bindings/python/src/rectangle.zig
@@ -10,10 +10,10 @@ const stub_metadata = @import("stub_metadata.zig");
 
 pub const RectangleObject = extern struct {
     ob_base: c.PyObject,
-    left: f32,
-    top: f32,
-    right: f32,
-    bottom: f32,
+    left: f64,
+    top: f64,
+    right: f64,
+    bottom: f64,
 };
 
 fn rectangle_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
@@ -54,11 +54,10 @@ fn rectangle_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
         return -1;
     }
 
-    // Store as f32
-    self.left = @as(f32, @floatCast(left));
-    self.top = @as(f32, @floatCast(top));
-    self.right = @as(f32, @floatCast(right));
-    self.bottom = @as(f32, @floatCast(bottom));
+    self.left = left;
+    self.top = top;
+    self.right = right;
+    self.bottom = bottom;
 
     return 0;
 }

--- a/bindings/python/src/transforms.zig
+++ b/bindings/python/src/transforms.zig
@@ -1,0 +1,754 @@
+const std = @import("std");
+const zignal = @import("zignal");
+const SimilarityTransform = zignal.SimilarityTransform;
+const AffineTransform = zignal.AffineTransform;
+const ProjectiveTransform = zignal.ProjectiveTransform;
+const Point = zignal.Point;
+
+const py_utils = @import("py_utils.zig");
+const c = py_utils.c;
+const allocator = py_utils.allocator;
+const stub_metadata = @import("stub_metadata.zig");
+
+// ============================================================================
+// SIMILARITY TRANSFORM
+// ============================================================================
+
+pub const SimilarityTransformObject = extern struct {
+    ob_base: c.PyObject,
+    // Store 2x2 matrix as array
+    matrix: [2][2]f64,
+    // Store translation vector as array
+    bias: [2]f64,
+};
+
+fn similarity_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    _ = kwds;
+
+    const self = @as(?*SimilarityTransformObject, @ptrCast(c.PyType_GenericAlloc(type_obj, 0)));
+    if (self) |obj| {
+        // Initialize as identity transform
+        obj.matrix = .{ .{ 1.0, 0.0 }, .{ 0.0, 1.0 } };
+        obj.bias = .{ 0.0, 0.0 };
+    }
+    return @as(?*c.PyObject, @ptrCast(self));
+}
+
+fn similarity_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
+    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+
+    var from_points_obj: ?*c.PyObject = null;
+    var to_points_obj: ?*c.PyObject = null;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("from_points"), @constCast("to_points"), null };
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|OO", @ptrCast(&kwlist), &from_points_obj, &to_points_obj) == 0) {
+        return -1;
+    }
+
+    // If no arguments, keep identity transform
+    if (from_points_obj == null or to_points_obj == null) {
+        return 0;
+    }
+
+    // Parse point lists
+    const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(from_points);
+
+    const to_points = py_utils.parsePointList(f64, to_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(to_points);
+
+    // Check we have same number of points
+    if (from_points.len != to_points.len) {
+        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        return -1;
+    }
+
+    // Check we have at least 2 points
+    if (from_points.len < 2) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 2 point correspondences for similarity transform");
+        return -1;
+    }
+
+    // Create and fit the transform
+    const transform = SimilarityTransform(f64).init(from_points, to_points);
+
+    // Store matrix components
+    self.matrix[0][0] = transform.matrix.at(0, 0).*;
+    self.matrix[0][1] = transform.matrix.at(0, 1).*;
+    self.matrix[1][0] = transform.matrix.at(1, 0).*;
+    self.matrix[1][1] = transform.matrix.at(1, 1).*;
+    self.bias[0] = transform.bias.at(0, 0).*;
+    self.bias[1] = transform.bias.at(1, 0).*;
+
+    return 0;
+}
+
+fn similarity_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
+    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+}
+
+fn similarity_project(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+
+    var point_obj: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "O", &point_obj) == 0) return null;
+
+    // Check if it's a single tuple (x, y)
+    if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {
+        // Single point - return single tuple
+        const point = py_utils.parsePointTuple(f64, point_obj) catch return null;
+
+        // Apply transform: new = matrix * point + bias
+        const new_x = self.matrix[0][0] * point.x() + self.matrix[0][1] * point.y() + self.bias[0];
+        const new_y = self.matrix[1][0] * point.x() + self.matrix[1][1] * point.y() + self.bias[1];
+
+        return c.PyTuple_Pack(2, c.PyFloat_FromDouble(new_x), c.PyFloat_FromDouble(new_y));
+    } else if (c.PySequence_Check(point_obj) != 0) {
+        // List/sequence of points - return list of tuples
+        const points = py_utils.parsePointList(f64, point_obj) catch return null;
+        defer allocator.free(points);
+
+        const result_list = c.PyList_New(@intCast(points.len)) orelse return null;
+
+        for (points, 0..) |point, i| {
+            const new_x = self.matrix[0][0] * point.x() + self.matrix[0][1] * point.y() + self.bias[0];
+            const new_y = self.matrix[1][0] * point.x() + self.matrix[1][1] * point.y() + self.bias[1];
+
+            const tuple = c.PyTuple_Pack(2, c.PyFloat_FromDouble(new_x), c.PyFloat_FromDouble(new_y)) orelse {
+                c.Py_DECREF(result_list);
+                return null;
+            };
+
+            // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+            // PyList_SET_ITEM is a macro that doesn't translate properly in Python 3.10
+            _ = c.PyList_SetItem(result_list, @intCast(i), tuple);
+        }
+
+        return result_list;
+    } else {
+        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        return null;
+    }
+}
+
+fn similarity_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+
+    var buffer: [512]u8 = undefined;
+    const str = std.fmt.bufPrintZ(&buffer, "SimilarityTransform(matrix=[[{d:.6}, {d:.6}], [{d:.6}, {d:.6}]], bias=({d:.6}, {d:.6}))", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[1][0], self.matrix[1][1], self.bias[0], self.bias[1] }) catch return null;
+
+    return c.PyUnicode_FromString(str.ptr);
+}
+
+// Property getters for matrix and bias
+fn similarity_get_matrix(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+
+    // Create a 2x2 nested list
+    const row0 = c.PyList_New(2) orelse return null;
+    const row1 = c.PyList_New(2) orelse return null;
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 0, c.PyFloat_FromDouble(self.matrix[0][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 1, c.PyFloat_FromDouble(self.matrix[0][1]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 0, c.PyFloat_FromDouble(self.matrix[1][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 1, c.PyFloat_FromDouble(self.matrix[1][1]));
+
+    const matrix = c.PyList_New(2) orelse {
+        c.Py_DECREF(row0);
+        c.Py_DECREF(row1);
+        return null;
+    };
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 0, row0);
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 1, row1);
+
+    return matrix;
+}
+
+fn similarity_get_bias(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+    return c.PyTuple_Pack(2, c.PyFloat_FromDouble(self.bias[0]), c.PyFloat_FromDouble(self.bias[1]));
+}
+
+var similarity_methods = [_]c.PyMethodDef{
+    .{ .ml_name = "project", .ml_meth = @ptrCast(&similarity_project), .ml_flags = c.METH_VARARGS, .ml_doc = "Transform point(s). Accepts (x,y) tuple or list of tuples." },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
+};
+
+var similarity_getset = [_]c.PyGetSetDef{
+    .{ .name = "matrix", .get = similarity_get_matrix, .set = null, .doc = "2x2 transformation matrix", .closure = null },
+    .{ .name = "bias", .get = similarity_get_bias, .set = null, .doc = "Translation vector (x, y)", .closure = null },
+    .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
+};
+
+pub var SimilarityTransformType = c.PyTypeObject{
+    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
+    .tp_name = "zignal.SimilarityTransform",
+    .tp_basicsize = @sizeOf(SimilarityTransformObject),
+    .tp_dealloc = similarity_dealloc,
+    .tp_repr = similarity_repr,
+    .tp_flags = c.Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Similarity transform (rotation + uniform scale + translation)",
+    .tp_methods = &similarity_methods,
+    .tp_getset = &similarity_getset,
+    .tp_init = similarity_init,
+    .tp_new = similarity_new,
+};
+
+// ============================================================================
+// AFFINE TRANSFORM
+// ============================================================================
+
+pub const AffineTransformObject = extern struct {
+    ob_base: c.PyObject,
+    // Store 2x2 matrix as array
+    matrix: [2][2]f64,
+    // Store translation vector as array
+    bias: [2]f64,
+};
+
+fn affine_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    _ = kwds;
+
+    const self = @as(?*AffineTransformObject, @ptrCast(c.PyType_GenericAlloc(type_obj, 0)));
+    if (self) |obj| {
+        // Initialize as identity transform
+        obj.matrix = .{ .{ 1.0, 0.0 }, .{ 0.0, 1.0 } };
+        obj.bias = .{ 0.0, 0.0 };
+    }
+    return @as(?*c.PyObject, @ptrCast(self));
+}
+
+fn affine_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
+    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+
+    var from_points_obj: ?*c.PyObject = null;
+    var to_points_obj: ?*c.PyObject = null;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("from_points"), @constCast("to_points"), null };
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|OO", @ptrCast(&kwlist), &from_points_obj, &to_points_obj) == 0) {
+        return -1;
+    }
+
+    // If no arguments, keep identity transform
+    if (from_points_obj == null or to_points_obj == null) {
+        return 0;
+    }
+
+    // Parse point lists
+    const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(from_points);
+
+    const to_points = py_utils.parsePointList(f64, to_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(to_points);
+
+    // Check we have same number of points
+    if (from_points.len != to_points.len) {
+        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        return -1;
+    }
+
+    // Check we have at least 3 points
+    if (from_points.len < 3) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 3 point correspondences for affine transform");
+        return -1;
+    }
+
+    // Create and fit the transform
+    const transform = AffineTransform(f64).init(allocator, from_points, to_points) catch {
+        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to compute affine transform");
+        return -1;
+    };
+
+    // Store matrix components
+    self.matrix[0][0] = transform.matrix.at(0, 0).*;
+    self.matrix[0][1] = transform.matrix.at(0, 1).*;
+    self.matrix[1][0] = transform.matrix.at(1, 0).*;
+    self.matrix[1][1] = transform.matrix.at(1, 1).*;
+    self.bias[0] = transform.bias.at(0, 0).*;
+    self.bias[1] = transform.bias.at(1, 0).*;
+
+    return 0;
+}
+
+fn affine_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
+    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+}
+
+fn affine_project(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+
+    var point_obj: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "O", &point_obj) == 0) return null;
+
+    // Check if it's a single tuple (x, y)
+    if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {
+        // Single point - return single tuple
+        const point = py_utils.parsePointTuple(f64, point_obj) catch return null;
+
+        // Apply transform: new = matrix * point + bias
+        const new_x = self.matrix[0][0] * point.x() + self.matrix[0][1] * point.y() + self.bias[0];
+        const new_y = self.matrix[1][0] * point.x() + self.matrix[1][1] * point.y() + self.bias[1];
+
+        return c.PyTuple_Pack(2, c.PyFloat_FromDouble(new_x), c.PyFloat_FromDouble(new_y));
+    } else if (c.PySequence_Check(point_obj) != 0) {
+        // List/sequence of points - return list of tuples
+        const points = py_utils.parsePointList(f64, point_obj) catch return null;
+        defer allocator.free(points);
+
+        const result_list = c.PyList_New(@intCast(points.len)) orelse return null;
+
+        for (points, 0..) |point, i| {
+            const new_x = self.matrix[0][0] * point.x() + self.matrix[0][1] * point.y() + self.bias[0];
+            const new_y = self.matrix[1][0] * point.x() + self.matrix[1][1] * point.y() + self.bias[1];
+
+            const tuple = c.PyTuple_Pack(2, c.PyFloat_FromDouble(new_x), c.PyFloat_FromDouble(new_y)) orelse {
+                c.Py_DECREF(result_list);
+                return null;
+            };
+
+            // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+            // PyList_SET_ITEM is a macro that doesn't translate properly in Python 3.10
+            _ = c.PyList_SetItem(result_list, @intCast(i), tuple);
+        }
+
+        return result_list;
+    } else {
+        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        return null;
+    }
+}
+
+fn affine_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+
+    var buffer: [512]u8 = undefined;
+    const str = std.fmt.bufPrintZ(&buffer, "AffineTransform(matrix=[[{d:.6}, {d:.6}], [{d:.6}, {d:.6}]], bias=({d:.6}, {d:.6}))", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[1][0], self.matrix[1][1], self.bias[0], self.bias[1] }) catch return null;
+
+    return c.PyUnicode_FromString(str.ptr);
+}
+
+// Property getters for matrix and bias
+fn affine_get_matrix(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+
+    // Create a 2x2 nested list
+    const row0 = c.PyList_New(2) orelse return null;
+    const row1 = c.PyList_New(2) orelse return null;
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 0, c.PyFloat_FromDouble(self.matrix[0][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 1, c.PyFloat_FromDouble(self.matrix[0][1]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 0, c.PyFloat_FromDouble(self.matrix[1][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 1, c.PyFloat_FromDouble(self.matrix[1][1]));
+
+    const matrix = c.PyList_New(2) orelse {
+        c.Py_DECREF(row0);
+        c.Py_DECREF(row1);
+        return null;
+    };
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 0, row0);
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 1, row1);
+
+    return matrix;
+}
+
+fn affine_get_bias(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+    return c.PyTuple_Pack(2, c.PyFloat_FromDouble(self.bias[0]), c.PyFloat_FromDouble(self.bias[1]));
+}
+
+var affine_methods = [_]c.PyMethodDef{
+    .{ .ml_name = "project", .ml_meth = @ptrCast(&affine_project), .ml_flags = c.METH_VARARGS, .ml_doc = "Transform point(s). Accepts (x,y) tuple or list of tuples." },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
+};
+
+var affine_getset = [_]c.PyGetSetDef{
+    .{ .name = "matrix", .get = affine_get_matrix, .set = null, .doc = "2x2 transformation matrix", .closure = null },
+    .{ .name = "bias", .get = affine_get_bias, .set = null, .doc = "Translation vector (x, y)", .closure = null },
+    .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
+};
+
+pub var AffineTransformType = c.PyTypeObject{
+    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
+    .tp_name = "zignal.AffineTransform",
+    .tp_basicsize = @sizeOf(AffineTransformObject),
+    .tp_dealloc = affine_dealloc,
+    .tp_repr = affine_repr,
+    .tp_flags = c.Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Affine transform (general 2D linear transform)",
+    .tp_methods = &affine_methods,
+    .tp_getset = &affine_getset,
+    .tp_init = affine_init,
+    .tp_new = affine_new,
+};
+
+// ============================================================================
+// PROJECTIVE TRANSFORM
+// ============================================================================
+
+pub const ProjectiveTransformObject = extern struct {
+    ob_base: c.PyObject,
+    // Store 3x3 homogeneous matrix as array
+    matrix: [3][3]f64,
+};
+
+fn projective_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    _ = kwds;
+
+    const self = @as(?*ProjectiveTransformObject, @ptrCast(c.PyType_GenericAlloc(type_obj, 0)));
+    if (self) |obj| {
+        // Initialize as identity transform
+        obj.matrix = .{
+            .{ 1.0, 0.0, 0.0 },
+            .{ 0.0, 1.0, 0.0 },
+            .{ 0.0, 0.0, 1.0 },
+        };
+    }
+    return @as(?*c.PyObject, @ptrCast(self));
+}
+
+fn projective_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
+    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+
+    var from_points_obj: ?*c.PyObject = null;
+    var to_points_obj: ?*c.PyObject = null;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("from_points"), @constCast("to_points"), null };
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|OO", @ptrCast(&kwlist), &from_points_obj, &to_points_obj) == 0) {
+        return -1;
+    }
+
+    // If no arguments, keep identity transform
+    if (from_points_obj == null or to_points_obj == null) {
+        return 0;
+    }
+
+    // Parse point lists
+    const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(from_points);
+
+    const to_points = py_utils.parsePointList(f64, to_points_obj) catch {
+        return -1;
+    };
+    defer allocator.free(to_points);
+
+    // Check we have same number of points
+    if (from_points.len != to_points.len) {
+        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        return -1;
+    }
+
+    // Check we have at least 4 points
+    if (from_points.len < 4) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 4 point correspondences for projective transform");
+        return -1;
+    }
+
+    // Create and fit the transform
+    const transform = ProjectiveTransform(f64).init(from_points, to_points);
+
+    // Store matrix components
+    for (0..3) |i| {
+        for (0..3) |j| {
+            self.matrix[i][j] = transform.matrix.at(i, j).*;
+        }
+    }
+
+    return 0;
+}
+
+fn projective_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
+    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+}
+
+fn projective_project(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+
+    var point_obj: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "O", &point_obj) == 0) return null;
+
+    // Check if it's a single tuple (x, y)
+    if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {
+        // Single point - return single tuple
+        const point = py_utils.parsePointTuple(f64, point_obj) catch return null;
+
+        // Apply projective transform: [x', y', w'] = matrix * [x, y, 1]
+        const x = point.x();
+        const y = point.y();
+        const new_x = self.matrix[0][0] * x + self.matrix[0][1] * y + self.matrix[0][2];
+        const new_y = self.matrix[1][0] * x + self.matrix[1][1] * y + self.matrix[1][2];
+        const w = self.matrix[2][0] * x + self.matrix[2][1] * y + self.matrix[2][2];
+
+        // Normalize by w
+        const result_x = if (w != 0) new_x / w else new_x;
+        const result_y = if (w != 0) new_y / w else new_y;
+
+        return c.PyTuple_Pack(2, c.PyFloat_FromDouble(result_x), c.PyFloat_FromDouble(result_y));
+    } else if (c.PySequence_Check(point_obj) != 0) {
+        // List/sequence of points - return list of tuples
+        const points = py_utils.parsePointList(f64, point_obj) catch return null;
+        defer allocator.free(points);
+
+        const result_list = c.PyList_New(@intCast(points.len)) orelse return null;
+
+        for (points, 0..) |point, i| {
+            const x = point.x();
+            const y = point.y();
+            const new_x = self.matrix[0][0] * x + self.matrix[0][1] * y + self.matrix[0][2];
+            const new_y = self.matrix[1][0] * x + self.matrix[1][1] * y + self.matrix[1][2];
+            const w = self.matrix[2][0] * x + self.matrix[2][1] * y + self.matrix[2][2];
+
+            // Normalize by w
+            const result_x = if (w != 0) new_x / w else new_x;
+            const result_y = if (w != 0) new_y / w else new_y;
+
+            const tuple = c.PyTuple_Pack(2, c.PyFloat_FromDouble(result_x), c.PyFloat_FromDouble(result_y)) orelse {
+                c.Py_DECREF(result_list);
+                return null;
+            };
+
+            // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+            // PyList_SET_ITEM is a macro that doesn't translate properly in Python 3.10
+            _ = c.PyList_SetItem(result_list, @intCast(i), tuple);
+        }
+
+        return result_list;
+    } else {
+        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        return null;
+    }
+}
+
+fn projective_inverse(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+
+    // Reconstruct the matrix from components
+    const matrix = zignal.SMatrix(f64, 3, 3).init(.{
+        .{ self.matrix[0][0], self.matrix[0][1], self.matrix[0][2] },
+        .{ self.matrix[1][0], self.matrix[1][1], self.matrix[1][2] },
+        .{ self.matrix[2][0], self.matrix[2][1], self.matrix[2][2] },
+    });
+
+    // Compute inverse
+    const transform = ProjectiveTransform(f64){ .matrix = matrix };
+    const inverse_transform = transform.inverse() orelse {
+        const none = c.Py_None();
+        c.Py_INCREF(none);
+        return none;
+    };
+
+    // Create new ProjectiveTransform object
+    const py_obj = c.PyType_GenericAlloc(@ptrCast(&ProjectiveTransformType), 0) orelse return null;
+    const result = @as(*ProjectiveTransformObject, @ptrCast(py_obj));
+
+    // Copy inverse matrix components
+    for (0..3) |i| {
+        for (0..3) |j| {
+            result.matrix[i][j] = inverse_transform.matrix.at(i, j).*;
+        }
+    }
+
+    return py_obj;
+}
+
+fn projective_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+
+    var buffer: [1024]u8 = undefined;
+    const str = std.fmt.bufPrintZ(&buffer, "ProjectiveTransform(matrix=[[{d:.6}, {d:.6}, {d:.6}], [{d:.6}, {d:.6}, {d:.6}], [{d:.6}, {d:.6}, {d:.6}]])", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[0][2], self.matrix[1][0], self.matrix[1][1], self.matrix[1][2], self.matrix[2][0], self.matrix[2][1], self.matrix[2][2] }) catch return null;
+
+    return c.PyUnicode_FromString(str.ptr);
+}
+
+// Property getter for matrix
+fn projective_get_matrix(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+
+    // Create a 3x3 nested list
+    const row0 = c.PyList_New(3) orelse return null;
+    const row1 = c.PyList_New(3) orelse return null;
+    const row2 = c.PyList_New(3) orelse return null;
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 0, c.PyFloat_FromDouble(self.matrix[0][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 1, c.PyFloat_FromDouble(self.matrix[0][1]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row0, 2, c.PyFloat_FromDouble(self.matrix[0][2]));
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 0, c.PyFloat_FromDouble(self.matrix[1][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 1, c.PyFloat_FromDouble(self.matrix[1][1]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row1, 2, c.PyFloat_FromDouble(self.matrix[1][2]));
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row2, 0, c.PyFloat_FromDouble(self.matrix[2][0]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row2, 1, c.PyFloat_FromDouble(self.matrix[2][1]));
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(row2, 2, c.PyFloat_FromDouble(self.matrix[2][2]));
+
+    const matrix = c.PyList_New(3) orelse {
+        c.Py_DECREF(row0);
+        c.Py_DECREF(row1);
+        c.Py_DECREF(row2);
+        return null;
+    };
+
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 0, row0);
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 1, row1);
+    // TODO: Use PyList_SET_ITEM once we drop Python 3.10 support
+    _ = c.PyList_SetItem(matrix, 2, row2);
+
+    return matrix;
+}
+
+var projective_methods = [_]c.PyMethodDef{
+    .{ .ml_name = "project", .ml_meth = @ptrCast(&projective_project), .ml_flags = c.METH_VARARGS, .ml_doc = "Transform point(s). Accepts (x,y) tuple or list of tuples." },
+    .{ .ml_name = "inverse", .ml_meth = @ptrCast(&projective_inverse), .ml_flags = c.METH_NOARGS, .ml_doc = "Get inverse transform, or None if not invertible." },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
+};
+
+var projective_getset = [_]c.PyGetSetDef{
+    .{ .name = "matrix", .get = projective_get_matrix, .set = null, .doc = "3x3 homogeneous transformation matrix", .closure = null },
+    .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
+};
+
+pub var ProjectiveTransformType = c.PyTypeObject{
+    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
+    .tp_name = "zignal.ProjectiveTransform",
+    .tp_basicsize = @sizeOf(ProjectiveTransformObject),
+    .tp_dealloc = projective_dealloc,
+    .tp_repr = projective_repr,
+    .tp_flags = c.Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Projective transform (homography/perspective transform)",
+    .tp_methods = &projective_methods,
+    .tp_getset = &projective_getset,
+    .tp_init = projective_init,
+    .tp_new = projective_new,
+};
+
+// ============================================================================
+// STUB GENERATION METADATA
+// ============================================================================
+
+pub const similarity_methods_metadata = [_]stub_metadata.MethodInfo{
+    .{
+        .name = "__init__",
+        .params = "self, from_points: list[tuple[float, float]] | None = None, to_points: list[tuple[float, float]] | None = None",
+        .returns = "None",
+        .doc = "Create similarity transform from point correspondences. If no points provided, creates identity transform.",
+    },
+    .{
+        .name = "project",
+        .params = "self, points: tuple[float, float] | list[tuple[float, float]]",
+        .returns = "tuple[float, float] | list[tuple[float, float]]",
+        .doc = "Transform point(s). Returns same type as input.",
+    },
+};
+
+pub const similarity_properties_metadata = [_]stub_metadata.PropertyInfo{
+    .{
+        .name = "matrix",
+        .type = "list[list[float]]",
+        .doc = "2x2 transformation matrix",
+    },
+    .{
+        .name = "bias",
+        .type = "tuple[float, float]",
+        .doc = "Translation vector (x, y)",
+    },
+};
+
+pub const affine_methods_metadata = [_]stub_metadata.MethodInfo{
+    .{
+        .name = "__init__",
+        .params = "self, from_points: list[tuple[float, float]] | None = None, to_points: list[tuple[float, float]] | None = None",
+        .returns = "None",
+        .doc = "Create affine transform from point correspondences. If no points provided, creates identity transform.",
+    },
+    .{
+        .name = "project",
+        .params = "self, points: tuple[float, float] | list[tuple[float, float]]",
+        .returns = "tuple[float, float] | list[tuple[float, float]]",
+        .doc = "Transform point(s). Returns same type as input.",
+    },
+};
+
+pub const affine_properties_metadata = [_]stub_metadata.PropertyInfo{
+    .{
+        .name = "matrix",
+        .type = "list[list[float]]",
+        .doc = "2x2 transformation matrix",
+    },
+    .{
+        .name = "bias",
+        .type = "tuple[float, float]",
+        .doc = "Translation vector (x, y)",
+    },
+};
+
+pub const projective_methods_metadata = [_]stub_metadata.MethodInfo{
+    .{
+        .name = "__init__",
+        .params = "self, from_points: list[tuple[float, float]] | None = None, to_points: list[tuple[float, float]] | None = None",
+        .returns = "None",
+        .doc = "Create projective transform from point correspondences. If no points provided, creates identity transform.",
+    },
+    .{
+        .name = "project",
+        .params = "self, points: tuple[float, float] | list[tuple[float, float]]",
+        .returns = "tuple[float, float] | list[tuple[float, float]]",
+        .doc = "Transform point(s). Returns same type as input.",
+    },
+    .{
+        .name = "inverse",
+        .params = "self",
+        .returns = "ProjectiveTransform | None",
+        .doc = "Get inverse transform, or None if not invertible.",
+    },
+};
+
+pub const projective_properties_metadata = [_]stub_metadata.PropertyInfo{
+    .{
+        .name = "matrix",
+        .type = "list[list[float]]",
+        .doc = "3x3 homogeneous transformation matrix",
+    },
+};

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -139,6 +139,39 @@ class TestImageSmoke:
         assert isinstance(rgb, zignal.Rgb)
         assert rgb.r == 255
 
+    def test_warp_smoke(self):
+        """Test image warp API exists and is callable."""
+        img = zignal.Image(10, 10)
+
+        # Can warp with similarity
+        sim = zignal.SimilarityTransform([(2, 2), (8, 2)], [(3, 3), (7, 3)])
+        warped = img.warp(sim)
+        assert warped is not None
+
+        # Can warp with affine
+        aff = zignal.AffineTransform([(2, 2), (8, 2), (5, 8)], [(3, 3), (7, 3), (5, 7)])
+        warped = img.warp(aff)
+        assert warped is not None
+
+        # Can warp with projective
+        proj = zignal.ProjectiveTransform(
+            [(1, 1), (9, 1), (9, 9), (1, 9)], [(2, 2), (8, 1), (9, 8), (1, 9)]
+        )
+        warped = img.warp(proj)
+        assert warped is not None
+
+        # Can warp with options
+        warped = img.warp(sim, shape=(20, 20))
+        assert warped is not None
+
+        warped = img.warp(sim, method=zignal.Interpolation.NEAREST_NEIGHBOR)
+        assert warped is not None
+
+        # Works with different image types
+        gray = img.convert(zignal.Grayscale)
+        warped = gray.warp(sim)
+        assert warped is not None
+
     def test_motion_blur_smoke(self):
         """Test motion blur API basics"""
         # Create test image

--- a/bindings/python/tests/test_transforms.py
+++ b/bindings/python/tests/test_transforms.py
@@ -1,0 +1,80 @@
+"""Smoke tests for geometric transforms API.
+
+Focus on API surface - methods exist and can be called.
+"""
+
+import pytest
+import zignal
+
+
+class TestTransformsSmoke:
+    """Smoke tests for transform API - just verify methods exist and are callable."""
+
+    def test_similarity_transform_smoke(self):
+        """Test SimilarityTransform API exists."""
+        # Can construct
+        transform = zignal.SimilarityTransform([(0, 0), (10, 0)], [(5, 5), (15, 5)])
+
+        # Can project single point
+        result = transform.project((5, 0))
+        assert result is not None
+
+        # Can project list
+        results = transform.project([(0, 0), (5, 5)])
+        assert results is not None
+
+    def test_affine_transform_smoke(self):
+        """Test AffineTransform API exists."""
+        # Can construct
+        transform = zignal.AffineTransform([(0, 0), (10, 0), (0, 10)], [(1, 1), (11, 2), (2, 11)])
+
+        # Can project
+        result = transform.project((5, 5))
+        assert result is not None
+
+        # Can project list
+        results = transform.project([(0, 0), (5, 5)])
+        assert results is not None
+
+    def test_projective_transform_smoke(self):
+        """Test ProjectiveTransform API exists."""
+        # Can construct
+        transform = zignal.ProjectiveTransform(
+            [(0, 0), (10, 0), (10, 10), (0, 10)], [(1, 1), (9, 2), (8, 8), (2, 9)]
+        )
+
+        # Can project
+        result = transform.project((5, 5))
+        assert result is not None
+
+        # Can project list
+        results = transform.project([(2, 2), (8, 8)])
+        assert results is not None
+
+    def test_transform_with_warp(self):
+        """Test transforms work with Image.warp()."""
+        img = zignal.Image(10, 10)
+
+        # Similarity with warp
+        sim = zignal.SimilarityTransform([(2, 2), (8, 2)], [(3, 3), (7, 3)])
+        warped = img.warp(sim)
+        assert warped is not None
+
+        # Affine with warp
+        aff = zignal.AffineTransform([(0, 0), (10, 0), (0, 10)], [(1, 1), (9, 1), (1, 9)])
+        warped = img.warp(aff)
+        assert warped is not None
+
+        # Projective with warp
+        proj = zignal.ProjectiveTransform(
+            [(0, 0), (10, 0), (10, 10), (0, 10)], [(1, 1), (9, 1), (9, 9), (1, 9)]
+        )
+        warped = img.warp(proj)
+        assert warped is not None
+
+        # With options
+        warped = img.warp(sim, shape=(20, 20))
+        assert warped is not None
+
+        warped = img.warp(sim, method=zignal.Interpolation.BICUBIC)
+        assert warped is not None

--- a/src/geometry/Rectangle.zig
+++ b/src/geometry/Rectangle.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 const expectEqual = std.testing.expectEqual;
 const expectEqualDeep = std.testing.expectEqualDeep;
 
-const as = @import("../meta.zig").as;
+const meta = @import("../meta.zig");
 
 /// A generic rectangle object with some convenience functionality.
 pub fn Rectangle(comptime T: type) type {
@@ -47,12 +47,12 @@ pub fn Rectangle(comptime T: type) type {
         }
 
         /// Casts self's underlying type to U.
-        pub fn cast(self: Self, comptime U: type) Rectangle(U) {
+        pub fn as(self: Self, comptime U: type) Rectangle(U) {
             return .{
-                .l = as(U, self.l),
-                .t = as(U, self.t),
-                .r = as(U, self.r),
-                .b = as(U, self.b),
+                .l = meta.as(U, self.l),
+                .t = meta.as(U, self.t),
+                .r = meta.as(U, self.r),
+                .b = meta.as(U, self.b),
             };
         }
 
@@ -160,7 +160,7 @@ test "Rectangle" {
     try expectEqual(frect.height(), 480);
     try expectEqual(frect.contains(320, 240), true);
     try expectEqual(irect.contains(640, 480), false);
-    try expectEqualDeep(frect.cast(isize), irect);
+    try expectEqualDeep(frect.as(isize), irect);
 }
 
 test "Rectangle grow and shrink" {

--- a/src/image.zig
+++ b/src/image.zig
@@ -435,6 +435,31 @@ pub fn Image(comptime T: type) type {
             return Transform(T).insert(self, source, rect, angle, method);
         }
 
+        /// Applies a geometric transform to the image using the specified interpolation method.
+        ///
+        /// This method warps an image using a geometric transform (Similarity, Affine, or Projective).
+        /// For each pixel in the output image, it applies the transform to find the corresponding
+        /// location in the source image and samples using the specified interpolation method.
+        ///
+        /// Parameters:
+        /// - `allocator`: The allocator to use for the output image.
+        /// - `transform`: A geometric transform object (SimilarityTransform, AffineTransform, or ProjectiveTransform).
+        /// - `method`: Interpolation method for sampling pixels.
+        /// - `out`: Output image. If empty, will be allocated with specified dimensions.
+        /// - `out_rows`: Number of rows in the output image.
+        /// - `out_cols`: Number of columns in the output image.
+        ///
+        /// Example usage:
+        /// ```zig
+        /// const transform = SimilarityTransform(f32).init(from_points, to_points);
+        /// var warped: Image(T) = .empty;
+        /// try image.warp(allocator, transform, .bilinear, &warped, 512, 512);
+        /// defer warped.deinit(allocator);
+        /// ```
+        pub fn warp(self: Self, allocator: Allocator, transform: anytype, method: @import("image/interpolation.zig").Interpolation, out: *Self, out_rows: usize, out_cols: usize) !void {
+            return Transform(T).warp(self, allocator, transform, method, out, out_rows, out_cols);
+        }
+
         /// Computes the integral image, also known as a summed-area table (SAT), of `self`.
         /// For multi-channel images (e.g., structs like `Rgba`), it computes a per-channel
         /// integral image, storing the result as an array of floats per pixel in the output `integral` image.


### PR DESCRIPTION
Exposes SimilarityTransform, AffineTransform, and ProjectiveTransform classes to the Python bindings.

Refactors geometry parsing utilities to be generic over float types. Python Rectangle objects now store coordinates as f64 for higher precision, while canvas drawing operations explicitly parse geometry inputs as f32.