### PR TITLE
feat(python): allow tuple for view rect parameter

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -2588,20 +2588,21 @@ const image_view_doc =
     \\are reflected in both. This is a zero-copy operation.
     \\
     \\## Parameters
-    \\- `rect` (`Rectangle | None`, optional): The rectangular region to view. If omitted or `None`, returns a view of the full image.
+    \\- `rect` (`Rectangle | tuple[float, float, float, float] | None`, optional): The rectangular region to view.
+    \\  Can be a Rectangle object or a tuple of (left, top, right, bottom).
+    \\  If omitted or `None`, returns a view of the full image.
     \\
     \\## Examples
     \\```python
-    \\# Create a view of the top-left quadrant
+    \\# Create a view using a Rectangle object
     \\rect = Rectangle(0, 0, img.cols // 2, img.rows // 2)
     \\view = img.view(rect)
     \\
+    \\# Create a view using a tuple (left, top, right, bottom)
+    \\view = img.view((0, 0, img.cols // 2, img.rows // 2))
+    \\
     \\# Modifications to the view affect the parent
     \\view.fill((255, 0, 0))  # Fills the top-left quadrant with red
-    \\
-    \\# Check if an image is a view
-    \\print(view.is_view)  # True
-    \\print(img.is_view)   # False (unless img itself is a view)
     \\```
     \\
     \\## Notes
@@ -3665,7 +3666,7 @@ pub const image_methods_metadata = [_]stub_metadata.MethodWithMetadata{
         .meth = @ptrCast(&image_view),
         .flags = c.METH_VARARGS,
         .doc = image_view_doc,
-        .params = "self, rect: Rectangle | None = None",
+        .params = "self, rect: Rectangle | tuple[float, float, float, float] | None = None",
         .returns = "Image",
     },
     .{

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -42,6 +42,13 @@ class TestImageSmoke:
         arr = img.to_numpy()
         assert (arr[1, 1] == np.array([5, 6, 7, 255], dtype=np.uint8)).all()
 
+    def test_view_with_tuple(self):
+        """Test that view() accepts tuple input"""
+        img = zignal.Image(4, 4, (0, 0, 0, 0), dtype=zignal.Rgba)
+        # Create view using tuple (left, top, right, bottom)
+        v = img.view((1, 1, 3, 3))
+        assert (v.rows, v.cols) == (2, 2)
+
     def test_numpy_roundtrip_and_validation(self):
         # Round‑trip
         img = zignal.Image(2, 3, (1, 2, 3), dtype=zignal.Rgb)


### PR DESCRIPTION
The `image.view` method now accepts a tuple `(left, top, right, bottom)` to define the rectangular region, in addition to the existing `Rectangle` object.