### PR TITLE
refactor(python): unify motion blur classes

### DIFF
--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -301,42 +301,18 @@ fn generateModuleFunctionsFromMetadata(stub: *GeneratedStub, functions: []const 
     }
 }
 
-/// Generate flat motion blur classes from metadata
+/// Generate unified MotionBlur class from metadata
 fn generateMotionBlurClasses(stub: *GeneratedStub) !void {
-    // Generate MotionBlurLinear class from metadata
-    const linear_properties = stub_metadata.extractPropertyInfo(&motion_blur_module.linear_properties_metadata);
-    const linear_doc = std.mem.span(motion_blur_module.LinearType.tp_doc);
+    // Generate unified MotionBlur class from metadata
+    const properties = stub_metadata.extractPropertyInfo(&motion_blur_module.motion_blur_properties_metadata);
+    const doc = std.mem.span(motion_blur_module.MotionBlurType.tp_doc);
     try generateClassFromMetadata(stub, .{
-        .name = "MotionBlurLinear",
-        .doc = linear_doc,
-        .methods = &[_]stub_metadata.MethodInfo{},
-        .properties = &linear_properties,
+        .name = "MotionBlur",
+        .doc = doc,
+        .methods = &motion_blur_module.motion_blur_methods_metadata,
+        .properties = &properties,
         .bases = &.{},
-        .special_methods = &motion_blur_module.linear_special_methods_metadata,
-    });
-
-    // Generate MotionBlurZoom class from metadata
-    const zoom_properties = stub_metadata.extractPropertyInfo(&motion_blur_module.zoom_properties_metadata);
-    const zoom_doc = std.mem.span(motion_blur_module.ZoomType.tp_doc);
-    try generateClassFromMetadata(stub, .{
-        .name = "MotionBlurZoom",
-        .doc = zoom_doc,
-        .methods = &[_]stub_metadata.MethodInfo{},
-        .properties = &zoom_properties,
-        .bases = &.{},
-        .special_methods = &motion_blur_module.zoom_special_methods_metadata,
-    });
-
-    // Generate MotionBlurSpin class from metadata
-    const spin_properties = stub_metadata.extractPropertyInfo(&motion_blur_module.spin_properties_metadata);
-    const spin_doc = std.mem.span(motion_blur_module.SpinType.tp_doc);
-    try generateClassFromMetadata(stub, .{
-        .name = "MotionBlurSpin",
-        .doc = spin_doc,
-        .methods = &[_]stub_metadata.MethodInfo{},
-        .properties = &spin_properties,
-        .bases = &.{},
-        .special_methods = &motion_blur_module.spin_special_methods_metadata,
+        .special_methods = &motion_blur_module.motion_blur_special_methods_metadata,
     });
 }
 
@@ -358,7 +334,7 @@ fn generateStubFile(gpa: std.mem.Allocator) ![]u8 {
         \\from __future__ import annotations
         \\
         \\from enum import IntEnum
-        \\from typing import TypeAlias
+        \\from typing import Literal, TypeAlias
         \\
         \\import numpy as np
         \\from numpy.typing import NDArray

--- a/bindings/python/src/motion_blur.zig
+++ b/bindings/python/src/motion_blur.zig
@@ -6,419 +6,451 @@ const c = py_utils.c;
 const stub_metadata = @import("stub_metadata.zig");
 
 // ============================================================================
-// Motion Blur Configuration Classes
+// Motion Blur Type Enum
 // ============================================================================
 
-// MotionBlurLinear configuration object
-pub const LinearObject = extern struct {
+const MotionBlurVariant = enum(u8) {
+    linear,
+    radial_zoom,
+    radial_spin,
+};
+
+// ============================================================================
+// Unified MotionBlur Object
+// ============================================================================
+
+pub const MotionBlurObject = extern struct {
     ob_base: c.PyObject,
+    blur_type: MotionBlurVariant,
+
+    // Linear parameters
     angle: f64,
     distance: c_long,
-};
 
-// MotionBlurZoom configuration object
-pub const RadialZoomObject = extern struct {
-    ob_base: c.PyObject,
-    center_x: f64,
-    center_y: f64,
-    strength: f64,
-};
-
-// MotionBlurSpin configuration object
-pub const RadialSpinObject = extern struct {
-    ob_base: c.PyObject,
+    // Radial parameters (shared by zoom and spin)
     center_x: f64,
     center_y: f64,
     strength: f64,
 };
 
 // ============================================================================
-// MotionBlurLinear Implementation
+// MotionBlur Implementation
 // ============================================================================
 
-fn linear_dealloc(self: [*c]c.PyObject) callconv(.c) void {
+fn motion_blur_dealloc(self: [*c]c.PyObject) callconv(.c) void {
     c.Py_TYPE(self).*.tp_free.?(self);
 }
 
-fn linear_new(type_obj: [*c]c.PyTypeObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
+fn motion_blur_new(type_obj: [*c]c.PyTypeObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
     _ = args;
     _ = kwds;
 
-    const self = @as(?*LinearObject, @ptrCast(type_obj.*.tp_alloc.?(type_obj, 0)));
+    const self = @as(?*MotionBlurObject, @ptrCast(type_obj.*.tp_alloc.?(type_obj, 0)));
     if (self) |obj| {
+        // Initialize with defaults
+        obj.blur_type = .linear;
         obj.angle = 0.0;
         obj.distance = 0;
+        obj.center_x = 0.5;
+        obj.center_y = 0.5;
+        obj.strength = 0.5;
     }
     return @ptrCast(self);
 }
 
-fn linear_init(self_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) c_int {
-    const self = @as(*LinearObject, @ptrCast(self_obj));
+fn motion_blur_init(self_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) c_int {
+    _ = self_obj;
+    _ = args;
+    _ = kwds;
+    // This should not be called directly - factory methods handle initialization
+    c.PyErr_SetString(c.PyExc_TypeError, "MotionBlur cannot be instantiated directly. Use MotionBlur.linear(), MotionBlur.radial_zoom(), or MotionBlur.radial_spin()");
+    return -1;
+}
+
+fn motion_blur_repr(self_obj: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj));
+    var buf: [256]u8 = undefined;
+
+    const str = switch (self.blur_type) {
+        .linear => std.fmt.bufPrintZ(
+            &buf,
+            "MotionBlur.linear(angle={d:.4}, distance={d})",
+            .{ self.angle, self.distance },
+        ) catch return null,
+        .radial_zoom => std.fmt.bufPrintZ(
+            &buf,
+            "MotionBlur.radial_zoom(center=({d:.3}, {d:.3}), strength={d:.3})",
+            .{ self.center_x, self.center_y, self.strength },
+        ) catch return null,
+        .radial_spin => std.fmt.bufPrintZ(
+            &buf,
+            "MotionBlur.radial_spin(center=({d:.3}, {d:.3}), strength={d:.3})",
+            .{ self.center_x, self.center_y, self.strength },
+        ) catch return null,
+    };
+
+    return @ptrCast(c.PyUnicode_FromString(str));
+}
+
+// ============================================================================
+// Static Factory Methods
+// ============================================================================
+
+fn motion_blur_linear(type_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
+    _ = type_obj;
 
     var angle: f64 = 0.0;
     var distance: c_long = 0;
 
     var kwlist = [_:null]?[*:0]u8{ @constCast("angle"), @constCast("distance"), null };
     if (c.PyArg_ParseTupleAndKeywords(args, kwds, "dl", @ptrCast(&kwlist), &angle, &distance) == 0) {
-        return -1;
+        return null;
     }
 
     if (distance < 0) {
         c.PyErr_SetString(c.PyExc_ValueError, "distance must be non-negative");
-        return -1;
+        return null;
     }
 
-    self.angle = angle;
-    self.distance = distance;
+    // Create new instance
+    const self = @as(?*MotionBlurObject, @ptrCast(MotionBlurType.tp_alloc.?(&MotionBlurType, 0)));
+    if (self) |obj| {
+        obj.blur_type = .linear;
+        obj.angle = angle;
+        obj.distance = distance;
+        // Other fields keep their defaults
+        obj.center_x = 0.5;
+        obj.center_y = 0.5;
+        obj.strength = 0.5;
+    }
 
-    return 0;
+    return @ptrCast(self);
 }
 
-fn linear_repr(self_obj: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
-    const self = @as(*LinearObject, @ptrCast(self_obj));
-    var buf: [256]u8 = undefined;
-    const str = std.fmt.bufPrintZ(
-        &buf,
-        "MotionBlurLinear(angle={d:.4}, distance={d})",
-        .{ self.angle, self.distance },
-    ) catch return null;
+fn motion_blur_radial_zoom(type_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
+    _ = type_obj;
 
-    return @ptrCast(c.PyUnicode_FromString(str));
+    var center_tuple: [*c]c.PyObject = null;
+    var strength: f64 = 0.5;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("center"), @constCast("strength"), null };
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|Od", @ptrCast(&kwlist), &center_tuple, &strength) == 0) {
+        return null;
+    }
+
+    var center_x: f64 = 0.5;
+    var center_y: f64 = 0.5;
+
+    // Parse center tuple if provided
+    if (center_tuple != null) {
+        if (c.PyArg_ParseTuple(center_tuple, "dd", &center_x, &center_y) == 0) {
+            c.PyErr_SetString(c.PyExc_TypeError, "center must be a tuple of two floats");
+            return null;
+        }
+
+        if (center_x < 0.0 or center_x > 1.0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "center[0] must be between 0.0 and 1.0");
+            return null;
+        }
+        if (center_y < 0.0 or center_y > 1.0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "center[1] must be between 0.0 and 1.0");
+            return null;
+        }
+    }
+
+    if (strength < 0.0 or strength > 1.0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "strength must be between 0.0 and 1.0");
+        return null;
+    }
+
+    // Create new instance
+    const self = @as(?*MotionBlurObject, @ptrCast(MotionBlurType.tp_alloc.?(&MotionBlurType, 0)));
+    if (self) |obj| {
+        obj.blur_type = .radial_zoom;
+        obj.center_x = center_x;
+        obj.center_y = center_y;
+        obj.strength = strength;
+        // Linear fields keep their defaults
+        obj.angle = 0.0;
+        obj.distance = 0;
+    }
+
+    return @ptrCast(self);
 }
 
-fn linear_get_angle(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+fn motion_blur_radial_spin(type_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
+    _ = type_obj;
+
+    var center_tuple: [*c]c.PyObject = null;
+    var strength: f64 = 0.5;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("center"), @constCast("strength"), null };
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|Od", @ptrCast(&kwlist), &center_tuple, &strength) == 0) {
+        return null;
+    }
+
+    var center_x: f64 = 0.5;
+    var center_y: f64 = 0.5;
+
+    // Parse center tuple if provided
+    if (center_tuple != null) {
+        if (c.PyArg_ParseTuple(center_tuple, "dd", &center_x, &center_y) == 0) {
+            c.PyErr_SetString(c.PyExc_TypeError, "center must be a tuple of two floats");
+            return null;
+        }
+
+        if (center_x < 0.0 or center_x > 1.0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "center[0] must be between 0.0 and 1.0");
+            return null;
+        }
+        if (center_y < 0.0 or center_y > 1.0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "center[1] must be between 0.0 and 1.0");
+            return null;
+        }
+    }
+
+    if (strength < 0.0 or strength > 1.0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "strength must be between 0.0 and 1.0");
+        return null;
+    }
+
+    // Create new instance
+    const self = @as(?*MotionBlurObject, @ptrCast(MotionBlurType.tp_alloc.?(&MotionBlurType, 0)));
+    if (self) |obj| {
+        obj.blur_type = .radial_spin;
+        obj.center_x = center_x;
+        obj.center_y = center_y;
+        obj.strength = strength;
+        // Linear fields keep their defaults
+        obj.angle = 0.0;
+        obj.distance = 0;
+    }
+
+    return @ptrCast(self);
+}
+
+// ============================================================================
+// Property Getters
+// ============================================================================
+
+fn get_type(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*LinearObject, @ptrCast(self_obj.?));
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj.?));
+    const type_str = switch (self.blur_type) {
+        .linear => "linear",
+        .radial_zoom => "radial_zoom",
+        .radial_spin => "radial_spin",
+    };
+    return c.PyUnicode_FromString(type_str);
+}
+
+fn get_angle(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj.?));
+    if (self.blur_type != .linear) {
+        return py_utils.getPyNone();
+    }
     return c.PyFloat_FromDouble(self.angle);
 }
 
-fn linear_get_distance(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+fn get_distance(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*LinearObject, @ptrCast(self_obj.?));
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj.?));
+    if (self.blur_type != .linear) {
+        return py_utils.getPyNone();
+    }
     return c.PyLong_FromLong(self.distance);
 }
 
-pub const linear_doc =
-    \\Linear motion blur configuration.
-    \\
-    \\Simulates straight-line motion blur effects such as camera shake or panning.
-    \\This type of blur is commonly seen when a camera moves in a straight line during exposure.
-    \\
-    \\## Parameters:
-    \\- `angle` (float): Blur angle in radians. 0 = horizontal, π/2 = vertical, π/4 = diagonal.
-    \\- `distance` (int): Blur distance in pixels. Larger values create stronger blur.
-;
-
-pub var LinearType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.MotionBlurLinear",
-    .tp_basicsize = @sizeOf(LinearObject),
-    .tp_dealloc = linear_dealloc,
-    .tp_repr = linear_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = linear_doc,
-    .tp_getset = &linear_getset,
-    .tp_init = linear_init,
-    .tp_new = linear_new,
-};
-
-// ============================================================================
-// MotionBlurZoom Implementation
-// ============================================================================
-
-fn zoom_dealloc(self: [*c]c.PyObject) callconv(.c) void {
-    c.Py_TYPE(self).*.tp_free.?(self);
-}
-
-fn zoom_new(type_obj: [*c]c.PyTypeObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
-    _ = args;
-    _ = kwds;
-
-    const self = @as(?*RadialZoomObject, @ptrCast(type_obj.*.tp_alloc.?(type_obj, 0)));
-    if (self) |obj| {
-        obj.center_x = 0.5;
-        obj.center_y = 0.5;
-        obj.strength = 0.5;
-    }
-    return @ptrCast(self);
-}
-
-fn zoom_init(self_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) c_int {
-    const self = @as(*RadialZoomObject, @ptrCast(self_obj));
-
-    var center_tuple: [*c]c.PyObject = null;
-    var strength: f64 = 0.5;
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("center"), @constCast("strength"), null };
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|Od", @ptrCast(&kwlist), &center_tuple, &strength) == 0) {
-        return -1;
-    }
-
-    // Parse center tuple if provided
-    if (center_tuple != null) {
-        var center_x: f64 = 0.5;
-        var center_y: f64 = 0.5;
-        if (c.PyArg_ParseTuple(center_tuple, "dd", &center_x, &center_y) == 0) {
-            c.PyErr_SetString(c.PyExc_TypeError, "center must be a tuple of two floats");
-            return -1;
-        }
-        self.center_x = center_x;
-        self.center_y = center_y;
-
-        // Validate parameters
-        if (self.center_x < 0.0 or self.center_x > 1.0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "center[0] must be between 0.0 and 1.0");
-            return -1;
-        }
-        if (self.center_y < 0.0 or self.center_y > 1.0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "center[1] must be between 0.0 and 1.0");
-            return -1;
-        }
-    } else {
-        self.center_x = 0.5;
-        self.center_y = 0.5;
-    }
-
-    if (strength < 0.0 or strength > 1.0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "strength must be between 0.0 and 1.0");
-        return -1;
-    }
-
-    self.strength = strength;
-
-    return 0;
-}
-
-fn zoom_repr(self_obj: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
-    const self = @as(*RadialZoomObject, @ptrCast(self_obj));
-    var buf: [256]u8 = undefined;
-    const str = std.fmt.bufPrintZ(
-        &buf,
-        "MotionBlurZoom(center=({d:.3}, {d:.3}), strength={d:.3})",
-        .{ self.center_x, self.center_y, self.strength },
-    ) catch return null;
-
-    return @ptrCast(c.PyUnicode_FromString(str));
-}
-
-fn zoom_get_center(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+fn get_center(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*RadialZoomObject, @ptrCast(self_obj.?));
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj.?));
+    if (self.blur_type == .linear) {
+        return py_utils.getPyNone();
+    }
     return c.Py_BuildValue("(dd)", self.center_x, self.center_y);
 }
 
-fn zoom_get_strength(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+fn get_strength(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*RadialZoomObject, @ptrCast(self_obj.?));
+    const self = @as(*MotionBlurObject, @ptrCast(self_obj.?));
+    if (self.blur_type == .linear) {
+        return py_utils.getPyNone();
+    }
     return c.PyFloat_FromDouble(self.strength);
 }
 
-pub const zoom_doc =
-    \\Motion blur zoom effect configuration.
+// ============================================================================
+// Type Definition
+// ============================================================================
+
+pub const motion_blur_doc =
+    \\Motion blur effect configuration.
     \\
-    \\Simulates zooming in or out from a center point, creating a "zoom burst" effect.
-    \\This effect radiates outward from the specified center point, similar to zooming
-    \\a camera lens during exposure.
+    \\Use the static factory methods to create motion blur configurations:
+    \\- `MotionBlur.linear(angle, distance)` - Linear motion blur
+    \\- `MotionBlur.radial_zoom(center, strength)` - Radial zoom blur
+    \\- `MotionBlur.radial_spin(center, strength)` - Radial spin blur
     \\
-    \\## Parameters:
-    \\- `center` (tuple[float, float]): Normalized center position (x, y) where both values are 0.0-1.0. Default is (0.5, 0.5).
-    \\- `strength` (float): Blur strength (0.0-1.0). Higher values create stronger zoom effect.
+    \\## Examples
+    \\```python
+    \\import math
+    \\from zignal import Image, MotionBlur
+    \\
+    \\img = Image.load("photo.jpg")
+    \\
+    \\# Linear motion blur
+    \\horizontal = img.motion_blur(MotionBlur.linear(angle=0, distance=30))
+    \\vertical = img.motion_blur(MotionBlur.linear(angle=math.pi/2, distance=20))
+    \\
+    \\# Radial zoom blur
+    \\zoom = img.motion_blur(MotionBlur.radial_zoom(center=(0.5, 0.5), strength=0.7))
+    \\zoom_default = img.motion_blur(MotionBlur.radial_zoom())  # Uses defaults
+    \\
+    \\# Radial spin blur
+    \\spin = img.motion_blur(MotionBlur.radial_spin(center=(0.3, 0.7), strength=0.5))
+    \\```
 ;
 
-pub var ZoomType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.MotionBlurZoom",
-    .tp_basicsize = @sizeOf(RadialZoomObject),
-    .tp_dealloc = zoom_dealloc,
-    .tp_repr = zoom_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = zoom_doc,
-    .tp_getset = &zoom_getset,
-    .tp_init = zoom_init,
-    .tp_new = zoom_new,
+var motion_blur_methods = [_]c.PyMethodDef{
+    .{
+        .ml_name = "linear",
+        .ml_meth = @ptrCast(&motion_blur_linear),
+        .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS | c.METH_STATIC,
+        .ml_doc = "Create linear motion blur configuration.\n\nArgs:\n    angle: Blur angle in radians (0 = horizontal)\n    distance: Blur distance in pixels",
+    },
+    .{
+        .ml_name = "radial_zoom",
+        .ml_meth = @ptrCast(&motion_blur_radial_zoom),
+        .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS | c.METH_STATIC,
+        .ml_doc = "Create radial zoom blur configuration.\n\nArgs:\n    center: Normalized center (x, y), default (0.5, 0.5)\n    strength: Blur strength (0.0-1.0), default 0.5",
+    },
+    .{
+        .ml_name = "radial_spin",
+        .ml_meth = @ptrCast(&motion_blur_radial_spin),
+        .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS | c.METH_STATIC,
+        .ml_doc = "Create radial spin blur configuration.\n\nArgs:\n    center: Normalized center (x, y), default (0.5, 0.5)\n    strength: Blur strength (0.0-1.0), default 0.5",
+    },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
 
-// ============================================================================
-// MotionBlurSpin Implementation
-// ============================================================================
+var motion_blur_getset = [_]c.PyGetSetDef{
+    .{
+        .name = "type",
+        .get = get_type,
+        .set = null,
+        .doc = "Type of motion blur: 'linear', 'radial_zoom', or 'radial_spin'",
+        .closure = null,
+    },
+    .{
+        .name = "angle",
+        .get = get_angle,
+        .set = null,
+        .doc = "Blur angle in radians (linear only)",
+        .closure = null,
+    },
+    .{
+        .name = "distance",
+        .get = get_distance,
+        .set = null,
+        .doc = "Blur distance in pixels (linear only)",
+        .closure = null,
+    },
+    .{
+        .name = "center",
+        .get = get_center,
+        .set = null,
+        .doc = "Normalized center position (zoom/spin only)",
+        .closure = null,
+    },
+    .{
+        .name = "strength",
+        .get = get_strength,
+        .set = null,
+        .doc = "Blur strength 0.0-1.0 (zoom/spin only)",
+        .closure = null,
+    },
+    .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
+};
 
-fn spin_dealloc(self: [*c]c.PyObject) callconv(.c) void {
-    c.Py_TYPE(self).*.tp_free.?(self);
-}
-
-fn spin_new(type_obj: [*c]c.PyTypeObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
-    _ = args;
-    _ = kwds;
-
-    const self = @as(?*RadialSpinObject, @ptrCast(type_obj.*.tp_alloc.?(type_obj, 0)));
-    if (self) |obj| {
-        obj.center_x = 0.5;
-        obj.center_y = 0.5;
-        obj.strength = 0.5;
-    }
-    return @ptrCast(self);
-}
-
-fn spin_init(self_obj: [*c]c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) c_int {
-    const self = @as(*RadialSpinObject, @ptrCast(self_obj));
-
-    var center_tuple: [*c]c.PyObject = null;
-    var strength: f64 = 0.5;
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("center"), @constCast("strength"), null };
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "|Od", @ptrCast(&kwlist), &center_tuple, &strength) == 0) {
-        return -1;
-    }
-
-    // Parse center tuple if provided
-    if (center_tuple != null) {
-        var center_x: f64 = 0.5;
-        var center_y: f64 = 0.5;
-        if (c.PyArg_ParseTuple(center_tuple, "dd", &center_x, &center_y) == 0) {
-            c.PyErr_SetString(c.PyExc_TypeError, "center must be a tuple of two floats");
-            return -1;
-        }
-        self.center_x = center_x;
-        self.center_y = center_y;
-
-        // Validate parameters
-        if (self.center_x < 0.0 or self.center_x > 1.0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "center[0] must be between 0.0 and 1.0");
-            return -1;
-        }
-        if (self.center_y < 0.0 or self.center_y > 1.0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "center[1] must be between 0.0 and 1.0");
-            return -1;
-        }
-    } else {
-        self.center_x = 0.5;
-        self.center_y = 0.5;
-    }
-
-    if (strength < 0.0 or strength > 1.0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "strength must be between 0.0 and 1.0");
-        return -1;
-    }
-
-    self.strength = strength;
-
-    return 0;
-}
-
-fn spin_repr(self_obj: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
-    const self = @as(*RadialSpinObject, @ptrCast(self_obj));
-    var buf: [256]u8 = undefined;
-    const str = std.fmt.bufPrintZ(
-        &buf,
-        "MotionBlurSpin(center=({d:.3}, {d:.3}), strength={d:.3})",
-        .{ self.center_x, self.center_y, self.strength },
-    ) catch return null;
-
-    return @ptrCast(c.PyUnicode_FromString(str));
-}
-
-fn spin_get_center(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
-    _ = closure;
-    const self = @as(*RadialSpinObject, @ptrCast(self_obj.?));
-    return c.Py_BuildValue("(dd)", self.center_x, self.center_y);
-}
-
-fn spin_get_strength(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
-    _ = closure;
-    const self = @as(*RadialSpinObject, @ptrCast(self_obj.?));
-    return c.PyFloat_FromDouble(self.strength);
-}
-
-pub const spin_doc =
-    \\Motion blur spin effect configuration.
-    \\
-    \\Simulates rotational motion blur around a center point, creating a spinning effect.
-    \\This effect creates circular blur trails around the specified center, similar to
-    \\rotating the camera during exposure.
-    \\
-    \\## Parameters:
-    \\- `center` (tuple[float, float]): Normalized center position (x, y) where both values are 0.0-1.0. Default is (0.5, 0.5).
-    \\- `strength` (float): Blur strength (0.0-1.0). Higher values create stronger rotation.
-;
-
-pub var SpinType = c.PyTypeObject{
+pub var MotionBlurType = c.PyTypeObject{
     .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.MotionBlurSpin",
-    .tp_basicsize = @sizeOf(RadialSpinObject),
-    .tp_dealloc = spin_dealloc,
-    .tp_repr = spin_repr,
+    .tp_name = "zignal.MotionBlur",
+    .tp_basicsize = @sizeOf(MotionBlurObject),
+    .tp_dealloc = motion_blur_dealloc,
+    .tp_repr = motion_blur_repr,
     .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = spin_doc,
-    .tp_getset = &spin_getset,
-    .tp_init = spin_init,
-    .tp_new = spin_new,
+    .tp_doc = motion_blur_doc,
+    .tp_methods = &motion_blur_methods,
+    .tp_getset = &motion_blur_getset,
+    .tp_init = motion_blur_init,
+    .tp_new = motion_blur_new,
 };
 
 // ============================================================================
 // Metadata for stub generation
 // ============================================================================
 
-// Linear class metadata
-pub const linear_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
+pub const motion_blur_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
+    .{
+        .name = "type",
+        .get = get_type,
+        .set = null,
+        .doc = "Type of motion blur: 'linear', 'radial_zoom', or 'radial_spin'",
+        .type = "Literal['linear', 'radial_zoom', 'radial_spin']",
+    },
     .{
         .name = "angle",
-        .get = linear_get_angle,
+        .get = get_angle,
         .set = null,
-        .doc = "Blur angle in radians (0 = horizontal)",
-        .type = "float",
+        .doc = "Blur angle in radians (linear only)",
+        .type = "float | None",
     },
     .{
         .name = "distance",
-        .get = linear_get_distance,
+        .get = get_distance,
         .set = null,
-        .doc = "Blur distance in pixels",
-        .type = "int",
+        .doc = "Blur distance in pixels (linear only)",
+        .type = "int | None",
     },
-};
-
-pub const linear_special_methods_metadata = [_]stub_metadata.MethodInfo{
-    .{
-        .name = "__init__",
-        .params = "self, angle: float, distance: int",
-        .returns = "None",
-        .doc = "Create linear motion blur configuration.\n\nArgs:\n    angle: Blur angle in radians (0 = horizontal)\n    distance: Blur distance in pixels",
-    },
-    .{
-        .name = "__repr__",
-        .params = "self",
-        .returns = "str",
-        .doc = null,
-    },
-};
-
-// Generate getset array from metadata
-var linear_getset = stub_metadata.toPyGetSetDefArray(&linear_properties_metadata);
-
-// Zoom class metadata
-pub const zoom_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
     .{
         .name = "center",
-        .get = zoom_get_center,
+        .get = get_center,
         .set = null,
-        .doc = "Normalized center position (x, y)",
-        .type = "tuple[float, float]",
+        .doc = "Normalized center position (zoom/spin only)",
+        .type = "tuple[float, float] | None",
     },
     .{
         .name = "strength",
-        .get = zoom_get_strength,
+        .get = get_strength,
         .set = null,
-        .doc = "Blur strength (0.0-1.0)",
-        .type = "float",
+        .doc = "Blur strength 0.0-1.0 (zoom/spin only)",
+        .type = "float | None",
     },
 };
 
-pub const zoom_special_methods_metadata = [_]stub_metadata.MethodInfo{
+pub const motion_blur_methods_metadata = [_]stub_metadata.MethodInfo{
     .{
-        .name = "__init__",
-        .params = "self, center: tuple[float, float] = (0.5, 0.5), strength: float = 0.5",
-        .returns = "None",
-        .doc = "Create radial zoom blur configuration.\n\nArgs:\n    center: Normalized center position (x, y), default (0.5, 0.5)\n    strength: Blur strength (0.0-1.0), default 0.5",
+        .name = "linear",
+        .params = "angle: float, distance: int",
+        .returns = "MotionBlur",
+        .doc = "Create linear motion blur configuration.",
     },
+    .{
+        .name = "radial_zoom",
+        .params = "center: tuple[float, float] = (0.5, 0.5), strength: float = 0.5",
+        .returns = "MotionBlur",
+        .doc = "Create radial zoom blur configuration.",
+    },
+    .{
+        .name = "radial_spin",
+        .params = "center: tuple[float, float] = (0.5, 0.5), strength: float = 0.5",
+        .returns = "MotionBlur",
+        .doc = "Create radial spin blur configuration.",
+    },
+};
+
+pub const motion_blur_special_methods_metadata = [_]stub_metadata.MethodInfo{
     .{
         .name = "__repr__",
         .params = "self",
@@ -427,77 +459,18 @@ pub const zoom_special_methods_metadata = [_]stub_metadata.MethodInfo{
     },
 };
 
-// Generate getset array from metadata
-var zoom_getset = stub_metadata.toPyGetSetDefArray(&zoom_properties_metadata);
-
-// Spin class metadata
-pub const spin_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
-    .{
-        .name = "center",
-        .get = spin_get_center,
-        .set = null,
-        .doc = "Normalized center position (x, y)",
-        .type = "tuple[float, float]",
-    },
-    .{
-        .name = "strength",
-        .get = spin_get_strength,
-        .set = null,
-        .doc = "Blur strength (0.0-1.0)",
-        .type = "float",
-    },
-};
-
-pub const spin_special_methods_metadata = [_]stub_metadata.MethodInfo{
-    .{
-        .name = "__init__",
-        .params = "self, center: tuple[float, float] = (0.5, 0.5), strength: float = 0.5",
-        .returns = "None",
-        .doc = "Create radial spin blur configuration.\n\nArgs:\n    center: Normalized center position (x, y), default (0.5, 0.5)\n    strength: Blur strength (0.0-1.0), default 0.5",
-    },
-    .{
-        .name = "__repr__",
-        .params = "self",
-        .returns = "str",
-        .doc = null,
-    },
-};
-
-// Generate getset array from metadata
-var spin_getset = stub_metadata.toPyGetSetDefArray(&spin_properties_metadata);
-
-// Register all motion blur types
+// Register the motion blur type
 pub fn registerMotionBlur(module: *c.PyObject) !void {
-    // Initialize types
-    if (c.PyType_Ready(&LinearType) < 0) {
-        return error.TypeInitFailed;
-    }
-    if (c.PyType_Ready(&ZoomType) < 0) {
-        return error.TypeInitFailed;
-    }
-    if (c.PyType_Ready(&SpinType) < 0) {
+    // Initialize type
+    if (c.PyType_Ready(&MotionBlurType) < 0) {
         return error.TypeInitFailed;
     }
 
-    // Add to module as top-level classes
+    // Add to module
     // TODO: Remove explicit cast after Python 3.10 is dropped
-    c.Py_INCREF(@as(?*c.PyObject, @ptrCast(&LinearType)));
-    if (c.PyModule_AddObject(module, "MotionBlurLinear", @as(?*c.PyObject, @ptrCast(&LinearType))) < 0) {
-        c.Py_DECREF(@as(?*c.PyObject, @ptrCast(&LinearType)));
-        return error.ModuleAddFailed;
-    }
-
-    // TODO: Remove explicit cast after Python 3.10 is dropped
-    c.Py_INCREF(@as(?*c.PyObject, @ptrCast(&ZoomType)));
-    if (c.PyModule_AddObject(module, "MotionBlurZoom", @as(?*c.PyObject, @ptrCast(&ZoomType))) < 0) {
-        c.Py_DECREF(@as(?*c.PyObject, @ptrCast(&ZoomType)));
-        return error.ModuleAddFailed;
-    }
-
-    // TODO: Remove explicit cast after Python 3.10 is dropped
-    c.Py_INCREF(@as(?*c.PyObject, @ptrCast(&SpinType)));
-    if (c.PyModule_AddObject(module, "MotionBlurSpin", @as(?*c.PyObject, @ptrCast(&SpinType))) < 0) {
-        c.Py_DECREF(@as(?*c.PyObject, @ptrCast(&SpinType)));
+    c.Py_INCREF(@as(?*c.PyObject, @ptrCast(&MotionBlurType)));
+    if (c.PyModule_AddObject(module, "MotionBlur", @as(?*c.PyObject, @ptrCast(&MotionBlurType))) < 0) {
+        c.Py_DECREF(@as(?*c.PyObject, @ptrCast(&MotionBlurType)));
         return error.ModuleAddFailed;
     }
 }

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -183,16 +183,16 @@ class TestImageSmoke:
         img = zignal.Image(10, 10, (255, 0, 0), dtype=zignal.Rgb)
 
         # Test linear motion blur
-        linear_config = zignal.MotionBlurLinear(angle=0.0, distance=3)
+        linear_config = zignal.MotionBlur.linear(angle=0.0, distance=3)
         blurred = img.motion_blur(linear_config)
         assert blurred.rows == 10 and blurred.cols == 10
 
         # Test radial zoom blur with defaults
-        zoom_config = zignal.MotionBlurZoom()
+        zoom_config = zignal.MotionBlur.radial_zoom()
         blurred = img.motion_blur(zoom_config)
         assert blurred.rows == 10 and blurred.cols == 10
 
         # Test radial spin blur with custom center
-        spin_config = zignal.MotionBlurSpin(center=(0.3, 0.7), strength=0.8)
+        spin_config = zignal.MotionBlur.radial_spin(center=(0.3, 0.7), strength=0.8)
         blurred = img.motion_blur(spin_config)
         assert blurred.rows == 10 and blurred.cols == 10


### PR DESCRIPTION
Consolidates MotionBlurLinear, MotionBlurZoom, and MotionBlurSpin into a single MotionBlur class with static factory methods (.linear(), .radial_zoom(), .radial_spin()).

BREAKING CHANGE: MotionBlurLinear, MotionBlurZoom, and MotionBlurSpin classes are removed. Use MotionBlur.linear(), MotionBlur.radial_zoom(), or MotionBlur.radial_spin() to create motion blur configurations.