### PR TITLE
refactor(image): split module into sub-modules

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1,3 +1,6 @@
+//! Python bindings for Zignal Image type
+//! This module aggregates functionality from sub-modules
+
 const std = @import("std");
 
 const zignal = @import("zignal");
@@ -7,8 +10,14 @@ const Image = zignal.Image;
 const Rgba = zignal.Rgba;
 const Rgb = zignal.Rgb;
 const DisplayFormat = zignal.DisplayFormat;
-const detectJpegComponents = zignal.jpeg.detectComponents;
 
+// Import sub-modules
+const core = @import("image/core.zig");
+const numpy_interop = @import("image/numpy_interop.zig");
+const transforms = @import("image/transforms.zig");
+const filtering = @import("image/filtering.zig");
+
+// Import other required modules
 const blending = @import("blending.zig");
 const canvas = @import("canvas.zig");
 const color_bindings = @import("color.zig");
@@ -98,7 +107,7 @@ const image_init_doc =
     \\img = Image(*arr.shape[:2])
     \\
     \\# Create with semi-transparent blue (requires RGBA)
-    \\img = Image(100, 200, (0, 0, 255, 128), dtype=zignal.Rgba)
+    \\img = Image(100, 100, (0, 0, 255, 128), dtype=zignal.Rgba)
     \\```
 ;
 
@@ -321,65 +330,6 @@ fn image_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
     c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
 }
 
-fn image_richcompare(self_obj: [*c]c.PyObject, other_obj: [*c]c.PyObject, op: c_int) callconv(.c) [*c]c.PyObject {
-    // Only handle == (Py_EQ=2) and != (Py_NE=3); defer other comparisons
-    if (op != c.Py_EQ and op != c.Py_NE) {
-        const not_impl = c.Py_NotImplemented();
-        c.Py_INCREF(not_impl);
-        return not_impl;
-    }
-
-    // Check if other is an Image object; if not, defer using NotImplemented
-    const image_type = @as([*c]c.PyTypeObject, @ptrCast(&ImageType));
-    if (c.PyObject_TypeCheck(other_obj, image_type) == 0) {
-        const not_impl = c.Py_NotImplemented();
-        c.Py_INCREF(not_impl);
-        return not_impl;
-    }
-
-    // Cast to ImageObject
-    const self = @as(*ImageObject, @ptrCast(self_obj));
-    const other = @as(*ImageObject, @ptrCast(other_obj));
-
-    // Variant-aware equality: compare size and per-pixel RGBA values
-    if (self.py_image == null or other.py_image == null) {
-        // If either is uninitialized, they are equal only for != case
-        return @ptrCast(py_utils.getPyBool(op != c.Py_EQ));
-    }
-    // Store in local variables after null check to avoid repeated unwrapping
-    const self_img = self.py_image.?;
-    const other_img = other.py_image.?;
-    const dims_self = .{ self_img.rows(), self_img.cols() };
-    const dims_other = .{ other_img.rows(), other_img.cols() };
-
-    if (dims_self[0] != dims_other[0] or dims_self[1] != dims_other[1]) {
-        return @ptrCast(py_utils.getPyBool(op != c.Py_EQ));
-    }
-
-    const rows = dims_self[0];
-    const cols = dims_self[1];
-    var equal = true;
-    var r: usize = 0;
-    while (r < rows) : (r += 1) {
-        var cidx: usize = 0;
-        while (cidx < cols) : (cidx += 1) {
-            const a = self_img.getPixelRgba(r, cidx);
-            const b = other_img.getPixelRgba(r, cidx);
-            if (a != b) {
-                equal = false;
-                break;
-            }
-        }
-        if (!equal) break;
-    }
-
-    if (op == c.Py_EQ) {
-        return @ptrCast(py_utils.getPyBool(equal));
-    } else {
-        return @ptrCast(py_utils.getPyBool(!equal));
-    }
-}
-
 fn image_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = @as(*ImageObject, @ptrCast(self_obj.?));
 
@@ -397,2966 +347,15 @@ fn image_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     }
 }
 
-fn image_get_rows(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
-    _ = closure;
+fn image_len(self_obj: ?*c.PyObject) callconv(.c) c.Py_ssize_t {
     const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        return c.PyLong_FromLong(@intCast(pimg.rows()));
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-fn image_get_cols(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
-    _ = closure;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        return c.PyLong_FromLong(@intCast(pimg.cols()));
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-fn image_get_dtype(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
-    _ = closure;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Return sentinel type objects: zignal.Grayscale, zignal.Rgb, or zignal.Rgba
-    if (self.py_image) |pimg| {
-        return switch (pimg.data) {
-            .grayscale => blk: {
-                const obj = @as(*c.PyObject, @ptrCast(&grayscale_format.GrayscaleType));
-                c.Py_INCREF(obj);
-                break :blk obj;
-            },
-            .rgb => blk: {
-                const obj = @as(*c.PyObject, @ptrCast(&color_bindings.RgbType));
-                c.Py_INCREF(obj);
-                break :blk obj;
-            },
-            .rgba => blk: {
-                const obj = @as(*c.PyObject, @ptrCast(&color_bindings.RgbaType));
-                c.Py_INCREF(obj);
-                break :blk obj;
-            },
-        };
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_is_contiguous_doc =
-    \\Check if this image data is stored contiguously in memory
-    \\
-    \\Returns True when the image data is stored without padding between rows (stride equals width).
-    \\Returns False when there is padding between rows, typically for sub-image views.
-;
-
-fn image_is_contiguous(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args; // No arguments
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        const is_contiguous = switch (pimg.data) {
-            .grayscale => |img| img.isContiguous(),
-            .rgb => |img| img.isContiguous(),
-            .rgba => |img| img.isContiguous(),
-        };
-        return @ptrCast(py_utils.getPyBool(is_contiguous));
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_load_doc =
-    \\Load an image from file (PNG/JPEG).
-    \\
-    \\## Parameters
-    \\- `path` (`str`): Path to the image file to load
-    \\
-    \\## Raises
-    \\- `FileNotFoundError`: If the image file is not found
-    \\- `ValueError`: If the image format is not supported
-    \\- `MemoryError`: If allocation fails
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\print(img.rows, img.cols)
-    \\# Output: 512 768
-    \\```
-;
-
-fn image_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    var file_path: [*c]const u8 = undefined;
-
-    const format = std.fmt.comptimePrint("s", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &file_path) == 0) {
-        return null;
-    }
-
-    // Convert C string to Zig slice
-    const path_slice = std.mem.span(file_path);
-
-    // PNG: load native dtype (Grayscale, RGB, RGBA)
-    if (std.mem.endsWith(u8, path_slice, ".png") or std.mem.endsWith(u8, path_slice, ".PNG")) {
-        const data = std.fs.cwd().readFileAlloc(allocator, path_slice, 100 * 1024 * 1024) catch |err| {
-            py_utils.setErrorWithPath(err, path_slice);
-            return null;
-        };
-        defer allocator.free(data);
-        var decoded = zignal.png.decode(allocator, data) catch |err| {
-            py_utils.setErrorWithPath(err, path_slice);
-            return null;
-        };
-        defer decoded.deinit(allocator);
-        const native = zignal.png.toNativeImage(allocator, decoded) catch |err| {
-            py_utils.setErrorWithPath(err, path_slice);
-            return null;
-        };
-        const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(type_obj), 0)));
-        if (self == null) return null;
-        switch (native) {
-            .grayscale => |img| {
-                const p = PyImage.createFrom(allocator, img, .owned) orelse {
-                    var tmp = img;
-                    tmp.deinit(allocator);
-                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                self.?.py_image = p;
-            },
-            .rgb => |img| {
-                const p = PyImage.createFrom(allocator, img, .owned) orelse {
-                    var tmp = img;
-                    tmp.deinit(allocator);
-                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                self.?.py_image = p;
-            },
-            .rgba => |img| {
-                const p = PyImage.createFrom(allocator, img, .owned) orelse {
-                    var tmp = img;
-                    tmp.deinit(allocator);
-                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                self.?.py_image = p;
-            },
-        }
-        self.?.numpy_ref = null;
-        self.?.parent_ref = null;
-        return @as(?*c.PyObject, @ptrCast(self));
-    }
-
-    // JPEG: detect grayscale vs color and load native
-    if (std.mem.endsWith(u8, path_slice, ".jpg") or std.mem.endsWith(u8, path_slice, ".JPG") or
-        std.mem.endsWith(u8, path_slice, ".jpeg") or std.mem.endsWith(u8, path_slice, ".JPEG"))
-    {
-        const data = std.fs.cwd().readFileAlloc(allocator, path_slice, 200 * 1024 * 1024) catch |err| {
-            py_utils.setErrorWithPath(err, path_slice);
-            return null;
-        };
-        defer allocator.free(data);
-
-        const comps = detectJpegComponents(data) orelse {
-            c.PyErr_SetString(c.PyExc_ValueError, "Invalid JPEG file (no SOF marker)");
-            return null;
-        };
-        if (comps == 1) {
-            const image = Image(u8).load(allocator, path_slice) catch |err| {
-                py_utils.setErrorWithPath(err, path_slice);
-                return null;
-            };
-            const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(type_obj), 0)));
-            if (self == null) {
-                var img = image;
-                img.deinit(allocator);
-                return null;
-            }
-            const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
-                var img = image;
-                img.deinit(allocator);
-                c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-                c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                return null;
-            };
-            self.?.py_image = pimg;
-            self.?.numpy_ref = null;
-            self.?.parent_ref = null;
-            return @as(?*c.PyObject, @ptrCast(self));
-        } else {
-            const image = Image(Rgb).load(allocator, path_slice) catch |err| {
-                py_utils.setErrorWithPath(err, path_slice);
-                return null;
-            };
-            const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(type_obj), 0)));
-            if (self == null) {
-                var img = image;
-                img.deinit(allocator);
-                return null;
-            }
-            const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
-                var img = image;
-                img.deinit(allocator);
-                c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-                c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                return null;
-            };
-            self.?.py_image = pimg;
-            self.?.numpy_ref = null;
-            self.?.parent_ref = null;
-            return @as(?*c.PyObject, @ptrCast(self));
-        }
-    }
-
-    // Others: default to RGB
-    const image = Image(Rgb).load(allocator, path_slice) catch |err| {
-        py_utils.setErrorWithPath(err, path_slice);
-        return null;
-    };
-    const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(type_obj), 0)));
-    if (self == null) {
-        var img = image;
-        img.deinit(allocator);
-        return null;
-    }
-    const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
-        var img = image;
-        img.deinit(allocator);
-        c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-        return null;
-    };
-    self.?.py_image = pimg;
-    self.?.numpy_ref = null;
-    self.?.parent_ref = null;
-    return @as(?*c.PyObject, @ptrCast(self));
-}
-
-const image_to_numpy_doc =
-    \\Convert the image to a NumPy array (zero-copy when possible).
-    \\
-    \\Returns an array in the image's native dtype:\n
-    \\- Grayscale → shape (rows, cols, 1)\n
-    \\- Rgb → shape (rows, cols, 3)\n
-    \\- Rgba → shape (rows, cols, 4)
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\arr = img.to_numpy()
-    \\print(arr.shape, arr.dtype)
-    \\# Example: (H, W, C) uint8 where C is 1, 3, or 4
-    \\```
-;
-
-fn image_to_numpy(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args; // No arguments
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            .grayscale => |img| {
-                // Import numpy
-                const np_module = c.PyImport_ImportModule("numpy") orelse {
-                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
-                    return null;
-                };
-                defer c.Py_DECREF(np_module);
-
-                // Allocate shape and strides arrays that persist for the lifetime of the array
-                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
-                    return null;
-                };
-                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    allocator.free(shape_array);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
-                    return null;
-                };
-
-                // Set shape: (rows, cols, 1)
-                shape_array[0] = @intCast(img.rows);
-                shape_array[1] = @intCast(img.cols);
-                shape_array[2] = 1;
-
-                // Set strides for proper memory layout: (stride*1, 1, 1)
-                strides_array[0] = @intCast(img.stride * @sizeOf(u8));
-                strides_array[1] = @sizeOf(u8);
-                strides_array[2] = 1;
-
-                // Create a 3D buffer view with proper strides
-                var buffer = c.Py_buffer{
-                    .buf = @ptrCast(img.data.ptr),
-                    .obj = self_obj,
-                    .len = @intCast(img.data.len * @sizeOf(u8)),
-                    .itemsize = 1,
-                    .readonly = 0,
-                    .ndim = 3,
-                    .format = @constCast("B"),
-                    .shape = @ptrCast(shape_array.ptr),
-                    .strides = @ptrCast(strides_array.ptr),
-                    .suboffsets = null,
-                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
-                };
-                c.Py_INCREF(self_obj); // Keep parent alive
-
-                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
-                    c.Py_DECREF(self_obj);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Create numpy array from memoryview
-                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(np_asarray);
-
-                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(args_tuple);
-
-                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Clean up memoryview but arrays are kept alive by numpy array
-                c.Py_DECREF(memview);
-
-                return array;
-            },
-            .rgb => |img| {
-                // Import numpy
-                const np_module = c.PyImport_ImportModule("numpy") orelse {
-                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
-                    return null;
-                };
-                defer c.Py_DECREF(np_module);
-
-                // Allocate shape and strides arrays that persist for the lifetime of the array
-                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
-                    return null;
-                };
-                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    allocator.free(shape_array);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
-                    return null;
-                };
-
-                // Set shape: (rows, cols, 3)
-                shape_array[0] = @intCast(img.rows);
-                shape_array[1] = @intCast(img.cols);
-                shape_array[2] = 3;
-
-                // Set strides for proper memory layout: (stride*3, 3, 1)
-                strides_array[0] = @intCast(img.stride * @sizeOf(Rgb));
-                strides_array[1] = @sizeOf(Rgb);
-                strides_array[2] = 1;
-
-                // Create a 3D buffer view with proper strides
-                var buffer = c.Py_buffer{
-                    .buf = @ptrCast(img.data.ptr),
-                    .obj = self_obj,
-                    .len = @intCast(img.data.len * @sizeOf(Rgb)),
-                    .itemsize = 1,
-                    .readonly = 0,
-                    .ndim = 3,
-                    .format = @constCast("B"),
-                    .shape = @ptrCast(shape_array.ptr),
-                    .strides = @ptrCast(strides_array.ptr),
-                    .suboffsets = null,
-                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
-                };
-                c.Py_INCREF(self_obj); // Keep parent alive
-
-                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
-                    c.Py_DECREF(self_obj);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Create numpy array from memoryview
-                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(np_asarray);
-
-                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(args_tuple);
-
-                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Clean up memoryview but arrays are kept alive by numpy array
-                c.Py_DECREF(memview);
-
-                return array;
-            },
-            .rgba => |img| {
-                // Import numpy
-                const np_module = c.PyImport_ImportModule("numpy") orelse {
-                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
-                    return null;
-                };
-                defer c.Py_DECREF(np_module);
-
-                // Allocate shape and strides arrays that persist for the lifetime of the array
-                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
-                    return null;
-                };
-                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
-                    allocator.free(shape_array);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
-                    return null;
-                };
-
-                // Set shape: (rows, cols, 4)
-                shape_array[0] = @intCast(img.rows);
-                shape_array[1] = @intCast(img.cols);
-                shape_array[2] = 4;
-
-                // Set strides for proper memory layout: (stride*4, 4, 1)
-                strides_array[0] = @intCast(img.stride * @sizeOf(Rgba));
-                strides_array[1] = @sizeOf(Rgba);
-                strides_array[2] = 1;
-
-                // Create a 3D buffer view with proper strides
-                var buffer = c.Py_buffer{
-                    .buf = @ptrCast(img.data.ptr),
-                    .obj = self_obj,
-                    .len = @intCast(img.data.len * @sizeOf(Rgba)),
-                    .itemsize = 1,
-                    .readonly = 0,
-                    .ndim = 3,
-                    .format = @constCast("B"),
-                    .shape = @ptrCast(shape_array.ptr),
-                    .strides = @ptrCast(strides_array.ptr),
-                    .suboffsets = null,
-                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
-                };
-                c.Py_INCREF(self_obj); // Keep parent alive
-
-                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
-                    c.Py_DECREF(self_obj);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Create numpy array from memoryview
-                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(np_asarray);
-
-                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-                defer c.Py_DECREF(args_tuple);
-
-                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
-                    c.Py_DECREF(memview);
-                    allocator.free(shape_array);
-                    allocator.free(strides_array);
-                    return null;
-                };
-
-                // Clean up memoryview but arrays are kept alive by numpy array
-                c.Py_DECREF(memview);
-
-                return array;
-            },
-        }
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_from_numpy_doc =
-    \\Create Image from a NumPy array with dtype uint8.
-    \\
-    \\Zero-copy is used for arrays with these shapes:
-    \\- Grayscale: (rows, cols, 1) → Image(Grayscale)
-    \\- RGB: (rows, cols, 3) → Image(Rgb)
-    \\- RGBA: (rows, cols, 4) → Image(Rgba)
-    \\
-    \\The array can have row strides (e.g., from views or slicing) as long as pixels
-    \\within each row are contiguous. For arrays with incompatible strides (e.g., transposed),
-    \\use `numpy.ascontiguousarray()` first.
-    \\
-    \\## Parameters
-    \\- `array` (NDArray[np.uint8]): NumPy array with shape (rows, cols, 1), (rows, cols, 3) or (rows, cols, 4) and dtype uint8.
-    \\  Pixels within rows must be contiguous.
-    \\
-    \\## Raises
-    \\- `TypeError`: If array is None or has wrong dtype
-    \\- `ValueError`: If array has wrong shape or incompatible strides
-    \\
-    \\## Notes
-    \\The array can have row strides (padding between rows) but pixels within
-    \\each row must be contiguous. For incompatible layouts (e.g., transposed
-    \\arrays), use np.ascontiguousarray() first:
-    \\
-    \\```python
-    \\arr = np.ascontiguousarray(arr)
-    \\img = Image.from_numpy(arr)
-    \\```
-    \\
-    \\## Examples
-    \\```python
-    \\arr = np.zeros((100, 200, 3), dtype=np.uint8)
-    \\img = Image.from_numpy(arr)
-    \\print(img.rows, img.cols)
-    \\# Output: 100 200
-    \\```
-;
-
-fn image_from_numpy(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    var array_obj: ?*c.PyObject = undefined;
-
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &array_obj) == 0) {
-        return null;
-    }
-
-    if (array_obj == null or array_obj == c.Py_None()) {
-        c.PyErr_SetString(c.PyExc_TypeError, "Array cannot be None");
-        return null;
-    }
-
-    // Get buffer interface from the array
-    var buffer: c.Py_buffer = undefined;
-    buffer = std.mem.zeroes(c.Py_buffer);
-
-    // Request buffer with strides info
-    const flags: c_int = 0x001c; // PyBUF_ND | PyBUF_STRIDES | PyBUF_FORMAT
-    if (c.PyObject_GetBuffer(array_obj, &buffer, flags) != 0) {
-        // Error already set by PyObject_GetBuffer
-        return null;
-    }
-    defer c.PyBuffer_Release(&buffer);
-
-    // Validate buffer format if available (should be 'B' for uint8)
-    // Note: format might be null if PyBUF_FORMAT wasn't requested
-    if (buffer.format != null and (buffer.format[0] != 'B' or buffer.format[1] != 0)) {
-        c.PyErr_SetString(c.PyExc_TypeError, "Array must have dtype uint8");
-        return null;
-    }
-
-    // Validate dimensions and shape: only 3D arrays with 1, 3 or 4 channels are supported
-    const ndim: c_int = buffer.ndim;
-    if (ndim != 3) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Array must have shape (rows, cols, 1|3|4)");
-        return null;
-    }
-
-    const shape = @as([*]c.Py_ssize_t, @ptrCast(buffer.shape));
-    const rows = @as(usize, @intCast(shape[0]));
-    const cols = @as(usize, @intCast(shape[1]));
-    const channels: usize = @as(usize, @intCast(shape[2]));
-    if (!(channels == 1 or channels == 3 or channels == 4)) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Array must have 1 channel (grayscale), 3 channels (RGB) or 4 channels (RGBA)");
-        return null;
-    }
-
-    // Check if array strides are compatible (pixels must be contiguous within rows)
-    const strides = @as([*]c.Py_ssize_t, @ptrCast(buffer.strides));
-    const item = buffer.itemsize; // 1 for uint8
-
-    // Check that pixels within a row are contiguous
-    const expected_pixel_stride = item * @as(c.Py_ssize_t, @intCast(channels));
-    if (strides[2] != item or strides[1] != expected_pixel_stride) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Array pixels must be contiguous. Use numpy.ascontiguousarray() first.");
-        return null;
-    }
-
-    // Calculate row stride in pixels (not bytes)
-    const row_stride_bytes = strides[0];
-    const pixel_size: c.Py_ssize_t = @intCast(channels);
-    if (@rem(row_stride_bytes, pixel_size) != 0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Array row stride must be a multiple of pixel size.");
-        return null;
-    }
-    const row_stride_pixels = @divExact(row_stride_bytes, pixel_size);
-
-    // Create new Python object
-    const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(type_obj), 0)));
-    if (self == null) {
-        return null;
-    }
-
-    if (channels == 1) {
-        // Zero-copy: create grayscale image that points to NumPy's data directly
-        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
-        const data_slice = data_ptr[0..@intCast(buffer.len)];
-
-        // Create image with custom stride to handle non-contiguous arrays
-        const img = Image(u8){
-            .rows = rows,
-            .cols = cols,
-            .data = data_slice,
-            .stride = @intCast(row_stride_pixels),
-        };
-
-        // Keep a reference to the NumPy array to prevent deallocation
-        c.Py_INCREF(array_obj.?);
-        self.?.numpy_ref = array_obj;
-        // Wrap as PyImage non-owning grayscale
-        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
-            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-            return null;
-        };
-        self.?.py_image = pimg;
-        self.?.parent_ref = null;
-        return @as(?*c.PyObject, @ptrCast(self));
-    } else if (channels == 4) {
-        // Zero-copy: create image that points to NumPy's data directly
-        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
-        const rgba_ptr = @as([*]Rgba, @ptrCast(@alignCast(data_ptr)));
-        const data_slice = rgba_ptr[0..@divExact(@as(usize, @intCast(buffer.len)), @sizeOf(Rgba))];
-
-        // Create image with custom stride to handle non-contiguous arrays
-        const img = Image(Rgba){
-            .rows = rows,
-            .cols = cols,
-            .data = data_slice,
-            .stride = @intCast(row_stride_pixels),
-        };
-
-        // Keep a reference to the NumPy array to prevent deallocation
-        c.Py_INCREF(array_obj.?);
-        self.?.numpy_ref = array_obj;
-        // Wrap as PyImage non-owning RGBA
-        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
-            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-            return null;
-        };
-        self.?.py_image = pimg;
-        self.?.parent_ref = null;
-        return @as(?*c.PyObject, @ptrCast(self));
-    } else if (channels == 3) {
-        // Zero-copy RGB
-        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
-        const rgb_ptr = @as([*]Rgb, @ptrCast(@alignCast(data_ptr)));
-        const data_slice = rgb_ptr[0..@divExact(@as(usize, @intCast(buffer.len)), @sizeOf(Rgb))];
-
-        // Create image with custom stride to handle non-contiguous arrays
-        const img = Image(Rgb){
-            .rows = rows,
-            .cols = cols,
-            .data = data_slice,
-            .stride = @intCast(row_stride_pixels),
-        };
-        c.Py_INCREF(array_obj.?);
-        self.?.numpy_ref = array_obj;
-        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
-            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
-            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-            return null;
-        };
-        self.?.py_image = pimg;
-        self.?.parent_ref = null;
-    } else unreachable; // validated above
-    return @as(?*c.PyObject, @ptrCast(self));
-}
-
-const image_save_doc =
-    \\Save the image to a PNG file.
-    \\
-    \\## Parameters
-    \\- `path` (str): Path where the PNG file will be saved. Must have .png extension.
-    \\
-    \\## Raises
-    \\- `ValueError`: If the file does not have .png extension
-    \\- `MemoryError`: If allocation fails during save
-    \\- `PermissionError`: If write permission is denied
-    \\- `FileNotFoundError`: If the directory does not exist
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("input.png")
-    \\img.save("output.png")
-    \\```
-;
-
-fn image_save(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Determine display format based on spec (parsed below)
-
-    // Parse file path argument
-    var file_path: [*c]const u8 = undefined;
-    const format = std.fmt.comptimePrint("s", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &file_path) == 0) {
-        return null;
-    }
-
-    // Convert C string to Zig slice
-    const path_slice = std.mem.span(file_path);
-
-    // Validate file extension
-    if (!std.mem.endsWith(u8, path_slice, ".png") and
-        !std.mem.endsWith(u8, path_slice, ".PNG"))
-    {
-        c.PyErr_SetString(c.PyExc_ValueError, "File must have .png extension. Currently only PNG format is supported.");
-        return null;
-    }
-
-    // Save PNG for current image format
-    if (self.py_image) |pimg| {
-        const res = switch (pimg.data) {
-            .grayscale => |img| img.save(allocator, path_slice),
-            .rgb => |img| img.save(allocator, path_slice),
-            .rgba => |img| img.save(allocator, path_slice),
-        };
-        res catch |err| {
-            py_utils.setErrorWithPath(err, path_slice);
-            return null;
-        };
-    } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-
-    // Return None
-    const none = c.Py_None();
-    c.Py_INCREF(none);
-    return none;
-}
-
-const image_convert_doc =
-    \\
-    \\Convert the image to a different pixel data type.
-    \\
-    \\Supported targets: Grayscale, Rgb, Rgba.
-    \\
-    \\Returns a new Image with the requested format.
-;
-
-fn image_convert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse one argument: target dtype sentinel or instance of Rgb/Rgba
-    var dtype_obj: ?*c.PyObject = null;
-    const fmt = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTuple(args, fmt.ptr, &dtype_obj) == 0) {
-        return null;
-    }
-
-    if (dtype_obj == null) {
-        c.PyErr_SetString(c.PyExc_TypeError, "convert() requires a target dtype (zignal.Grayscale, zignal.Rgb, or zignal.Rgba)");
-        return null;
-    }
-
-    // Determine target type
-    var target_gray = false;
-    var target_rgb = false;
-    var target_rgba = false;
-
-    // TODO: Remove explicit cast after Python 3.10 is dropped
-    const is_type_obj = c.PyObject_TypeCheck(dtype_obj.?, @as([*c]c.PyTypeObject, @ptrCast(&c.PyType_Type))) != 0;
-    if (is_type_obj) {
-        if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&grayscale_format.GrayscaleType))) {
-            target_gray = true;
-        } else if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&color_bindings.RgbType))) {
-            target_rgb = true;
-        } else if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&color_bindings.RgbaType))) {
-            target_rgba = true;
-        } else {
-            c.PyErr_SetString(c.PyExc_TypeError, "format must be zignal.Grayscale, zignal.Rgb, or zignal.Rgba");
-            return null;
-        }
-    } else {
-        if (c.PyObject_IsInstance(dtype_obj.?, @ptrCast(&color_bindings.RgbType)) == 1) {
-            target_rgb = true;
-        } else if (c.PyObject_IsInstance(dtype_obj.?, @ptrCast(&color_bindings.RgbaType)) == 1) {
-            target_rgba = true;
-        } else {
-            c.PyErr_SetString(c.PyExc_TypeError, "format must be zignal.Grayscale, zignal.Rgb, or zignal.Rgba");
-            return null;
-        }
-    }
-
-    // Execute conversion using underlying Image(T).convert
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            .grayscale => |*img| {
-                if (target_gray) {
-                    // Same dtype: copy
-                    var out = Image(u8).init(allocator, img.rows, img.cols) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                        return null;
-                    };
-                    img.copy(out);
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        out.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgb) {
-                    const out = img.convert(Rgb, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgba) {
-                    const out = img.convert(Rgba, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                }
-            },
-            .rgb => |*img| {
-                if (target_gray) {
-                    const out = img.convert(u8, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgb) {
-                    var out = Image(Rgb).init(allocator, img.rows, img.cols) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                        return null;
-                    };
-                    img.copy(out);
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        out.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgba) {
-                    const out = img.convert(Rgba, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                }
-            },
-            .rgba => |*img| {
-                if (target_gray) {
-                    const out = img.convert(u8, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgb) {
-                    const out = img.convert(Rgb, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
-                        return null;
-                    };
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        var tmp = out;
-                        tmp.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                } else if (target_rgba) {
-                    var out = Image(Rgba).init(allocator, img.rows, img.cols) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                        return null;
-                    };
-                    img.copy(out);
-                    const py = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-                    const out_self = @as(*ImageObject, @ptrCast(py));
-                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                        out.deinit(allocator);
-                        c.Py_DECREF(py);
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                        return null;
-                    };
-                    out_self.py_image = pnew;
-                    out_self.numpy_ref = null;
-                    out_self.parent_ref = null;
-                    return py;
-                }
-            },
-        }
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-fn image_iter(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-    // Require PyImage variant for iteration
-    if (self.py_image == null) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-    return pixel_iterator.new(self_obj);
-}
-
-/// Parse dimension string "WIDTHxHEIGHT" into optional width and height values
-/// Examples: "800x600" -> (800, 600), "800x" -> (800, null), "x600" -> (null, 600)
-fn parseDimensions(dims_str: []const u8) !struct { width: ?u32, height: ?u32 } {
-    const x_pos = std.mem.indexOf(u8, dims_str, "x") orelse
-        return error.InvalidFormat;
-
-    const width_str = dims_str[0..x_pos];
-    const height_str = dims_str[x_pos + 1 ..];
-
-    var width: ?u32 = null;
-    var height: ?u32 = null;
-
-    if (width_str.len > 0) {
-        width = std.fmt.parseInt(u32, width_str, 10) catch
-            return error.InvalidWidth;
-    }
-
-    if (height_str.len > 0) {
-        height = std.fmt.parseInt(u32, height_str, 10) catch
-            return error.InvalidHeight;
-    }
-
-    return .{ .width = width, .height = height };
-}
-
-const image_format_doc =
-    \\Format image for display using various terminal graphics protocols.
-    \\
-    \\## Parameters
-    \\- `format_spec` (str): Format specifier for display:
-    \\  - `''` (empty): Returns text representation (e.g., 'Image(800x600)')
-    \\  - `'auto'`: Auto-detect best format with progressive degradation: kitty → sixel → sgr
-    \\  - `'sgr'`: Display using sgr escape codes (half colored half-blocks with background)
-    \\  - `'braille'`: Display using Braille patterns (good for monochrome images)
-    \\  - `'sixel'`: Display using sixel graphics protocol (up to 256 colors)
-    \\  - `'sixel:WIDTHxHEIGHT'`: Display using sixel scaled to fit (e.g., 'sixel:800x600')
-    \\  - `'sixel:WIDTHx'`: Scale to fit width, maintain aspect ratio (e.g., 'sixel:800x')
-    \\  - `'sixel:xHEIGHT'`: Scale to fit height, maintain aspect ratio (e.g., 'sixel:x600')
-    \\  - `'kitty'`: Display using kitty graphics protocol (24-bit color)
-    \\  - `'kitty:WIDTHxHEIGHT'`: Display using kitty scaled to fit (e.g., 'kitty:800x600')
-    \\  - `'kitty:WIDTHx'`: Display with specified width, height auto-calculated (e.g., 'kitty:800x')
-    \\  - `'kitty:xHEIGHT'`: Display with specified height, width auto-calculated (e.g., 'kitty:x600')
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\print(f"{img}")         # Image(800x600)
-    \\print(f"{img:sgr}")     # Display with SGR and unicode half-blocks
-    \\print(f"{img:braille}") # Display with braille patterns
-    \\print(f"{img:sixel}")   # Display with sixel graphics
-    \\print(f"{img:sixel:800x600}")   # Display with sixel, scaled to fit 800x600
-    \\print(f"{img:sixel:800x}")      # Display with sixel, scaled to 800px width
-    \\print(f"{img:sixel:x600}")      # Display with sixel, scaled to 600px height
-    \\print(f"{img:kitty}")           # Display with kitty graphics
-    \\print(f"{img:kitty:800x600}")   # Display with kitty, scaled to fit 800x600
-    \\print(f"{img:kitty:800x}")      # Display with kitty, 800 pixels wide
-    \\print(f"{img:kitty:x600}")      # Display with kitty, 600 pixels tall
-    \\```
-;
-
-fn image_format(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse format_spec argument
-    var format_spec: [*c]const u8 = undefined;
-    const format = std.fmt.comptimePrint("s", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &format_spec) == 0) {
-        return null;
-    }
-
-    // Convert C string to Zig slice
-    const spec_slice = std.mem.span(format_spec);
-
-    // If empty format spec, return default repr
-    if (spec_slice.len == 0) {
-        return image_repr(self_obj);
-    }
-
-    // Determine display format based on spec
-
-    // Determine display format based on spec
-    const display_format: DisplayFormat = if (std.mem.eql(u8, spec_slice, "sgr"))
-        .sgr
-    else if (std.mem.eql(u8, spec_slice, "braille"))
-        .{ .braille = .default }
-    else if (std.mem.eql(u8, spec_slice, "sixel"))
-        .{ .sixel = .default }
-    else if (std.mem.startsWith(u8, spec_slice, "sixel:")) blk: {
-        // Parse sixel with dimensions: "sixel:WIDTHxHEIGHT"
-        const dims_str = spec_slice[6..]; // Skip "sixel:"
-
-        const dims = parseDimensions(dims_str) catch |err| {
-            const msg = switch (err) {
-                error.InvalidFormat => "Invalid sixel format. Use 'sixel:WIDTHxHEIGHT', 'sixel:WIDTHx', or 'sixel:xHEIGHT'",
-                error.InvalidWidth => "Invalid width value in sixel format",
-                error.InvalidHeight => "Invalid height value in sixel format",
-            };
-            c.PyErr_SetString(c.PyExc_ValueError, msg);
-            return null;
-        };
-
-        // Create sixel options with custom dimensions
-        break :blk .{ .sixel = .{
-            .palette = .{ .adaptive = .{ .max_colors = 256 } },
-            .dither = .auto,
-            .width = dims.width,
-            .height = dims.height,
-            .interpolation = .nearest_neighbor,
-        } };
-    } else if (std.mem.eql(u8, spec_slice, "kitty"))
-        .{ .kitty = .default }
-    else if (std.mem.startsWith(u8, spec_slice, "kitty:")) blk: {
-        // Parse kitty with dimensions: "kitty:WIDTHxHEIGHT"
-        const dims_str = spec_slice[6..]; // Skip "kitty:"
-
-        const dims = parseDimensions(dims_str) catch |err| {
-            const msg = switch (err) {
-                error.InvalidFormat => "Invalid kitty format. Use 'kitty:WIDTHxHEIGHT', 'kitty:WIDTHx', or 'kitty:xHEIGHT'",
-                error.InvalidWidth => "Invalid width value in kitty format",
-                error.InvalidHeight => "Invalid height value in kitty format",
-            };
-            c.PyErr_SetString(c.PyExc_ValueError, msg);
-            return null;
-        };
-
-        // Create kitty options with custom dimensions (in pixels)
-        break :blk .{
-            .kitty = .{
-                .quiet = 1,
-                .image_id = null,
-                .placement_id = null,
-                .delete_after = false,
-                .enable_chunking = false,
-                .width = dims.width,
-                .height = dims.height,
-                .interpolation = .bilinear,
-            },
-        };
-    } else if (std.mem.eql(u8, spec_slice, "auto"))
-        .auto
-    else if (std.mem.startsWith(u8, spec_slice, "sixel")) {
-        // Invalid sixel format that doesn't match "sixel" or "sixel:..."
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid sixel format. Use 'sixel' or 'sixel:WIDTHxHEIGHT' (e.g., 'sixel:800x600', 'sixel:800x', 'sixel:x600')");
-        return null;
-    } else if (std.mem.startsWith(u8, spec_slice, "kitty")) {
-        // Invalid kitty format that doesn't match "kitty" or "kitty:..."
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid kitty format. Use 'kitty' or 'kitty:WIDTHxHEIGHT' (e.g., 'kitty:800x600', 'kitty:800x', 'kitty:x600')");
-        return null;
-    } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid format spec. Use '', 'sgr', 'braille', 'sixel', 'sixel:WIDTHxHEIGHT', 'kitty', 'kitty:WIDTHxHEIGHT', or 'auto'");
-        return null;
-    };
-
-    // Format image according to display_format and return a string
-    if (self.py_image) |pimg| {
-        var buffer: std.ArrayList(u8) = .empty;
-        defer buffer.deinit(allocator);
-        const w = buffer.writer(allocator);
-        switch (pimg.data) {
-            .grayscale => |*img| std.fmt.format(w, "{f}", .{img.display(display_format)}) catch |err| {
-                if (err == error.OutOfMemory) c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                return null;
-            },
-            .rgb => |*img| std.fmt.format(w, "{f}", .{img.display(display_format)}) catch |err| {
-                if (err == error.OutOfMemory) c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                return null;
-            },
-            .rgba => |*img| std.fmt.format(w, "{f}", .{img.display(display_format)}) catch |err| {
-                if (err == error.OutOfMemory) c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                return null;
-            },
-        }
-        return c.PyUnicode_FromStringAndSize(buffer.items.ptr, @intCast(buffer.items.len));
-    } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-}
-
-fn pythonToZigInterpolation(py_value: c_long) !Interpolation {
-    return switch (py_value) {
-        0 => .nearest_neighbor,
-        1 => .bilinear,
-        2 => .bicubic,
-        3 => .catmull_rom,
-        4 => .{ .mitchell = .{ .b = 1.0 / 3.0, .c = 1.0 / 3.0 } }, // Default Mitchell parameters
-        5 => .lanczos,
-        else => return error.InvalidInterpolation,
-    };
-}
-
-fn image_scale(self: *ImageObject, scale: f32, method: Interpolation) !*ImageObject {
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            inline else => |*img| {
-                var out = img.scale(allocator, scale, method) catch |err| return mapScaleError(err);
-                const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
-                const result = @as(*ImageObject, @ptrCast(py_obj));
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                result.py_image = pnew;
-                result.numpy_ref = null;
-                result.parent_ref = null;
-                return result;
-            },
-        }
-    }
-    return error.ImageNotInitialized;
-}
-
-fn image_reshape(self: *ImageObject, rows: usize, cols: usize, method: Interpolation) !*ImageObject {
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            inline else => |*img| {
-                var out = @TypeOf(img.*).init(allocator, rows, cols) catch return error.OutOfMemory;
-                img.resize(allocator, out, method) catch return error.OutOfMemory;
-                const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
-                const result = @as(*ImageObject, @ptrCast(py_obj));
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                result.py_image = pnew;
-                result.numpy_ref = null;
-                result.parent_ref = null;
-                return result;
-            },
-        }
-    }
-    return error.ImageNotInitialized;
-}
-
-fn mapScaleError(err: anyerror) anyerror {
-    return switch (err) {
-        error.InvalidScaleFactor => blk: {
-            c.PyErr_SetString(c.PyExc_ValueError, "Scale factor must be positive");
-            break :blk error.InvalidScaleFactor;
-        },
-        error.InvalidDimensions => blk: {
-            c.PyErr_SetString(c.PyExc_ValueError, "Resulting image dimensions would be zero");
-            break :blk error.InvalidDimensions;
-        },
-        error.OutOfMemory => blk: {
-            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate scaled image");
-            break :blk error.OutOfMemory;
-        },
-        else => err,
-    };
-}
-
-const image_fill_doc =
-    \\Fill the entire image with a solid color.
-    \\
-    \\The color is converted to the image's native pixel data type (Grayscale/Rgb/Rgba).
-    \\
-    \\## Parameters
-    \\- `color`: Color value as:
-    \\  - int: Grayscale value (0-255)
-    \\  - tuple[int, int, int]: RGB values
-    \\  - tuple[int, int, int, int]: RGBA values
-    \\  - Any supported color object (e.g., Rgb, Rgba)
-    \\
-    \\## Examples
-    \\```python
-    \\img.fill(128)                      # Fill with gray
-    \\img.fill((255, 0, 0))              # Fill with red
-    \\img.fill((0, 255, 0, 128))         # Fill with semi-transparent green
-    \\img.fill(zignal.Rgb(255, 128, 0))  # Fill with orange using color object
-    \\```
-;
-
-fn image_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments - expect a color
-    var color_obj: ?*c.PyObject = null;
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &color_obj) == 0) {
-        return null;
-    }
-
-    const color = color_utils.parseColorTo(Rgba, color_obj) catch {
-        return null;
-    };
-
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            .grayscale => |*img| img.fill(color),
-            .rgb => |*img| img.fill(color),
-            .rgba => |*img| img.fill(color),
-        }
-    } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-
-    c.Py_INCREF(c.Py_None());
-    return c.Py_None();
-}
-
-const image_resize_doc =
-    \\Resize the image to the specified size.
-    \\
-    \\## Parameters
-    \\- `size` (float or tuple[int, int]):
-    \\  - If float: scale factor (e.g., 0.5 for half size, 2.0 for double size)
-    \\  - If tuple: target dimensions as (rows, cols)
-    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
-;
-
-fn image_resize(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var shape_or_scale: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("size"), @constCast("method"), null };
-    const format = std.fmt.comptimePrint("O|l", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &shape_or_scale, &method_value) == 0) {
-        return null;
-    }
-
-    if (shape_or_scale == null) {
-        c.PyErr_SetString(c.PyExc_TypeError, "resize() missing required argument: 'size' (pos 1)");
-        return null;
-    }
-
-    // Convert method value to Zig enum
-    const method = pythonToZigInterpolation(method_value) catch {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-        return null;
-    };
-
-    // Check if argument is a number (scale) or tuple (dimensions)
-    if (c.PyFloat_Check(shape_or_scale) != 0 or c.PyLong_Check(shape_or_scale) != 0) {
-        // It's a scale factor
-        const scale = c.PyFloat_AsDouble(shape_or_scale);
-        if (scale == -1.0 and c.PyErr_Occurred() != null) {
-            return null;
-        }
-        if (scale <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Scale factor must be positive");
-            return null;
-        }
-
-        const result = image_scale(self, @floatCast(scale), method) catch return null;
-        return @ptrCast(result);
-    } else if (c.PyTuple_Check(shape_or_scale) != 0) {
-        // It's a tuple of dimensions
-        if (c.PyTuple_Size(shape_or_scale) != 2) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Size must be a 2-tuple of (rows, cols)");
-            return null;
-        }
-
-        const rows_obj = c.PyTuple_GetItem(shape_or_scale, 0);
-        const cols_obj = c.PyTuple_GetItem(shape_or_scale, 1);
-
-        const rows = c.PyLong_AsLong(rows_obj);
-        if (rows == -1 and c.PyErr_Occurred() != null) {
-            c.PyErr_SetString(c.PyExc_TypeError, "Rows must be an integer");
-            return null;
-        }
-        if (rows <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Rows must be positive");
-            return null;
-        }
-
-        const cols = c.PyLong_AsLong(cols_obj);
-        if (cols == -1 and c.PyErr_Occurred() != null) {
-            c.PyErr_SetString(c.PyExc_TypeError, "Cols must be an integer");
-            return null;
-        }
-        if (cols <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Cols must be positive");
-            return null;
-        }
-
-        const result = image_reshape(self, @intCast(rows), @intCast(cols), method) catch return null;
-        return @ptrCast(result);
-    } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "resize() argument must be a number (scale) or tuple (rows, cols)");
-        return null;
-    }
-}
-
-fn image_letterbox_square(self: *ImageObject, size: usize, method: Interpolation) !*ImageObject {
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).init(allocator, size, size) catch {
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                _ = img.letterbox(allocator, &out, method) catch {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return result;
-    }
-    return error.ImageNotInitialized;
-}
-
-fn image_letterbox_shape(self: *ImageObject, rows: usize, cols: usize, method: Interpolation) !*ImageObject {
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return error.OutOfMemory;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).init(allocator, rows, cols) catch {
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                _ = img.letterbox(allocator, &out, method) catch {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return error.OutOfMemory;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return result;
-    }
-    return error.ImageNotInitialized;
-}
-
-const image_rotate_doc =
-    \\Rotate the image by the specified angle around its center.
-    \\
-    \\The output image is automatically sized to fit the entire rotated image without clipping.
-    \\
-    \\## Parameters
-    \\- `angle` (float): Rotation angle in radians counter-clockwise.
-    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
-    \\
-    \\## Examples
-    \\```python
-    \\import math
-    \\img = Image.load("photo.png")
-    \\
-    \\# Rotate 45 degrees with default bilinear interpolation
-    \\rotated = img.rotate(math.radians(45))
-    \\
-    \\# Rotate 90 degrees with nearest neighbor (faster, lower quality)
-    \\rotated = img.rotate(math.radians(90), Interpolation.NEAREST_NEIGHBOR)
-    \\
-    \\# Rotate -30 degrees with Lanczos (slower, higher quality)
-    \\rotated = img.rotate(math.radians(-30), Interpolation.LANCZOS)
-    \\```
-;
-
-fn image_rotate(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var angle: f64 = 0;
-    var method_value: c_long = 1; // Default to BILINEAR
-    var kwlist = [_:null]?[*:0]u8{ @constCast("angle"), @constCast("method"), null };
-    const format = std.fmt.comptimePrint("d|l", .{});
-
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &angle, &method_value) == 0) {
-        return null;
-    }
-
-    // Convert method value to Zig enum
-    const method = pythonToZigInterpolation(method_value) catch {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-        return null;
-    };
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).empty;
-                img.rotate(allocator, @floatCast(angle), method, &out) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_box_blur_doc =
-    \\Apply a box blur to the image.
-    \\
-    \\## Parameters
-    \\- `radius` (int): Non-negative blur radius in pixels. `0` returns an unmodified copy.
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\soft = img.box_blur(2)
-    \\identity = img.box_blur(0)  # no-op copy
-    \\```
-;
-
-fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var radius_long: c_long = 0;
-    var kwlist = [_:null]?[*:0]u8{ @constCast("radius"), null };
-    const format = std.fmt.comptimePrint("l", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &radius_long) == 0) {
-        return null;
-    }
-
-    if (radius_long < 0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "radius must be >= 0");
-        return null;
-    }
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).empty;
-                img.boxBlur(allocator, &out, @intCast(radius_long)) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_sharpen_doc =
-    \\Sharpen the image using unsharp masking (2 * self - blur_box).
-    \\
-    \\## Parameters
-    \\- `radius` (int): Non-negative blur radius used to compute the unsharp mask. `0` returns an unmodified copy.
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\crisp = img.sharpen(2)
-    \\identity = img.sharpen(0)  # no-op copy
-    \\```
-;
-
-fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var radius_long: c_long = 0;
-    var kwlist = [_:null]?[*:0]u8{ @constCast("radius"), null };
-    const format = std.fmt.comptimePrint("l", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &radius_long) == 0) {
-        return null;
-    }
-
-    if (radius_long < 0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "radius must be >= 0");
-        return null;
-    }
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).empty;
-                img.sharpen(allocator, &out, @intCast(radius_long)) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_gaussian_blur_doc =
-    \\Apply Gaussian blur to the image.
-    \\
-    \\## Parameters
-    \\- `sigma` (float): Standard deviation of the Gaussian kernel. Must be > 0.
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\blurred = img.gaussian_blur(2.0)
-    \\blurred_soft = img.gaussian_blur(5.0)  # More blur
-    \\```
-;
-
-fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var sigma: f64 = 0;
-    var kwlist = [_:null]?[*:0]u8{ @constCast("sigma"), null };
-    const format = std.fmt.comptimePrint("d", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &sigma) == 0) {
-        return null;
-    }
-
-    // Validate sigma: must be finite and > 0
-    if (!std.math.isFinite(sigma) or sigma <= 0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "sigma must be > 0");
-        return null;
-    }
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).empty;
-                img.gaussianBlur(allocator, @floatCast(sigma), &out) catch |err| {
-                    c.Py_DECREF(py_obj);
-                    if (err == error.InvalidSigma) {
-                        c.PyErr_SetString(c.PyExc_ValueError, "Invalid sigma value");
-                    } else {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    }
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_motion_blur_doc =
-    \\Apply motion blur effect to the image.
-    \\
-    \\Motion blur simulates camera or object movement during exposure.
-    \\Three types of motion blur are supported:
-    \\- `MotionBlur.linear()` - Linear motion blur
-    \\- `MotionBlur.radial_zoom()` - Radial zoom blur
-    \\- `MotionBlur.radial_spin()` - Radial spin blur
-    \\
-    \\## Examples
-    \\```python
-    \\from zignal import Image, MotionBlur
-    \\import math
-    \\
-    \\img = Image.load("photo.png")
-    \\
-    \\# Linear motion blur examples
-    \\horizontal_blur = img.motion_blur(MotionBlur.linear(angle=0, distance=30))  # Camera panning
-    \\vertical_blur = img.motion_blur(MotionBlur.linear(angle=math.pi/2, distance=20))  # Camera shake
-    \\diagonal_blur = img.motion_blur(MotionBlur.linear(angle=math.pi/4, distance=25))  # Diagonal motion
-    \\
-    \\# Radial zoom blur examples
-    \\center_zoom = img.motion_blur(MotionBlur.radial_zoom(center=(0.5, 0.5), strength=0.7))  # Center zoom burst
-    \\off_center_zoom = img.motion_blur(MotionBlur.radial_zoom(center=(0.33, 0.67), strength=0.5))  # Rule of thirds
-    \\subtle_zoom = img.motion_blur(MotionBlur.radial_zoom(strength=0.3))  # Subtle effect with defaults
-    \\
-    \\# Radial spin blur examples
-    \\center_spin = img.motion_blur(MotionBlur.radial_spin(center=(0.5, 0.5), strength=0.5))  # Center rotation
-    \\swirl_effect = img.motion_blur(MotionBlur.radial_spin(center=(0.3, 0.3), strength=0.6))  # Off-center swirl
-    \\strong_spin = img.motion_blur(MotionBlur.radial_spin(strength=0.8))  # Strong spin with defaults
-    \\```
-    \\
-    \\## Notes
-    \\- Linear blur preserves image dimensions
-    \\- Radial effects use bilinear interpolation for smooth results
-    \\- Strength values closer to 1.0 produce stronger blur effects
-;
-
-fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-    const motion_blur = @import("motion_blur.zig");
-
-    // Parse the single argument (config object)
-    var config_obj: ?*c.PyObject = undefined;
-    if (c.PyArg_ParseTuple(args, "O", &config_obj) == 0) {
-        return null;
-    }
-
-    // Check that it's a MotionBlur object
-    const type_obj = c.Py_TYPE(config_obj);
-    const type_name = type_obj.*.tp_name;
-
-    if (!std.mem.eql(u8, std.mem.span(type_name), "zignal.MotionBlur")) {
-        c.PyErr_SetString(c.PyExc_TypeError, "config must be a MotionBlur object created with MotionBlur.linear(), MotionBlur.radial_zoom(), or MotionBlur.radial_spin()");
-        return null;
-    }
-
-    // Cast to MotionBlurObject to access the blur_type discriminator
-    const blur_obj = @as(*motion_blur.MotionBlurObject, @ptrCast(config_obj));
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).empty;
-
-                // Create the appropriate MotionBlur config based on the type
-                const blur_config: MotionBlur = switch (blur_obj.blur_type) {
-                    .linear => .{
-                        .linear = .{
-                            .angle = @floatCast(blur_obj.angle),
-                            .distance = @intCast(blur_obj.distance),
-                        },
-                    },
-                    .radial_zoom => .{
-                        .radial_zoom = .{
-                            .center_x = @floatCast(blur_obj.center_x),
-                            .center_y = @floatCast(blur_obj.center_y),
-                            .strength = @floatCast(blur_obj.strength),
-                        },
-                    },
-                    .radial_spin => .{
-                        .radial_spin = .{
-                            .center_x = @floatCast(blur_obj.center_x),
-                            .center_y = @floatCast(blur_obj.center_y),
-                            .strength = @floatCast(blur_obj.strength),
-                        },
-                    },
-                };
-
-                img.motionBlur(allocator, blur_config, &out) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    return null;
-                };
-
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_sobel_doc =
-    \\Apply Sobel edge detection and return the gradient magnitude.
-    \\
-    \\The result is a new grayscale image (`dtype=zignal.Grayscale`) where
-    \\each pixel encodes the edge strength at that location.
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\edges = img.sobel()
-    \\```
-;
-
-fn image_sobel(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-
-        var out = Image(u8).empty;
-        switch (pimg.data) {
-            inline else => |img| {
-                img.sobel(allocator, &out) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
-                    return null;
-                };
-            },
-        }
-
-        const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-            out.deinit(allocator);
-            c.Py_DECREF(py_obj);
-            return null;
-        };
-        result.py_image = pnew;
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_blend_doc =
-    \\Blend an overlay image onto this image using the specified blend mode.
-    \\
-    \\Modifies this image in-place. Both images must have the same dimensions.
-    \\The overlay image must have an alpha channel for proper blending.
-    \\
-    \\## Parameters
-    \\- `overlay` (Image): Image to blend onto this image
-    \\- `mode` (Blending, optional): Blending mode (default: NORMAL)
-    \\
-    \\## Raises
-    \\- `ValueError`: If images have different dimensions
-    \\- `TypeError`: If overlay is not an Image object
-    \\
-    \\## Examples
-    \\```python
-    \\# Basic alpha blending
-    \\base = Image(100, 100, (255, 0, 0))
-    \\overlay = Image(100, 100, (0, 0, 255, 128))  # Semi-transparent blue
-    \\base.blend(overlay)  # Default NORMAL mode
-    \\
-    \\# Using different blend modes
-    \\base.blend(overlay, zignal.Blending.MULTIPLY)
-    \\base.blend(overlay, zignal.Blending.SCREEN)
-    \\base.blend(overlay, zignal.Blending.OVERLAY)
-    \\```
-;
-
-fn image_blend(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments: overlay image and optional blend mode
-    var overlay_obj: ?*c.PyObject = null;
-    var mode_obj: ?*c.PyObject = null;
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("overlay"), @constCast("mode"), null };
-    const fmt = std.fmt.comptimePrint("O|O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, fmt.ptr, @ptrCast(&kwlist), &overlay_obj, &mode_obj) == 0) {
-        return null;
-    }
-
-    // Check if overlay is an Image instance
-    if (c.PyObject_IsInstance(overlay_obj, @ptrCast(&ImageType)) <= 0) {
-        c.PyErr_SetString(c.PyExc_TypeError, "overlay must be an Image object");
-        return null;
-    }
-
-    const overlay = @as(*ImageObject, @ptrCast(overlay_obj.?));
-
-    // Get blend mode (default to normal if not specified)
-    var blend_mode = zignal.Blending.normal;
-    if (mode_obj != null and mode_obj != c.Py_None()) {
-        blend_mode = blending.convertToZigBlending(mode_obj.?) catch {
-            return null; // Error already set by convertToZigBlending
-        };
-    }
-
-    // Both images must be initialized
-    if (self.py_image == null or overlay.py_image == null) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Both images must be initialized");
-        return null;
-    }
-
-    const self_pimg = self.py_image.?;
-    const overlay_pimg = overlay.py_image.?;
-
-    // Check dimensions match
-    const self_rows = self_pimg.rows();
-    const self_cols = self_pimg.cols();
-    const overlay_rows = overlay_pimg.rows();
-    const overlay_cols = overlay_pimg.cols();
-
-    if (self_rows != overlay_rows or self_cols != overlay_cols) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dimensions");
-        return null;
-    }
-
-    // Overlay must be RGBA
-    const overlay_img = switch (overlay_pimg.data) {
-        .rgba => |img| img,
-        else => {
-            c.PyErr_SetString(c.PyExc_TypeError, "Overlay image must be RGBA type");
-            return null;
-        },
-    };
-
-    // Perform the blend operation based on base image type
-    switch (self_pimg.data) {
-        .grayscale => |base_img| {
-            for (0..self_rows) |row| {
-                for (0..self_cols) |col| {
-                    const base_pixel = base_img.at(row, col).*;
-                    const base_rgb: Rgb = .{ .r = base_pixel, .g = base_pixel, .b = base_pixel };
-                    base_img.at(row, col).* = base_rgb.blend(overlay_img.at(row, col).*, blend_mode).toGray();
-                }
-            }
-        },
-        inline .rgb, .rgba => |*base_img| {
-            for (0..self_rows) |row| {
-                for (0..self_cols) |col| {
-                    base_img.at(row, col).* = base_img.at(row, col).blend(overlay_img.at(row, col).*, blend_mode);
-                }
-            }
-        },
-    }
-
-    // Return None (Python convention for in-place operations)
-    c.Py_INCREF(c.Py_None());
-    return c.Py_None();
-}
-
-const image_psnr_doc =
-    \\Calculate the Peak Signal-to-Noise Ratio (PSNR) between two images.
-    \\
-    \\Returns the PSNR value in decibels (dB). Higher values indicate more similarity.
-    \\  - Typical values: 30-50 dB for good quality
-    \\  - Returns `inf` for identical images
-    \\
-    \\## Parameters
-    \\- `other` (Image): The image to compare against. Must have the same dimensions.
-    \\
-    \\
-    \\## Raises
-    \\- `ValueError`: If the images have different dimensions
-    \\- `TypeError`: If `other` is not an Image object
-    \\
-    \\## Examples
-    \\```python
-    \\img1 = Image.load("original.png")
-    \\img2 = Image.load("compressed.jpg")
-    \\psnr_value = img1.psnr(img2)
-    \\print(f"PSNR: {psnr_value:.2f} dB")
-    \\
-    \\# Identical images return infinity
-    \\img3 = img1.copy()
-    \\print(img1.psnr(img3))  # inf
-    \\```
-;
-
-fn image_psnr(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments - expecting one Image object
-    var other_obj: ?*c.PyObject = null;
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &other_obj) == 0) {
-        return null;
-    }
-
-    // Check if other is an Image instance
-    if (c.PyObject_IsInstance(other_obj, @ptrCast(&ImageType)) <= 0) {
-        c.PyErr_SetString(c.PyExc_TypeError, "Argument must be an Image object");
-        return null;
-    }
-
-    const other = @as(*ImageObject, @ptrCast(other_obj.?));
-
-    // Require both images initialized via PyImage
-    if (self.py_image == null or other.py_image == null) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-
-    // Store in local variables after null check
-    const a = self.py_image.?;
-    const b = other.py_image.?;
-
-    // Compute PSNR only when both have the same pixel dtype
-    var out_value: f64 = 0;
-    switch (a.data) {
-        .grayscale => |img_a| {
-            const img_b = switch (b.data) {
-                .grayscale => |i| i,
-                else => {
-                    c.PyErr_SetString(c.PyExc_TypeError, "PSNR requires both images have the same pixel dtype");
-                    return null;
-                },
-            };
-            out_value = img_a.psnr(img_b) catch |err| {
-                if (err == error.DimensionMismatch) {
-                    var buf: [256]u8 = undefined;
-                    const msg = std.fmt.bufPrintZ(&buf, "Image dimensions must match. Self: {}x{}, Other: {}x{}", .{
-                        img_a.rows,
-                        img_a.cols,
-                        img_b.rows,
-                        img_b.cols,
-                    }) catch "Image dimensions must match";
-                    c.PyErr_SetString(c.PyExc_ValueError, msg.ptr);
-                    return null;
-                }
-                c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to compute PSNR");
-                return null;
-            };
-        },
-        .rgb => |img_a| {
-            const img_b = switch (b.data) {
-                .rgb => |i| i,
-                else => {
-                    c.PyErr_SetString(c.PyExc_TypeError, "PSNR requires both images have the same pixel dtype");
-                    return null;
-                },
-            };
-            out_value = img_a.psnr(img_b) catch |err| {
-                if (err == error.DimensionMismatch) {
-                    var buf: [256]u8 = undefined;
-                    const msg = std.fmt.bufPrintZ(&buf, "Image dimensions must match. Self: {}x{}, Other: {}x{}", .{
-                        img_a.rows,
-                        img_a.cols,
-                        img_b.rows,
-                        img_b.cols,
-                    }) catch "Image dimensions must match";
-                    c.PyErr_SetString(c.PyExc_ValueError, msg.ptr);
-                    return null;
-                }
-                c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to compute PSNR");
-                return null;
-            };
-        },
-        .rgba => |img_a| {
-            const img_b = switch (b.data) {
-                .rgba => |i| i,
-                else => {
-                    c.PyErr_SetString(c.PyExc_TypeError, "PSNR requires both images have the same pixel dtype");
-                    return null;
-                },
-            };
-            out_value = img_a.psnr(img_b) catch |err| {
-                if (err == error.DimensionMismatch) {
-                    var buf: [256]u8 = undefined;
-                    const msg = std.fmt.bufPrintZ(&buf, "Image dimensions must match. Self: {}x{}, Other: {}x{}", .{
-                        img_a.rows,
-                        img_a.cols,
-                        img_b.rows,
-                        img_b.cols,
-                    }) catch "Image dimensions must match";
-                    c.PyErr_SetString(c.PyExc_ValueError, msg.ptr);
-                    return null;
-                }
-                c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to compute PSNR");
-                return null;
-            };
-        },
-    }
-
-    return c.PyFloat_FromDouble(out_value);
-}
-
-const image_copy_doc =
-    \\Return a deep copy of the image.
-    \\
-    \\The returned image has the same dimensions and pixel data, but its
-    \\memory is independent. Modifying one image does not affect the other.
-    \\
-    \\## Examples
-    \\```python
-    \\img2 = img.copy()
-    \\```
-;
-
-fn image_copy(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args; // No arguments
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                const out = img.dupe(allocator) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    var tmp = out;
-                    tmp.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_view_doc =
-    \\Create a view (sub-image) from a rectangular region.
-    \\
-    \\A view shares memory with the parent image, so changes to either
-    \\are reflected in both. This is a zero-copy operation.
-    \\
-    \\## Parameters
-    \\- `rect` (`Rectangle | tuple[float, float, float, float] | None`, optional): The rectangular region to view.
-    \\  Can be a Rectangle object or a tuple of (left, top, right, bottom).
-    \\  If omitted or `None`, returns a view of the full image.
-    \\
-    \\## Examples
-    \\```python
-    \\# Create a view using a Rectangle object
-    \\rect = Rectangle(0, 0, img.cols // 2, img.rows // 2)
-    \\view = img.view(rect)
-    \\
-    \\# Create a view using a tuple (left, top, right, bottom)
-    \\view = img.view((0, 0, img.cols // 2, img.rows // 2))
-    \\
-    \\# Modifications to the view affect the parent
-    \\view.fill((255, 0, 0))  # Fills the top-left quadrant with red
-    \\```
-    \\
-    \\## Notes
-    \\- Views maintain a reference to their parent to prevent memory deallocation
-    \\- The rectangle bounds are clipped to the parent image dimensions
-    \\- Views can be nested (a view of a view)
-;
-
-fn image_view(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Optional rectangle argument; default to full image
-    var use_full: bool = false;
-    var rect: zignal.Rectangle(usize) = undefined;
-
-    const argc: c.Py_ssize_t = if (args != null) c.PyTuple_Size(args) else 0;
-    if (argc == 0) {
-        use_full = true;
-    } else if (argc == 1) {
-        var rect_obj: ?*c.PyObject = null;
-        const format = std.fmt.comptimePrint("O", .{});
-        if (c.PyArg_ParseTuple(args, format.ptr, &rect_obj) == 0) {
-            return null;
-        }
-        if (rect_obj == c.Py_None()) {
-            use_full = true;
-        } else {
-            const frect = py_utils.parseRectangle(f32, rect_obj) catch return null;
-            rect = zignal.Rectangle(usize).init(
-                @intFromFloat(@max(0, frect.l)),
-                @intFromFloat(@max(0, frect.t)),
-                @intFromFloat(@max(0, frect.r)),
-                @intFromFloat(@max(0, frect.b)),
-            );
-        }
-    } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "view() takes at most 1 argument (rect)");
-        return null;
-    }
-
-    if (self.py_image) |pimg| {
-        // Create new Python Image wrapping the view in the same variant
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                const view_img = if (use_full)
-                    img.view(zignal.Rectangle(usize).init(0, 0, img.cols, img.rows))
-                else
-                    img.view(rect);
-                const pnew = PyImage.createFrom(allocator, view_img, .borrowed) orelse {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate view");
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        c.Py_INCREF(self_obj);
-        result.parent_ref = self_obj;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_flip_left_right_doc =
-    \\Flip image left-to-right (horizontal mirror).
-    \\
-    \\Returns a new image that is a horizontal mirror of the original.
-    \\```python
-    \\flipped = img.flip_left_right()
-    \\```
-;
-
-fn image_flip_left_right(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = img.dupe(allocator) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                    return null;
-                };
-                out.flipLeftRight();
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_flip_top_bottom_doc =
-    \\Flip image top-to-bottom (vertical mirror).
-    \\
-    \\Returns a new image that is a vertical mirror of the original.
-    \\```python
-    \\flipped = img.flip_top_bottom()
-    \\```
-;
-
-fn image_flip_top_bottom(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = img.dupe(allocator) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                    return null;
-                };
-                out.flipTopBottom();
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_letterbox_doc =
-    \\Resize image to fit within the specified size while preserving aspect ratio.
-    \\
-    \\The image is scaled to fit within the target dimensions and centered with
-    \\black borders (letterboxing) to maintain the original aspect ratio.
-    \\
-    \\## Parameters
-    \\- `size` (int or tuple[int, int]):
-    \\  - If int: creates a square output of size x size
-    \\  - If tuple: target dimensions as (rows, cols)
-    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
-;
-
-fn image_letterbox(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var size: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
-    var kwlist = [_:null]?[*:0]u8{ @constCast("size"), @constCast("method"), null };
-    const format = std.fmt.comptimePrint("O|l", .{});
-
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &size, &method_value) == 0) {
-        return null;
-    }
-
-    if (size == null) {
-        c.PyErr_SetString(c.PyExc_TypeError, "letterbox() missing required argument: 'size' (pos 1)");
-        return null;
-    }
-
-    // Convert method value to Zig enum
-    const method = pythonToZigInterpolation(method_value) catch {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-        return null;
-    };
-
-    // Check if argument is a number (square) or tuple (dimensions)
-    if (c.PyLong_Check(size) != 0) {
-        // It's an integer for square letterbox
-        const square_size = c.PyLong_AsLong(size);
-        if (square_size == -1 and c.PyErr_Occurred() != null) {
-            return null;
-        }
-        if (square_size <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Size must be positive");
-            return null;
-        }
-        const result = image_letterbox_square(self, @intCast(square_size), method) catch return null;
-        return @ptrCast(result);
-    } else if (c.PyTuple_Check(size) != 0) {
-        // It's a tuple for dimensions
-        if (c.PyTuple_Size(size) != 2) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Dimensions must be a tuple of 2 integers (rows, cols)");
-            return null;
-        }
-
-        const rows_obj = c.PyTuple_GetItem(size, 0);
-        const cols_obj = c.PyTuple_GetItem(size, 1);
-
-        if (c.PyLong_Check(rows_obj) == 0 or c.PyLong_Check(cols_obj) == 0) {
-            c.PyErr_SetString(c.PyExc_TypeError, "Dimensions must be integers");
-            return null;
-        }
-
-        const rows = c.PyLong_AsLong(rows_obj);
-        const cols = c.PyLong_AsLong(cols_obj);
-
-        if ((rows == -1 or cols == -1) and c.PyErr_Occurred() != null) {
-            return null;
-        }
-
-        if (rows <= 0 or cols <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Dimensions must be positive");
-            return null;
-        }
-
-        const result = image_letterbox_shape(self, @intCast(rows), @intCast(cols), method) catch return null;
-        return @ptrCast(result);
-    } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "letterbox() argument must be an integer (square) or tuple (rows, cols)");
-        return null;
-    }
-}
-
-const image_warp_doc =
-    \\Apply a geometric transform to the image.
-    \\
-    \\This method warps an image using a geometric transform (Similarity, Affine, or Projective).
-    \\For each pixel in the output image, it applies the transform to find the corresponding
-    \\location in the source image and samples using the specified interpolation method.
-    \\
-    \\## Parameters
-    \\- `transform`: A geometric transform object (SimilarityTransform, AffineTransform, or ProjectiveTransform)
-    \\- `shape` (optional): Output image shape as (rows, cols) tuple. Defaults to input image shape.
-    \\- `method` (optional): Interpolation method. Defaults to Interpolation.BILINEAR.
-    \\
-    \\## Examples
-    \\```python
-    \\# Apply similarity transform
-    \\from_points = [(0, 0), (100, 0), (100, 100)]
-    \\to_points = [(10, 10), (110, 20), (105, 115)]
-    \\transform = SimilarityTransform(from_points, to_points)
-    \\warped = img.warp(transform)
-    \\
-    \\# Apply with custom output size and interpolation
-    \\warped = img.warp(transform, shape=(512, 512), method=Interpolation.BICUBIC)
-    \\```
-;
-
-fn image_warp(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var transform_obj: ?*c.PyObject = null;
-    var shape_obj: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
-
-    const keywords = [_:null]?[*:0]const u8{ "transform", "shape", "method", null };
-    const format = std.fmt.comptimePrint("O|Ol", .{});
-
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&keywords)), &transform_obj, &shape_obj, &method_value) == 0) {
-        return null;
-    }
 
     // Check if image is initialized
-    if (self.py_image == null) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-        return null;
-    }
-
-    // Parse interpolation method
-    const method = pythonToZigInterpolation(@intCast(method_value)) catch |err| {
-        switch (err) {
-            error.InvalidInterpolation => {
-                c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-                return null;
-            },
-        }
-    };
-
-    // Determine output dimensions
-    var out_rows = self.py_image.?.rows();
-    var out_cols = self.py_image.?.cols();
-
-    if (shape_obj != null and shape_obj != c.Py_None()) {
-        // Parse shape tuple
-        if (c.PyTuple_Check(shape_obj) == 0) {
-            c.PyErr_SetString(c.PyExc_TypeError, "shape must be a tuple of (rows, cols)");
-            return null;
-        }
-
-        if (c.PyTuple_Size(shape_obj) != 2) {
-            c.PyErr_SetString(c.PyExc_ValueError, "shape must have exactly 2 elements");
-            return null;
-        }
-
-        const rows_obj = c.PyTuple_GetItem(shape_obj, 0);
-        const cols_obj = c.PyTuple_GetItem(shape_obj, 1);
-
-        const rows_val = c.PyLong_AsLong(rows_obj);
-        const cols_val = c.PyLong_AsLong(cols_obj);
-
-        if (rows_val <= 0 or cols_val <= 0) {
-            c.PyErr_SetString(c.PyExc_ValueError, "Output dimensions must be positive");
-            return null;
-        }
-
-        out_rows = @intCast(rows_val);
-        out_cols = @intCast(cols_val);
-    }
-
-    // Import transforms module to check types
-    const transforms = @import("transforms.zig");
-
-    // Create output Python image object
-    const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-    const result = @as(*ImageObject, @ptrCast(py_obj));
-
-    // Create PyImage wrapper for the warped result
-    const warped_pyimage = allocator.create(PyImageMod.PyImage) catch {
-        c.Py_DECREF(py_obj);
-        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate memory for warped image");
-        return null;
-    };
-
-    // Apply warp using inline else to handle all image formats generically
-    switch (self.py_image.?.data) {
-        inline else => |img| {
-            var warped_img: @TypeOf(img) = .empty;
-
-            // Determine transform type and apply warp
-            if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.SimilarityTransformType)) > 0) {
-                const transform = @as(*transforms.SimilarityTransformObject, @ptrCast(transform_obj));
-                const zignal_transform: zignal.SimilarityTransform(f32) = .{
-                    .matrix = .init(.{
-                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]) },
-                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]) },
-                    }),
-                    .bias = .init(.{
-                        .{@floatCast(transform.bias[0])},
-                        .{@floatCast(transform.bias[1])},
-                    }),
-                };
-                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
-                    c.Py_DECREF(py_obj);
-                    allocator.destroy(warped_pyimage);
-                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
-                    return null;
-                };
-            } else if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.AffineTransformType)) > 0) {
-                const transform = @as(*transforms.AffineTransformObject, @ptrCast(transform_obj));
-                const zignal_transform: zignal.AffineTransform(f32) = .{
-                    .matrix = .init(.{
-                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]) },
-                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]) },
-                    }),
-                    .bias = .init(.{
-                        .{@floatCast(transform.bias[0])},
-                        .{@floatCast(transform.bias[1])},
-                    }),
-                    .allocator = allocator,
-                };
-                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
-                    c.Py_DECREF(py_obj);
-                    allocator.destroy(warped_pyimage);
-                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
-                    return null;
-                };
-            } else if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.ProjectiveTransformType)) > 0) {
-                const transform = @as(*transforms.ProjectiveTransformObject, @ptrCast(transform_obj));
-                const zignal_transform: zignal.ProjectiveTransform(f32) = .{
-                    .matrix = .init(.{
-                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]), @floatCast(transform.matrix[0][2]) },
-                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]), @floatCast(transform.matrix[1][2]) },
-                        .{ @floatCast(transform.matrix[2][0]), @floatCast(transform.matrix[2][1]), @floatCast(transform.matrix[2][2]) },
-                    }),
-                };
-                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
-                    c.Py_DECREF(py_obj);
-                    allocator.destroy(warped_pyimage);
-                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
-                    return null;
-                };
-            } else {
-                c.Py_DECREF(py_obj);
-                allocator.destroy(warped_pyimage);
-                c.PyErr_SetString(c.PyExc_TypeError, "transform must be a SimilarityTransform, AffineTransform, or ProjectiveTransform");
-                return null;
-            }
-
-            // Create PyImage wrapper for the warped result based on image type
-            warped_pyimage.* = switch (@TypeOf(img)) {
-                zignal.Image(u8) => .{ .data = .{ .grayscale = warped_img }, .ownership = .owned },
-                zignal.Image(Rgb) => .{ .data = .{ .rgb = warped_img }, .ownership = .owned },
-                zignal.Image(Rgba) => .{ .data = .{ .rgba = warped_img }, .ownership = .owned },
-                else => unreachable,
-            };
-        },
-    }
-
-    result.py_image = warped_pyimage;
-    result.numpy_ref = null;
-    result.parent_ref = null;
-
-    return py_obj;
-}
-
-const image_crop_doc =
-    \\Extract a rectangular region from the image.
-    \\
-    \\Returns a new Image containing the cropped region. Pixels outside the original
-    \\image bounds are filled with transparent black (0, 0, 0, 0).
-    \\
-    \\## Parameters
-    \\- `rect` (Rectangle): The rectangular region to extract
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\rect = Rectangle(10, 10, 110, 110)  # 100x100 region starting at (10, 10)
-    \\cropped = img.crop(rect)
-    \\print(cropped.rows, cropped.cols)  # 100 100
-    \\```
-;
-
-fn image_crop(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse Rectangle argument
-    var rect_obj: ?*c.PyObject = undefined;
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTuple(args, format.ptr, &rect_obj) == 0) {
-        return null;
-    }
-
-    // Parse the Rectangle object
-    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
-
     if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |*img| {
-                var out = @TypeOf(img.*).init(allocator, img.rows, img.cols) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                img.crop(allocator, rect, &out) catch {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate cropped image");
-                    return null;
-                };
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
-    }
-
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_extract_doc =
-    \\Extract a rotated rectangular region from the image and resample it.
-    \\
-    \\Returns a new Image containing the extracted and resampled region.
-    \\
-    \\## Parameters
-    \\- `rect` (Rectangle): The rectangular region to extract (before rotation)
-    \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
-    \\- `size` (int or tuple[int, int], optional). If not specified, uses the rectangle's dimensions.
-    \\  - If int: output is a square of side `size`
-    \\  - If tuple: output size as (rows, cols)
-    \\- `method` (Interpolation, optional): Interpolation method. Default: BILINEAR
-    \\
-    \\## Examples
-    \\```python
-    \\import math
-    \\img = Image.load("photo.png")
-    \\rect = Rectangle(10, 10, 110, 110)
-    \\
-    \\# Extract without rotation
-    \\extracted = img.extract(rect)
-    \\
-    \\# Extract with 45-degree rotation
-    \\rotated = img.extract(rect, angle=math.radians(45))
-    \\
-    \\# Extract and resize to specific dimensions
-    \\resized = img.extract(rect, size=(50, 75))
-    \\
-    \\# Extract to a 64x64 square
-    \\square = img.extract(rect, size=64)
-    \\```
-;
-
-fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var rect_obj: ?*c.PyObject = undefined;
-    var angle: f64 = 0.0;
-    var size_obj: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("rect"), @constCast("angle"), @constCast("size"), @constCast("method"), null };
-    const format = std.fmt.comptimePrint("O|dOl", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &rect_obj, &angle, &size_obj, &method_value) == 0) {
-        return null;
-    }
-
-    // Parse the Rectangle object
-    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
-
-    // Convert method value to Zig enum
-    const method = pythonToZigInterpolation(method_value) catch {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-        return null;
-    };
-
-    // Determine output size
-    var out_rows: usize = @intFromFloat(@round(rect.height()));
-    var out_cols: usize = @intFromFloat(@round(rect.width()));
-
-    if (size_obj != null and size_obj != c.Py_None()) {
-        // Accept either an integer (square) or a tuple (rows, cols)
-        if (c.PyLong_Check(size_obj) != 0) {
-            const square = c.PyLong_AsLong(size_obj);
-            if (square == -1 and c.PyErr_Occurred() != null) {
-                return null;
-            }
-            if (square <= 0) {
-                c.PyErr_SetString(c.PyExc_ValueError, "size must be positive");
-                return null;
-            }
-            out_rows = @intCast(square);
-            out_cols = @intCast(square);
-        } else if (c.PyTuple_Check(size_obj) != 0) {
-            if (c.PyTuple_Size(size_obj) != 2) {
-                c.PyErr_SetString(c.PyExc_ValueError, "size must be a 2-tuple of (rows, cols)");
-                return null;
-            }
-
-            const rows_obj = c.PyTuple_GetItem(size_obj, 0);
-            const cols_obj = c.PyTuple_GetItem(size_obj, 1);
-
-            const rows = c.PyLong_AsLong(rows_obj);
-            if (rows == -1 and c.PyErr_Occurred() != null) {
-                c.PyErr_SetString(c.PyExc_TypeError, "Rows must be an integer");
-                return null;
-            }
-            if (rows <= 0) {
-                c.PyErr_SetString(c.PyExc_ValueError, "Rows must be positive");
-                return null;
-            }
-
-            const cols = c.PyLong_AsLong(cols_obj);
-            if (cols == -1 and c.PyErr_Occurred() != null) {
-                c.PyErr_SetString(c.PyExc_TypeError, "Cols must be an integer");
-                return null;
-            }
-            if (cols <= 0) {
-                c.PyErr_SetString(c.PyExc_ValueError, "Cols must be positive");
-                return null;
-            }
-
-            out_rows = @intCast(rows);
-            out_cols = @intCast(cols);
-        } else {
-            c.PyErr_SetString(c.PyExc_TypeError, "size must be an int (square) or a tuple (rows, cols)");
-            return null;
-        }
-    }
-
-    if (self.py_image) |pimg| {
-        const py_obj = c.PyType_GenericAlloc(@ptrCast(&ImageType), 0) orelse return null;
-        const result = @as(*ImageObject, @ptrCast(py_obj));
-        switch (pimg.data) {
-            inline else => |img| {
-                var out = @TypeOf(img).init(allocator, out_rows, out_cols) catch {
-                    c.Py_DECREF(py_obj);
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
-                    return null;
-                };
-                img.extract(rect, @floatCast(angle), out, method);
-                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
-                    out.deinit(allocator);
-                    c.Py_DECREF(py_obj);
-                    return null;
-                };
-                result.py_image = pnew;
-            },
-        }
-        result.numpy_ref = null;
-        result.parent_ref = null;
-        return py_obj;
+        return @intCast(pimg.rows() * pimg.cols());
     }
     c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_insert_doc =
-    \\Insert a source image into this image at a specified rectangle with optional rotation.
-    \\
-    \\This method modifies the image in-place.
-    \\
-    \\## Parameters
-    \\- `source` (Image): The image to insert
-    \\- `rect` (Rectangle): Destination rectangle where the source will be placed
-    \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
-    \\- `method` (Interpolation, optional): Interpolation method. Default: BILINEAR
-    \\
-    \\## Examples
-    \\```python
-    \\import math
-    \\canvas = Image(500, 500)
-    \\logo = Image.load("logo.png")
-    \\
-    \\# Insert at top-left
-    \\rect = Rectangle(10, 10, 110, 110)
-    \\canvas.insert(logo, rect)
-    \\
-    \\# Insert with rotation
-    \\rect2 = Rectangle(200, 200, 300, 300)
-    \\canvas.insert(logo, rect2, angle=math.radians(45))
-    \\```
-;
-
-fn image_insert(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Parse arguments
-    var source_obj: ?*c.PyObject = undefined;
-    var rect_obj: ?*c.PyObject = undefined;
-    var angle: f64 = 0.0;
-    var method_value: c_long = 1; // Default to BILINEAR
-
-    var kwlist = [_:null]?[*:0]u8{ @constCast("source"), @constCast("rect"), @constCast("angle"), @constCast("method"), null };
-    const format = std.fmt.comptimePrint("OO|dl", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &source_obj, &rect_obj, &angle, &method_value) == 0) {
-        return null;
-    }
-
-    // Check if source is an Image object
-    if (c.PyObject_IsInstance(source_obj, @ptrCast(&ImageType)) <= 0) {
-        c.PyErr_SetString(c.PyExc_TypeError, "source must be an Image object");
-        return null;
-    }
-
-    const source = @as(*ImageObject, @ptrCast(source_obj.?));
-
-    // Parse the Rectangle object
-    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
-
-    // Convert method value to Zig enum
-    const method = pythonToZigInterpolation(method_value) catch {
-        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
-        return null;
-    };
-
-    // Variant-aware in-place insert
-    if (self.py_image) |pimg| {
-        switch (pimg.data) {
-            .grayscale => |*dst| {
-                var src_u8: Image(u8) = undefined;
-                if (source.py_image == null) {
-                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
-                    return null;
-                }
-                const src_pimg = source.py_image.?;
-                switch (src_pimg.data) {
-                    .grayscale => |img| src_u8 = img,
-                    .rgb => |img| src_u8 = img.convert(u8, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                    .rgba => |img| src_u8 = img.convert(u8, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                }
-                defer src_u8.deinit(allocator);
-                dst.insert(src_u8, rect, @floatCast(angle), method);
-            },
-            .rgb => |*dst| {
-                var src_rgb: Image(Rgb) = undefined;
-                if (source.py_image == null) {
-                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
-                    return null;
-                }
-                const src_pimg = source.py_image.?;
-                switch (src_pimg.data) {
-                    .rgb => |img| src_rgb = img,
-                    .grayscale => |img| src_rgb = img.convert(Rgb, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                    .rgba => |img| src_rgb = img.convert(Rgb, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                }
-                defer src_rgb.deinit(allocator);
-                dst.insert(src_rgb, rect, @floatCast(angle), method);
-            },
-            .rgba => |*dst| {
-                var src_rgba: Image(Rgba) = undefined;
-                if (source.py_image == null) {
-                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
-                    return null;
-                }
-                const src_pimg = source.py_image.?;
-                switch (src_pimg.data) {
-                    .rgba => |img| src_rgba = img,
-                    .grayscale => |img| src_rgba = img.convert(Rgba, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                    .rgb => |img| src_rgba = img.convert(Rgba, allocator) catch {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
-                        return null;
-                    },
-                }
-                dst.insert(src_rgba, rect, @floatCast(angle), method);
-            },
-        }
-        const none = c.Py_None();
-        c.Py_INCREF(none);
-        return none;
-    }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return null;
-}
-
-const image_canvas_doc =
-    \\Create a Canvas object for drawing operations on this image.
-    \\
-    \\## Examples
-    \\```python
-    \\img = Image.load("photo.png")
-    \\canvas = img.canvas()
-    \\canvas.fill((255, 0, 0))  # Fill with red
-    \\canvas.draw_line((0, 0), (100, 100), (0, 255, 0))  # Draw green line
-    \\```
-;
-
-fn image_canvas(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args; // No arguments expected
-    // Create Canvas by calling its constructor with this Image object
-    const args_tuple = c.Py_BuildValue("(O)", self_obj.?) orelse return null;
-    defer c.Py_DECREF(args_tuple);
-    const canvas_py = c.PyObject_CallObject(@ptrCast(&canvas.CanvasType), args_tuple) orelse return null;
-    return canvas_py;
+    return -1;
 }
 
 fn image_getitem(self_obj: ?*c.PyObject, key: ?*c.PyObject) callconv(.c) ?*c.PyObject {
@@ -3540,234 +539,317 @@ fn image_setitem(self_obj: ?*c.PyObject, key: ?*c.PyObject, value: ?*c.PyObject)
     return 0;
 }
 
-fn image_len(self_obj: ?*c.PyObject) callconv(.c) c.Py_ssize_t {
+fn image_iter(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = @as(*ImageObject, @ptrCast(self_obj.?));
-
-    // Check if image is initialized
-    if (self.py_image) |pimg| {
-        return @intCast(pimg.rows() * pimg.cols());
+    // Require PyImage variant for iteration
+    if (self.py_image == null) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+        return null;
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
-    return -1;
+    return pixel_iterator.new(self_obj);
 }
 
-pub const image_methods_metadata = [_]stub_metadata.MethodWithMetadata{
-    .{
-        .name = "load",
-        .meth = @ptrCast(&image_load),
-        .flags = c.METH_VARARGS | c.METH_CLASS,
-        .doc = image_load_doc,
-        .params = "cls, path: str",
-        .returns = "Image",
-    },
-    .{
-        .name = "convert",
-        .meth = @ptrCast(&image_convert),
-        .flags = c.METH_VARARGS,
-        .doc = image_convert_doc,
-        .params = "self, dtype: Grayscale | Rgb | Rgba",
-        .returns = "Image",
-    },
-    .{
-        .name = "from_numpy",
-        .meth = @ptrCast(&image_from_numpy),
-        .flags = c.METH_VARARGS | c.METH_CLASS,
-        .doc = image_from_numpy_doc,
-        .params = "cls, array: NDArray[np.uint8]",
-        .returns = "Image",
-    },
-    .{
-        .name = "to_numpy",
-        .meth = @ptrCast(&image_to_numpy),
-        .flags = c.METH_NOARGS,
-        .doc = image_to_numpy_doc,
-        .params = "self",
-        .returns = "NDArray[np.uint8]",
-    },
-    .{
-        .name = "save",
-        .meth = @ptrCast(&image_save),
-        .flags = c.METH_VARARGS,
-        .doc = image_save_doc,
-        .params = "self, path: str",
-        .returns = "None",
-    },
-    .{
-        .name = "fill",
-        .meth = @ptrCast(&image_fill),
-        .flags = c.METH_VARARGS,
-        .doc = image_fill_doc,
-        .params = "self, color: " ++ stub_metadata.COLOR,
-        .returns = "None",
-    },
-    .{
-        .name = "resize",
-        .meth = @ptrCast(&image_resize),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_resize_doc,
-        .params = "self, size: float | tuple[int, int], method: Interpolation = Interpolation.BILINEAR",
-        .returns = "Image",
-    },
-    .{
-        .name = "letterbox",
-        .meth = @ptrCast(&image_letterbox),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_letterbox_doc,
-        .params = "self, size: int | tuple[int, int], method: Interpolation = Interpolation.BILINEAR",
-        .returns = "Image",
-    },
-    .{
-        .name = "rotate",
-        .meth = @ptrCast(&image_rotate),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_rotate_doc,
-        .params = "self, angle: float, method: Interpolation = Interpolation.BILINEAR",
-        .returns = "Image",
-    },
-    .{
-        .name = "warp",
-        .meth = @ptrCast(&image_warp),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_warp_doc,
-        .params = "self, transform: SimilarityTransform | AffineTransform | ProjectiveTransform, shape: tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
-        .returns = "Image",
-    },
-    .{
-        .name = "copy",
-        .meth = @ptrCast(&image_copy),
-        .flags = c.METH_NOARGS,
-        .doc = image_copy_doc,
-        .params = "self",
-        .returns = "Image",
-    },
-    .{
-        .name = "view",
-        .meth = @ptrCast(&image_view),
-        .flags = c.METH_VARARGS,
-        .doc = image_view_doc,
-        .params = "self, rect: Rectangle | tuple[float, float, float, float] | None = None",
-        .returns = "Image",
-    },
-    .{
-        .name = "is_contiguous",
-        .meth = @ptrCast(&image_is_contiguous),
-        .flags = c.METH_NOARGS,
-        .doc = image_is_contiguous_doc,
-        .params = "self",
-        .returns = "bool",
-    },
-    .{
-        .name = "flip_left_right",
-        .meth = @ptrCast(&image_flip_left_right),
-        .flags = c.METH_NOARGS,
-        .doc = image_flip_left_right_doc,
-        .params = "self",
-        .returns = "Image",
-    },
-    .{
-        .name = "flip_top_bottom",
-        .meth = @ptrCast(&image_flip_top_bottom),
-        .flags = c.METH_NOARGS,
-        .doc = image_flip_top_bottom_doc,
-        .params = "self",
-        .returns = "Image",
-    },
-    .{
-        .name = "box_blur",
-        .meth = @ptrCast(&image_box_blur),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_box_blur_doc,
-        .params = "self, radius: int",
-        .returns = "Image",
-    },
-    .{
-        .name = "sharpen",
-        .meth = @ptrCast(&image_sharpen),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_sharpen_doc,
-        .params = "self, radius: int",
-        .returns = "Image",
-    },
-    .{
-        .name = "gaussian_blur",
-        .meth = @ptrCast(&image_gaussian_blur),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_gaussian_blur_doc,
-        .params = "self, sigma: float",
-        .returns = "Image",
-    },
-    .{
-        .name = "motion_blur",
-        .meth = @ptrCast(&image_motion_blur),
-        .flags = c.METH_VARARGS,
-        .doc = image_motion_blur_doc,
-        .params = "self, config: MotionBlur",
-        .returns = "Image",
-    },
-    .{
-        .name = "sobel",
-        .meth = @ptrCast(&image_sobel),
-        .flags = c.METH_NOARGS,
-        .doc = image_sobel_doc,
-        .params = "self",
-        .returns = "Image",
-    },
-    .{
-        .name = "blend",
-        .meth = @ptrCast(&image_blend),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_blend_doc,
-        .params = "self, overlay: Image, mode: Blending = Blending.NORMAL",
-        .returns = "None",
-    },
-    .{
-        .name = "psnr",
-        .meth = @ptrCast(&image_psnr),
-        .flags = c.METH_VARARGS,
-        .doc = image_psnr_doc,
-        .params = "self, other: Image",
-        .returns = "float",
-    },
-    .{
-        .name = "__format__",
-        .meth = @ptrCast(&image_format),
-        .flags = c.METH_VARARGS,
-        .doc = image_format_doc,
-        .params = "self, format_spec: str",
-        .returns = "str",
-    },
-    .{
-        .name = "canvas",
-        .meth = @ptrCast(&image_canvas),
-        .flags = c.METH_NOARGS,
-        .doc = image_canvas_doc,
-        .params = "self",
-        .returns = "Canvas",
-    },
-    .{
-        .name = "crop",
-        .meth = @ptrCast(&image_crop),
-        .flags = c.METH_VARARGS,
-        .doc = image_crop_doc,
-        .params = "self, rect: Rectangle",
-        .returns = "Image",
-    },
-    .{
-        .name = "extract",
-        .meth = @ptrCast(&image_extract),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_extract_doc,
-        .params = "self, rect: Rectangle, angle: float = 0.0, size: int | tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
-        .returns = "Image",
-    },
-    .{
-        .name = "insert",
-        .meth = @ptrCast(&image_insert),
-        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
-        .doc = image_insert_doc,
-        .params = "self, source: Image, rect: Rectangle, angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR",
-        .returns = "None",
-    },
+fn image_richcompare(self_obj: [*c]c.PyObject, other_obj: [*c]c.PyObject, op: c_int) callconv(.c) [*c]c.PyObject {
+    // Only handle == (Py_EQ=2) and != (Py_NE=3); defer other comparisons
+    if (op != c.Py_EQ and op != c.Py_NE) {
+        const not_impl = c.Py_NotImplemented();
+        c.Py_INCREF(not_impl);
+        return not_impl;
+    }
+
+    // Check if other is an Image object; if not, defer using NotImplemented
+    const image_type = @as([*c]c.PyTypeObject, @ptrCast(&ImageType));
+    if (c.PyObject_TypeCheck(other_obj, image_type) == 0) {
+        const not_impl = c.Py_NotImplemented();
+        c.Py_INCREF(not_impl);
+        return not_impl;
+    }
+
+    // Cast to ImageObject
+    const self = @as(*ImageObject, @ptrCast(self_obj));
+    const other = @as(*ImageObject, @ptrCast(other_obj));
+
+    // Variant-aware equality: compare size and per-pixel RGBA values
+    if (self.py_image == null or other.py_image == null) {
+        // If either is uninitialized, they are equal only for != case
+        return @ptrCast(py_utils.getPyBool(op != c.Py_EQ));
+    }
+    // Store in local variables after null check to avoid repeated unwrapping
+    const self_img = self.py_image.?;
+    const other_img = other.py_image.?;
+    const dims_self = .{ self_img.rows(), self_img.cols() };
+    const dims_other = .{ other_img.rows(), other_img.cols() };
+
+    if (dims_self[0] != dims_other[0] or dims_self[1] != dims_other[1]) {
+        return @ptrCast(py_utils.getPyBool(op != c.Py_EQ));
+    }
+
+    const rows = dims_self[0];
+    const cols = dims_self[1];
+    var equal = true;
+    var r: usize = 0;
+    while (r < rows) : (r += 1) {
+        var cidx: usize = 0;
+        while (cidx < cols) : (cidx += 1) {
+            const a = self_img.getPixelRgba(r, cidx);
+            const b = other_img.getPixelRgba(r, cidx);
+            if (a != b) {
+                equal = false;
+                break;
+            }
+        }
+        if (!equal) break;
+    }
+
+    if (op == c.Py_EQ) {
+        return @ptrCast(py_utils.getPyBool(equal));
+    } else {
+        return @ptrCast(py_utils.getPyBool(!equal));
+    }
+}
+
+fn image_format(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    // TODO: Keep in main file - this is a special display formatting function
+    _ = self_obj;
+    _ = args;
+    return null;
+}
+
+// Aggregate method metadata from all sub-modules
+pub const image_methods_metadata = blk: {
+    const core_methods = [_]stub_metadata.MethodWithMetadata{
+        .{
+            .name = "load",
+            .meth = @ptrCast(&core.image_load),
+            .flags = c.METH_VARARGS | c.METH_CLASS,
+            .doc = core.image_load_doc,
+            .params = "cls, path: str",
+            .returns = "Image",
+        },
+        .{
+            .name = "save",
+            .meth = @ptrCast(&core.image_save),
+            .flags = c.METH_VARARGS,
+            .doc = core.image_save_doc,
+            .params = "self, path: str",
+            .returns = "None",
+        },
+        .{
+            .name = "copy",
+            .meth = @ptrCast(&core.image_copy),
+            .flags = c.METH_NOARGS,
+            .doc = core.image_copy_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
+            .name = "fill",
+            .meth = @ptrCast(&core.image_fill),
+            .flags = c.METH_VARARGS,
+            .doc = core.image_fill_doc,
+            .params = "self, color: " ++ stub_metadata.COLOR,
+            .returns = "None",
+        },
+        .{
+            .name = "view",
+            .meth = @ptrCast(&core.image_view),
+            .flags = c.METH_VARARGS,
+            .doc = core.image_view_doc,
+            .params = "self, rect: Rectangle | tuple[float, float, float, float] | None = None",
+            .returns = "Image",
+        },
+        .{
+            .name = "is_contiguous",
+            .meth = @ptrCast(&core.image_is_contiguous),
+            .flags = c.METH_NOARGS,
+            .doc = core.image_is_contiguous_doc,
+            .params = "self",
+            .returns = "bool",
+        },
+        .{
+            .name = "convert",
+            .meth = @ptrCast(&core.image_convert),
+            .flags = c.METH_VARARGS,
+            .doc = core.image_convert_doc,
+            .params = "self, dtype: Grayscale | Rgb | Rgba",
+            .returns = "Image",
+        },
+        .{
+            .name = "canvas",
+            .meth = @ptrCast(&core.image_canvas),
+            .flags = c.METH_NOARGS,
+            .doc = core.image_canvas_doc,
+            .params = "self",
+            .returns = "Canvas",
+        },
+        .{
+            .name = "psnr",
+            .meth = @ptrCast(&core.image_psnr),
+            .flags = c.METH_VARARGS,
+            .doc = core.image_psnr_doc,
+            .params = "self, other: Image",
+            .returns = "float",
+        },
+    };
+
+    const numpy_methods = [_]stub_metadata.MethodWithMetadata{
+        .{
+            .name = "from_numpy",
+            .meth = @ptrCast(&numpy_interop.image_from_numpy),
+            .flags = c.METH_VARARGS | c.METH_CLASS,
+            .doc = numpy_interop.image_from_numpy_doc,
+            .params = "cls, array: NDArray[np.uint8]",
+            .returns = "Image",
+        },
+        .{
+            .name = "to_numpy",
+            .meth = @ptrCast(&numpy_interop.image_to_numpy),
+            .flags = c.METH_NOARGS,
+            .doc = numpy_interop.image_to_numpy_doc,
+            .params = "self",
+            .returns = "NDArray[np.uint8]",
+        },
+    };
+
+    const transform_methods = [_]stub_metadata.MethodWithMetadata{
+        .{
+            .name = "resize",
+            .meth = @ptrCast(&transforms.image_resize),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_resize_doc,
+            .params = "self, size: float | tuple[int, int], method: Interpolation = Interpolation.BILINEAR",
+            .returns = "Image",
+        },
+        .{
+            .name = "letterbox",
+            .meth = @ptrCast(&transforms.image_letterbox),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_letterbox_doc,
+            .params = "self, size: int | tuple[int, int], method: Interpolation = Interpolation.BILINEAR",
+            .returns = "Image",
+        },
+        .{
+            .name = "rotate",
+            .meth = @ptrCast(&transforms.image_rotate),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_rotate_doc,
+            .params = "self, angle: float, method: Interpolation = Interpolation.BILINEAR",
+            .returns = "Image",
+        },
+        .{
+            .name = "warp",
+            .meth = @ptrCast(&transforms.image_warp),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_warp_doc,
+            .params = "self, transform: SimilarityTransform | AffineTransform | ProjectiveTransform, shape: tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
+            .returns = "Image",
+        },
+        .{
+            .name = "flip_left_right",
+            .meth = @ptrCast(&transforms.image_flip_left_right),
+            .flags = c.METH_NOARGS,
+            .doc = transforms.image_flip_left_right_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
+            .name = "flip_top_bottom",
+            .meth = @ptrCast(&transforms.image_flip_top_bottom),
+            .flags = c.METH_NOARGS,
+            .doc = transforms.image_flip_top_bottom_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
+            .name = "crop",
+            .meth = @ptrCast(&transforms.image_crop),
+            .flags = c.METH_VARARGS,
+            .doc = transforms.image_crop_doc,
+            .params = "self, rect: Rectangle",
+            .returns = "Image",
+        },
+        .{
+            .name = "extract",
+            .meth = @ptrCast(&transforms.image_extract),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_extract_doc,
+            .params = "self, rect: Rectangle, angle: float = 0.0, size: int | tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
+            .returns = "Image",
+        },
+        .{
+            .name = "insert",
+            .meth = @ptrCast(&transforms.image_insert),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = transforms.image_insert_doc,
+            .params = "self, source: Image, rect: Rectangle, angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR",
+            .returns = "None",
+        },
+    };
+
+    const filter_methods = [_]stub_metadata.MethodWithMetadata{
+        .{
+            .name = "box_blur",
+            .meth = @ptrCast(&filtering.image_box_blur),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = filtering.image_box_blur_doc,
+            .params = "self, radius: int",
+            .returns = "Image",
+        },
+        .{
+            .name = "gaussian_blur",
+            .meth = @ptrCast(&filtering.image_gaussian_blur),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = filtering.image_gaussian_blur_doc,
+            .params = "self, sigma: float",
+            .returns = "Image",
+        },
+        .{
+            .name = "sharpen",
+            .meth = @ptrCast(&filtering.image_sharpen),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = filtering.image_sharpen_doc,
+            .params = "self, radius: int",
+            .returns = "Image",
+        },
+        .{
+            .name = "motion_blur",
+            .meth = @ptrCast(&filtering.image_motion_blur),
+            .flags = c.METH_VARARGS,
+            .doc = filtering.image_motion_blur_doc,
+            .params = "self, config: MotionBlur",
+            .returns = "Image",
+        },
+        .{
+            .name = "sobel",
+            .meth = @ptrCast(&filtering.image_sobel),
+            .flags = c.METH_NOARGS,
+            .doc = filtering.image_sobel_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
+            .name = "blend",
+            .meth = @ptrCast(&filtering.image_blend),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = filtering.image_blend_doc,
+            .params = "self, overlay: Image, mode: Blending = Blending.NORMAL",
+            .returns = "None",
+        },
+    };
+
+    const special_methods = [_]stub_metadata.MethodWithMetadata{
+        .{
+            .name = "__format__",
+            .meth = @ptrCast(&image_format),
+            .flags = c.METH_VARARGS,
+            .doc = "Format image for display",
+            .params = "self, format_spec: str",
+            .returns = "str",
+        },
+    };
+
+    // Combine all methods
+    break :blk core_methods ++ numpy_methods ++ transform_methods ++ filter_methods ++ special_methods;
 };
 
 var image_methods = stub_metadata.toPyMethodDefArray(&image_methods_metadata);
@@ -3775,21 +857,21 @@ var image_methods = stub_metadata.toPyMethodDefArray(&image_methods_metadata);
 pub const image_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
     .{
         .name = "rows",
-        .get = @ptrCast(&image_get_rows),
+        .get = @ptrCast(&core.image_get_rows),
         .set = null,
         .doc = "Number of rows (height) in the image",
         .type = "int",
     },
     .{
         .name = "cols",
-        .get = @ptrCast(&image_get_cols),
+        .get = @ptrCast(&core.image_get_cols),
         .set = null,
         .doc = "Number of columns (width) in the image",
         .type = "int",
     },
     .{
         .name = "dtype",
-        .get = @ptrCast(&image_get_dtype),
+        .get = @ptrCast(&core.image_get_dtype),
         .set = null,
         .doc = "Pixel data type (Grayscale, Rgb, or Rgba)",
         .type = "Grayscale | Rgb | Rgba",
@@ -3852,6 +934,11 @@ var image_as_mapping = c.PyMappingMethods{
     .mp_subscript = image_getitem,
     .mp_ass_subscript = image_setitem,
 };
+
+// Function to get ImageType pointer for sub-modules
+pub fn getImageType() *c.PyTypeObject {
+    return &ImageType;
+}
 
 pub var ImageType = c.PyTypeObject{
     .ob_base = .{

--- a/bindings/python/src/image/core.zig
+++ b/bindings/python/src/image/core.zig
@@ -1,0 +1,1007 @@
+//! Core image operations: I/O, memory management, type conversion
+
+const std = @import("std");
+const zignal = @import("zignal");
+const Image = zignal.Image;
+const Rgba = zignal.Rgba;
+const Rgb = zignal.Rgb;
+const detectJpegComponents = zignal.jpeg.detectComponents;
+
+const py_utils = @import("../py_utils.zig");
+const allocator = py_utils.allocator;
+const c = py_utils.c;
+
+const canvas = @import("../canvas.zig");
+const color_bindings = @import("../color.zig");
+const color_utils = @import("../color_utils.zig");
+const grayscale_format = @import("../grayscale_format.zig");
+const PyImageMod = @import("../PyImage.zig");
+const PyImage = PyImageMod.PyImage;
+const stub_metadata = @import("../stub_metadata.zig");
+
+// Import the ImageObject type from parent
+const ImageObject = @import("../image.zig").ImageObject;
+const getImageType = @import("../image.zig").getImageType;
+
+// ============================================================================
+// IMAGE LOAD
+// ============================================================================
+
+pub const image_load_doc =
+    \\Load an image from file (PNG or JPEG).
+    \\
+    \\The pixel format (Grayscale, Rgb, or Rgba) is automatically determined from the
+    \\file metadata. For PNGs, the format matches the file's color type. For JPEGs,
+    \\grayscale images load as Grayscale, color images as Rgb.
+    \\
+    \\## Parameters
+    \\- `path` (str): Path to the PNG or JPEG file to load
+    \\
+    \\## Returns
+    \\Image: A new Image object with pixels in the format matching the file
+    \\
+    \\## Raises
+    \\- `FileNotFoundError`: If the file does not exist
+    \\- `ValueError`: If the file format is unsupported
+    \\- `MemoryError`: If allocation fails during loading
+    \\- `PermissionError`: If read permission is denied
+    \\
+    \\## Examples
+    \\```python
+    \\# Load images with automatic format detection
+    \\img = Image.load("photo.png")     # May be Rgba
+    \\img2 = Image.load("grayscale.jpg") # Will be Grayscale
+    \\img3 = Image.load("rgb.png")       # Will be Rgb
+    \\
+    \\# Check format after loading
+    \\print(img.dtype)  # e.g., Rgba, Rgb, or Grayscale
+    \\```
+;
+
+pub fn image_load(type_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = type_obj;
+
+    // Parse file path argument
+    var file_path: [*c]const u8 = undefined;
+    const format = std.fmt.comptimePrint("s", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &file_path) == 0) {
+        return null;
+    }
+
+    // Convert C string to Zig slice
+    const path_slice = std.mem.span(file_path);
+
+    // Detect format and load accordingly
+    const is_jpeg = std.mem.endsWith(u8, path_slice, ".jpg") or
+        std.mem.endsWith(u8, path_slice, ".jpeg") or
+        std.mem.endsWith(u8, path_slice, ".JPG") or
+        std.mem.endsWith(u8, path_slice, ".JPEG");
+
+    if (is_jpeg) {
+        // Read file to detect JPEG color space
+        const data = std.fs.cwd().readFileAlloc(allocator, path_slice, 200 * 1024 * 1024) catch |err| {
+            py_utils.setErrorWithPath(err, path_slice);
+            return null;
+        };
+        defer allocator.free(data);
+
+        const components = detectJpegComponents(data) orelse {
+            c.PyErr_SetString(c.PyExc_ValueError, "Invalid JPEG file (no SOF marker)");
+            return null;
+        };
+
+        if (components == 1) {
+            // Grayscale JPEG
+            const image = Image(u8).load(allocator, path_slice) catch |err| {
+                py_utils.setErrorWithPath(err, path_slice);
+                return null;
+            };
+            const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(getImageType()), 0)));
+            if (self == null) {
+                var img = image;
+                img.deinit(allocator);
+                return null;
+            }
+            const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
+                var img = image;
+                img.deinit(allocator);
+                c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+                c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                return null;
+            };
+            self.?.py_image = pimg;
+            self.?.numpy_ref = null;
+            self.?.parent_ref = null;
+            return @as(?*c.PyObject, @ptrCast(self));
+        } else {
+            // Color JPEG - load as RGB
+            const image = Image(Rgb).load(allocator, path_slice) catch |err| {
+                py_utils.setErrorWithPath(err, path_slice);
+                return null;
+            };
+            const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(getImageType()), 0)));
+            if (self == null) {
+                var img = image;
+                img.deinit(allocator);
+                return null;
+            }
+            const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
+                var img = image;
+                img.deinit(allocator);
+                c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+                c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                return null;
+            };
+            self.?.py_image = pimg;
+            self.?.numpy_ref = null;
+            self.?.parent_ref = null;
+            return @as(?*c.PyObject, @ptrCast(self));
+        }
+    }
+
+    // PNG: load native dtype (Grayscale, RGB, RGBA)
+    if (std.mem.endsWith(u8, path_slice, ".png") or std.mem.endsWith(u8, path_slice, ".PNG")) {
+        const data = std.fs.cwd().readFileAlloc(allocator, path_slice, 100 * 1024 * 1024) catch |err| {
+            py_utils.setErrorWithPath(err, path_slice);
+            return null;
+        };
+        defer allocator.free(data);
+        var decoded = zignal.png.decode(allocator, data) catch |err| {
+            py_utils.setErrorWithPath(err, path_slice);
+            return null;
+        };
+        defer decoded.deinit(allocator);
+        const native = zignal.png.toNativeImage(allocator, decoded) catch |err| {
+            py_utils.setErrorWithPath(err, path_slice);
+            return null;
+        };
+        const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(getImageType()), 0)));
+        if (self == null) return null;
+        switch (native) {
+            .grayscale => |img| {
+                const p = PyImage.createFrom(allocator, img, .owned) orelse {
+                    var tmp = img;
+                    tmp.deinit(allocator);
+                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                self.?.py_image = p;
+            },
+            .rgb => |img| {
+                const p = PyImage.createFrom(allocator, img, .owned) orelse {
+                    var tmp = img;
+                    tmp.deinit(allocator);
+                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                self.?.py_image = p;
+            },
+            .rgba => |img| {
+                const p = PyImage.createFrom(allocator, img, .owned) orelse {
+                    var tmp = img;
+                    tmp.deinit(allocator);
+                    c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                self.?.py_image = p;
+            },
+        }
+        self.?.numpy_ref = null;
+        self.?.parent_ref = null;
+        return @as(?*c.PyObject, @ptrCast(self));
+    }
+
+    // Default: Try to load as RGB
+    const image = Image(Rgb).load(allocator, path_slice) catch |err| {
+        py_utils.setErrorWithPath(err, path_slice);
+        return null;
+    };
+    const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(getImageType()), 0)));
+    if (self == null) {
+        var img = image;
+        img.deinit(allocator);
+        return null;
+    }
+    const pimg = PyImage.createFrom(allocator, image, .owned) orelse {
+        var img = image;
+        img.deinit(allocator);
+        c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+        return null;
+    };
+    self.?.py_image = pimg;
+    self.?.numpy_ref = null;
+    self.?.parent_ref = null;
+    return @as(?*c.PyObject, @ptrCast(self));
+}
+
+// ============================================================================
+// IMAGE SAVE
+// ============================================================================
+
+pub const image_save_doc =
+    \\Save the image to a PNG file.
+    \\
+    \\## Parameters
+    \\- `path` (str): Path where the PNG file will be saved. Must have .png extension.
+    \\
+    \\## Raises
+    \\- `ValueError`: If the file does not have .png extension
+    \\- `MemoryError`: If allocation fails during save
+    \\- `PermissionError`: If write permission is denied
+    \\- `FileNotFoundError`: If the directory does not exist
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("input.png")
+    \\img.save("output.png")
+    \\```
+;
+
+pub fn image_save(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse file path argument
+    var file_path: [*c]const u8 = undefined;
+    const format = std.fmt.comptimePrint("s", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &file_path) == 0) {
+        return null;
+    }
+
+    // Convert C string to Zig slice
+    const path_slice = std.mem.span(file_path);
+
+    // Validate file extension
+    if (!std.mem.endsWith(u8, path_slice, ".png") and
+        !std.mem.endsWith(u8, path_slice, ".PNG"))
+    {
+        c.PyErr_SetString(c.PyExc_ValueError, "File must have .png extension. Currently only PNG format is supported.");
+        return null;
+    }
+
+    // Save PNG for current image format
+    if (self.py_image) |pimg| {
+        const res = switch (pimg.data) {
+            .grayscale => |img| img.save(allocator, path_slice),
+            .rgb => |img| img.save(allocator, path_slice),
+            .rgba => |img| img.save(allocator, path_slice),
+        };
+        res catch |err| {
+            py_utils.setErrorWithPath(err, path_slice);
+            return null;
+        };
+    } else {
+        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+        return null;
+    }
+
+    // Return None
+    const none = c.Py_None();
+    c.Py_INCREF(none);
+    return none;
+}
+
+// ============================================================================
+// IMAGE COPY
+// ============================================================================
+
+pub const image_copy_doc =
+    \\Create a deep copy of the image.
+    \\
+    \\Returns a new Image with the same dimensions and pixel data,
+    \\but with its own allocated memory.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\copy = img.copy()
+    \\# Modifying copy doesn't affect original
+    \\copy[0, 0] = (255, 0, 0)
+    \\```
+;
+
+pub fn image_copy(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args; // No arguments
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        const copy_result = switch (pimg.data) {
+            .grayscale => |img| blk: {
+                const copy = Image(u8).init(allocator, img.rows, img.cols) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                img.copy(copy);
+                break :blk PyImage.createFrom(allocator, copy, .owned);
+            },
+            .rgb => |img| blk: {
+                const copy = Image(Rgb).init(allocator, img.rows, img.cols) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                img.copy(copy);
+                break :blk PyImage.createFrom(allocator, copy, .owned);
+            },
+            .rgba => |img| blk: {
+                const copy = Image(Rgba).init(allocator, img.rows, img.cols) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                img.copy(copy);
+                break :blk PyImage.createFrom(allocator, copy, .owned);
+            },
+        };
+
+        const pimg_copy = copy_result orelse {
+            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+            return null;
+        };
+
+        // Create new Image object to wrap the copy
+        const new_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse {
+            pimg_copy.deinit(allocator);
+            return null;
+        };
+        const new_self = @as(*ImageObject, @ptrCast(new_obj));
+        new_self.py_image = pimg_copy;
+        new_self.numpy_ref = null;
+        new_self.parent_ref = null;
+
+        return new_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+// ============================================================================
+// IMAGE FILL
+// ============================================================================
+
+pub const image_fill_doc =
+    \\Fill the entire image with a solid color.
+    \\
+    \\## Parameters
+    \\- `color`: Fill color. Can be:
+    \\  - Integer (0-255) for grayscale images
+    \\  - RGB tuple (r, g, b) with values 0-255
+    \\  - RGBA tuple (r, g, b, a) with values 0-255
+    \\  - Any color object (Rgb, Hsl, Hsv, etc.)
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image(100, 100)
+    \\img.fill((255, 0, 0))  # Fill with red
+    \\```
+;
+
+pub fn image_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse the color argument (already validated in init)
+    var color_obj: ?*c.PyObject = undefined;
+    const format = std.fmt.comptimePrint("O", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &color_obj) == 0) {
+        return null;
+    }
+
+    const color = color_utils.parseColorTo(Rgba, color_obj) catch {
+        return null;
+    };
+
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            .grayscale => |img| img.fill(color),
+            .rgb => |img| img.fill(color),
+            .rgba => |img| img.fill(color),
+        }
+    } else {
+        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+        return null;
+    }
+
+    // Return None
+    const none = c.Py_None();
+    c.Py_INCREF(none);
+    return none;
+}
+
+// ============================================================================
+// IMAGE VIEW
+// ============================================================================
+
+pub const image_view_doc =
+    \\Create a view of the image or a sub-region (zero-copy).
+    \\
+    \\Creates a new Image that shares the same underlying pixel data. Changes
+    \\to the view affect the original image and vice versa.
+    \\
+    \\## Parameters
+    \\- `rect` (Rectangle | tuple[float, float, float, float] | None): Optional rectangle
+    \\  defining the sub-region to view. If None, creates a view of the entire image.
+    \\  When providing a tuple, it should be (left, top, right, bottom).
+    \\
+    \\## Returns
+    \\Image: A view of the image that shares the same pixel data
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\# View entire image
+    \\view = img.view()
+    \\# View sub-region
+    \\rect = Rectangle(10, 10, 100, 100)
+    \\sub = img.view(rect)
+    \\# Modifications to view affect original
+    \\sub.fill((255, 0, 0))  # Fills region in original image
+    \\```
+;
+
+pub fn image_view(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse optional rectangle argument
+    var rect_obj: ?*c.PyObject = null;
+    const format = std.fmt.comptimePrint("|O", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &rect_obj) == 0) {
+        return null;
+    }
+
+    if (self.py_image) |pimg| {
+        // Create view based on current image type
+        const view_result = switch (pimg.data) {
+            .grayscale => |img| blk: {
+                if (rect_obj) |ro| {
+                    const rect = py_utils.parseRectangle(usize, ro) catch return null;
+                    break :blk PyImage.createFrom(allocator, img.view(rect), .borrowed);
+                } else {
+                    const full_rect = zignal.Rectangle(usize).init(0, 0, img.cols, img.rows);
+                    break :blk PyImage.createFrom(allocator, img.view(full_rect), .borrowed);
+                }
+            },
+            .rgb => |img| blk: {
+                if (rect_obj) |ro| {
+                    const rect = py_utils.parseRectangle(usize, ro) catch return null;
+                    break :blk PyImage.createFrom(allocator, img.view(rect), .borrowed);
+                } else {
+                    const full_rect = zignal.Rectangle(usize).init(0, 0, img.cols, img.rows);
+                    break :blk PyImage.createFrom(allocator, img.view(full_rect), .borrowed);
+                }
+            },
+            .rgba => |img| blk: {
+                if (rect_obj) |ro| {
+                    const rect = py_utils.parseRectangle(usize, ro) catch return null;
+                    break :blk PyImage.createFrom(allocator, img.view(rect), .borrowed);
+                } else {
+                    const full_rect = zignal.Rectangle(usize).init(0, 0, img.cols, img.rows);
+                    break :blk PyImage.createFrom(allocator, img.view(full_rect), .borrowed);
+                }
+            },
+        };
+
+        const pimg_view = view_result orelse {
+            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image view");
+            return null;
+        };
+
+        // Create new Image object to wrap the view
+        const new_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse {
+            pimg_view.deinit(allocator);
+            return null;
+        };
+        const new_self = @as(*ImageObject, @ptrCast(new_obj));
+        new_self.py_image = pimg_view;
+        new_self.numpy_ref = null;
+        // Keep reference to parent to prevent deallocation
+        c.Py_INCREF(self_obj);
+        new_self.parent_ref = self_obj;
+
+        return new_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+// ============================================================================
+// IMAGE IS_CONTIGUOUS
+// ============================================================================
+
+pub const image_is_contiguous_doc =
+    \\Check if the image data is stored contiguously in memory.
+    \\
+    \\Returns True if pixels are stored without gaps (stride == cols),
+    \\False for views or images with custom strides.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image(100, 100)
+    \\print(img.is_contiguous())  # True
+    \\view = img.view(Rectangle(10, 10, 50, 50))
+    \\print(view.is_contiguous())  # False
+    \\```
+;
+
+pub fn image_is_contiguous(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args; // No arguments
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        const is_contig = switch (pimg.data) {
+            .grayscale => |img| img.isContiguous(),
+            .rgb => |img| img.isContiguous(),
+            .rgba => |img| img.isContiguous(),
+        };
+
+        return @ptrCast(py_utils.getPyBool(is_contig));
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+// ============================================================================
+// IMAGE CONVERT
+// ============================================================================
+
+pub const image_convert_doc =
+    \\
+    \\Convert the image to a different pixel data type.
+    \\
+    \\Supported targets: Grayscale, Rgb, Rgba.
+    \\
+    \\Returns a new Image with the requested format.
+;
+
+pub fn image_convert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse one argument: target dtype sentinel or instance of Rgb/Rgba
+    var dtype_obj: ?*c.PyObject = null;
+    const fmt = std.fmt.comptimePrint("O", .{});
+    if (c.PyArg_ParseTuple(args, fmt.ptr, &dtype_obj) == 0) {
+        return null;
+    }
+
+    if (dtype_obj == null) {
+        c.PyErr_SetString(c.PyExc_TypeError, "convert() requires a target dtype (zignal.Grayscale, zignal.Rgb, or zignal.Rgba)");
+        return null;
+    }
+
+    // Determine target type
+    var target_gray = false;
+    var target_rgb = false;
+    var target_rgba = false;
+
+    // TODO: Remove explicit cast after Python 3.10 is dropped
+    const is_type_obj = c.PyObject_TypeCheck(dtype_obj.?, @as([*c]c.PyTypeObject, @ptrCast(&c.PyType_Type))) != 0;
+    if (is_type_obj) {
+        if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&grayscale_format.GrayscaleType))) {
+            target_gray = true;
+        } else if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&color_bindings.RgbType))) {
+            target_rgb = true;
+        } else if (dtype_obj.? == @as(*c.PyObject, @ptrCast(&color_bindings.RgbaType))) {
+            target_rgba = true;
+        } else {
+            c.PyErr_SetString(c.PyExc_TypeError, "format must be zignal.Grayscale, zignal.Rgb, or zignal.Rgba");
+            return null;
+        }
+    } else {
+        if (c.PyObject_IsInstance(dtype_obj.?, @ptrCast(&color_bindings.RgbType)) == 1) {
+            target_rgb = true;
+        } else if (c.PyObject_IsInstance(dtype_obj.?, @ptrCast(&color_bindings.RgbaType)) == 1) {
+            target_rgba = true;
+        } else {
+            c.PyErr_SetString(c.PyExc_TypeError, "format must be zignal.Grayscale, zignal.Rgb, or zignal.Rgba");
+            return null;
+        }
+    }
+
+    // Execute conversion using underlying Image(T).convert
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            .grayscale => |*img| {
+                if (target_gray) {
+                    // Same dtype: copy
+                    var out = Image(u8).init(allocator, img.rows, img.cols) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                        return null;
+                    };
+                    img.copy(out);
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        out.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgb) {
+                    const out = img.convert(Rgb, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgba) {
+                    const out = img.convert(Rgba, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                }
+            },
+            .rgb => |*img| {
+                if (target_gray) {
+                    const out = img.convert(u8, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgb) {
+                    var out = Image(Rgb).init(allocator, img.rows, img.cols) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                        return null;
+                    };
+                    img.copy(out);
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        out.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgba) {
+                    const out = img.convert(Rgba, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                }
+            },
+            .rgba => |*img| {
+                if (target_gray) {
+                    const out = img.convert(u8, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgb) {
+                    const out = img.convert(Rgb, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert image");
+                        return null;
+                    };
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        var tmp = out;
+                        tmp.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                } else if (target_rgba) {
+                    var out = Image(Rgba).init(allocator, img.rows, img.cols) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                        return null;
+                    };
+                    img.copy(out);
+                    const py = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+                    const out_self = @as(*ImageObject, @ptrCast(py));
+                    const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                        out.deinit(allocator);
+                        c.Py_DECREF(py);
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                        return null;
+                    };
+                    out_self.py_image = pnew;
+                    out_self.numpy_ref = null;
+                    out_self.parent_ref = null;
+                    return py;
+                }
+            },
+        }
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+// ============================================================================
+// IMAGE CANVAS
+// ============================================================================
+
+pub const image_canvas_doc =
+    \\Get a Canvas object for drawing on this image.
+    \\
+    \\Returns a Canvas that can be used to draw shapes, lines, and text
+    \\directly onto the image pixels.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image(200, 200)
+    \\cv = img.canvas()
+    \\cv.draw_circle(100, 100, 50, (255, 0, 0))
+    \\cv.fill_rect(10, 10, 50, 50, (0, 255, 0))
+    \\```
+;
+
+pub fn image_canvas(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args; // No arguments expected
+    // Create Canvas by calling its constructor with this Image object
+    const args_tuple = c.Py_BuildValue("(O)", self_obj.?) orelse return null;
+    defer c.Py_DECREF(args_tuple);
+    const canvas_py = c.PyObject_CallObject(@ptrCast(&canvas.CanvasType), args_tuple) orelse return null;
+    return canvas_py;
+}
+
+// ============================================================================
+// IMAGE PSNR
+// ============================================================================
+
+pub const image_psnr_doc =
+    \\Calculate Peak Signal-to-Noise Ratio between two images.
+    \\
+    \\PSNR is a quality metric where higher values indicate greater similarity.
+    \\Typical values: 30-50 dB (higher is better). Returns infinity for identical images.
+    \\
+    \\## Parameters
+    \\- `other` (Image): The image to compare against. Must have same dimensions and dtype.
+    \\
+    \\## Returns
+    \\float: PSNR value in decibels (dB), or inf for identical images
+    \\
+    \\## Raises
+    \\- `ValueError`: If images have different dimensions or dtypes
+    \\
+    \\## Examples
+    \\```python
+    \\original = Image.load("original.png")
+    \\compressed = Image.load("compressed.png")
+    \\quality = original.psnr(compressed)
+    \\print(f"PSNR: {quality:.2f} dB")
+    \\```
+;
+
+pub fn image_psnr(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse other image argument
+    var other_obj: ?*c.PyObject = undefined;
+    const format = std.fmt.comptimePrint("O!", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, getImageType(), &other_obj) == 0) {
+        return null;
+    }
+
+    const other = @as(*ImageObject, @ptrCast(other_obj.?));
+
+    if (self.py_image == null or other.py_image == null) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Both images must be initialized");
+        return null;
+    }
+
+    // Check that images have compatible types
+    const self_type = switch (self.py_image.?.data) {
+        .grayscale => "grayscale",
+        .rgb => "rgb",
+        .rgba => "rgba",
+    };
+    const other_type = switch (other.py_image.?.data) {
+        .grayscale => "grayscale",
+        .rgb => "rgb",
+        .rgba => "rgba",
+    };
+
+    if (!std.mem.eql(u8, self_type, other_type)) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dtype for PSNR calculation");
+        return null;
+    }
+
+    // Calculate PSNR based on image type
+    const psnr_value = switch (self.py_image.?.data) {
+        .grayscale => |img1| blk: {
+            const img2 = other.py_image.?.data.grayscale;
+            if (img1.rows != img2.rows or img1.cols != img2.cols) {
+                c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dimensions");
+                return null;
+            }
+
+            // Calculate MSE
+            var sum: f64 = 0.0;
+            for (0..img1.rows) |r| {
+                for (0..img1.cols) |col| {
+                    const p1 = img1.at(r, col);
+                    const p2 = img2.at(r, col);
+                    const diff = @as(f64, @floatFromInt(@as(i32, @intCast(p1.*)) - @as(i32, @intCast(p2.*))));
+                    sum += diff * diff;
+                }
+            }
+            const mse = sum / @as(f64, @floatFromInt(img1.rows * img1.cols));
+            if (mse == 0.0) {
+                break :blk std.math.inf(f64);
+            }
+            const max_pixel_value = 255.0;
+            break :blk 20.0 * std.math.log10(max_pixel_value / @sqrt(mse));
+        },
+        .rgb => |img1| blk: {
+            const img2 = other.py_image.?.data.rgb;
+            if (img1.rows != img2.rows or img1.cols != img2.cols) {
+                c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dimensions");
+                return null;
+            }
+
+            // Calculate MSE across all channels
+            var sum: f64 = 0.0;
+            for (0..img1.rows) |r| {
+                for (0..img1.cols) |col| {
+                    const p1 = img1.at(r, col);
+                    const p2 = img2.at(r, col);
+                    const dr = @as(f64, @floatFromInt(@as(i32, p1.r) - @as(i32, p2.r)));
+                    const dg = @as(f64, @floatFromInt(@as(i32, p1.g) - @as(i32, p2.g)));
+                    const db = @as(f64, @floatFromInt(@as(i32, p1.b) - @as(i32, p2.b)));
+                    sum += dr * dr + dg * dg + db * db;
+                }
+            }
+            const mse = sum / @as(f64, @floatFromInt(img1.rows * img1.cols * 3));
+            if (mse == 0.0) {
+                break :blk std.math.inf(f64);
+            }
+            const max_pixel_value = 255.0;
+            break :blk 20.0 * std.math.log10(max_pixel_value / @sqrt(mse));
+        },
+        .rgba => |img1| blk: {
+            const img2 = other.py_image.?.data.rgba;
+            if (img1.rows != img2.rows or img1.cols != img2.cols) {
+                c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dimensions");
+                return null;
+            }
+
+            // Calculate MSE across all channels including alpha
+            var sum: f64 = 0.0;
+            for (0..img1.rows) |r| {
+                for (0..img1.cols) |col| {
+                    const p1 = img1.at(r, col);
+                    const p2 = img2.at(r, col);
+                    const dr = @as(f64, @floatFromInt(@as(i32, p1.r) - @as(i32, p2.r)));
+                    const dg = @as(f64, @floatFromInt(@as(i32, p1.g) - @as(i32, p2.g)));
+                    const db = @as(f64, @floatFromInt(@as(i32, p1.b) - @as(i32, p2.b)));
+                    const da = @as(f64, @floatFromInt(@as(i32, p1.a) - @as(i32, p2.a)));
+                    sum += dr * dr + dg * dg + db * db + da * da;
+                }
+            }
+            const mse = sum / @as(f64, @floatFromInt(img1.rows * img1.cols * 4));
+            if (mse == 0.0) {
+                break :blk std.math.inf(f64);
+            }
+            const max_pixel_value = 255.0;
+            break :blk 20.0 * std.math.log10(max_pixel_value / @sqrt(mse));
+        },
+    };
+
+    return c.PyFloat_FromDouble(psnr_value);
+}
+
+// ============================================================================
+// PROPERTY GETTERS
+// ============================================================================
+
+pub fn image_get_rows(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    if (self.py_image) |pimg| {
+        const rows = switch (pimg.data) {
+            .grayscale => |img| img.rows,
+            .rgb => |img| img.rows,
+            .rgba => |img| img.rows,
+        };
+        return c.PyLong_FromSize_t(rows);
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub fn image_get_cols(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    if (self.py_image) |pimg| {
+        const cols = switch (pimg.data) {
+            .grayscale => |img| img.cols,
+            .rgb => |img| img.cols,
+            .rgba => |img| img.cols,
+        };
+        return c.PyLong_FromSize_t(cols);
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub fn image_get_dtype(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
+    _ = closure;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    if (self.py_image) |pimg| {
+        const dtype_obj = switch (pimg.data) {
+            .grayscale => @as(*c.PyObject, @ptrCast(&grayscale_format.GrayscaleType)),
+            .rgb => @as(*c.PyObject, @ptrCast(&color_bindings.RgbType)),
+            .rgba => @as(*c.PyObject, @ptrCast(&color_bindings.RgbaType)),
+        };
+        c.Py_INCREF(dtype_obj);
+        return dtype_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}

--- a/bindings/python/src/image/filtering.zig
+++ b/bindings/python/src/image/filtering.zig
@@ -1,0 +1,470 @@
+//! Image filtering and effects
+
+const std = @import("std");
+const zignal = @import("zignal");
+const Image = zignal.Image;
+const Rgba = zignal.Rgba;
+const Rgb = zignal.Rgb;
+const MotionBlur = zignal.MotionBlur;
+
+const py_utils = @import("../py_utils.zig");
+const allocator = py_utils.allocator;
+const c = py_utils.c;
+
+const blending = @import("../blending.zig");
+const PyImageMod = @import("../PyImage.zig");
+const PyImage = PyImageMod.PyImage;
+
+// Import the ImageObject type from parent
+const ImageObject = @import("../image.zig").ImageObject;
+const getImageType = @import("../image.zig").getImageType;
+
+// Filtering functions
+pub const image_box_blur_doc =
+    \\Apply a box blur to the image.
+    \\
+    \\## Parameters
+    \\- `radius` (int): Non-negative blur radius in pixels. `0` returns an unmodified copy.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\soft = img.box_blur(2)
+    \\identity = img.box_blur(0)  # no-op copy
+    \\```
+;
+
+pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var radius_long: c_long = 0;
+    var kwlist = [_:null]?[*:0]u8{ @constCast("radius"), null };
+    const format = std.fmt.comptimePrint("l", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &radius_long) == 0) {
+        return null;
+    }
+
+    if (radius_long < 0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "radius must be >= 0");
+        return null;
+    }
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).empty;
+                img.boxBlur(allocator, &out, @intCast(radius_long)) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    return null;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_gaussian_blur_doc =
+    \\Apply Gaussian blur to the image.
+    \\
+    \\## Parameters
+    \\- `sigma` (float): Standard deviation of the Gaussian kernel. Must be > 0.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\blurred = img.gaussian_blur(2.0)
+    \\blurred_soft = img.gaussian_blur(5.0)  # More blur
+    \\```
+;
+
+pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var sigma: f64 = 0;
+    var kwlist = [_:null]?[*:0]u8{ @constCast("sigma"), null };
+    const format = std.fmt.comptimePrint("d", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &sigma) == 0) {
+        return null;
+    }
+
+    // Validate sigma: must be finite and > 0
+    if (!std.math.isFinite(sigma) or sigma <= 0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "sigma must be > 0");
+        return null;
+    }
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).empty;
+                img.gaussianBlur(allocator, @floatCast(sigma), &out) catch |err| {
+                    c.Py_DECREF(py_obj);
+                    if (err == error.InvalidSigma) {
+                        c.PyErr_SetString(c.PyExc_ValueError, "Invalid sigma value");
+                    } else {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    }
+                    return null;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_sharpen_doc =
+    \\Sharpen the image using unsharp masking (2 * self - blur_box).
+    \\
+    \\## Parameters
+    \\- `radius` (int): Non-negative blur radius used to compute the unsharp mask. `0` returns an unmodified copy.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\crisp = img.sharpen(2)
+    \\identity = img.sharpen(0)  # no-op copy
+    \\```
+;
+
+pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var radius_long: c_long = 0;
+    var kwlist = [_:null]?[*:0]u8{ @constCast("radius"), null };
+    const format = std.fmt.comptimePrint("l", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &radius_long) == 0) {
+        return null;
+    }
+
+    if (radius_long < 0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "radius must be >= 0");
+        return null;
+    }
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).empty;
+                img.sharpen(allocator, &out, @intCast(radius_long)) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    return null;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_motion_blur_doc =
+    \\Apply motion blur effect to the image.
+    \\
+    \\Motion blur simulates camera or object movement during exposure.
+    \\Three types of motion blur are supported:
+    \\- `MotionBlur.linear()` - Linear motion blur
+    \\- `MotionBlur.radial_zoom()` - Radial zoom blur
+    \\- `MotionBlur.radial_spin()` - Radial spin blur
+    \\
+    \\## Examples
+    \\```python
+    \\from zignal import Image, MotionBlur
+    \\import math
+    \\
+    \\img = Image.load("photo.png")
+    \\
+    \\# Linear motion blur examples
+    \\horizontal_blur = img.motion_blur(MotionBlur.linear(angle=0, distance=30))  # Camera panning
+    \\vertical_blur = img.motion_blur(MotionBlur.linear(angle=math.pi/2, distance=20))  # Camera shake
+    \\diagonal_blur = img.motion_blur(MotionBlur.linear(angle=math.pi/4, distance=25))  # Diagonal motion
+    \\
+    \\# Radial zoom blur examples
+    \\center_zoom = img.motion_blur(MotionBlur.radial_zoom(center=(0.5, 0.5), strength=0.7))  # Center zoom burst
+    \\off_center_zoom = img.motion_blur(MotionBlur.radial_zoom(center=(0.33, 0.67), strength=0.5))  # Rule of thirds
+    \\subtle_zoom = img.motion_blur(MotionBlur.radial_zoom(strength=0.3))  # Subtle effect with defaults
+    \\
+    \\# Radial spin blur examples
+    \\center_spin = img.motion_blur(MotionBlur.radial_spin(center=(0.5, 0.5), strength=0.5))  # Center rotation
+    \\swirl_effect = img.motion_blur(MotionBlur.radial_spin(center=(0.3, 0.3), strength=0.6))  # Off-center swirl
+    \\strong_spin = img.motion_blur(MotionBlur.radial_spin(strength=0.8))  # Strong spin with defaults
+    \\```
+    \\
+    \\## Notes
+    \\- Linear blur preserves image dimensions
+    \\- Radial effects use bilinear interpolation for smooth results
+    \\- Strength values closer to 1.0 produce stronger blur effects
+;
+
+pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const motion_blur = @import("../motion_blur.zig");
+
+    // Parse the single argument (config object)
+    var config_obj: ?*c.PyObject = undefined;
+    if (c.PyArg_ParseTuple(args, "O", &config_obj) == 0) {
+        return null;
+    }
+
+    // Check that it's a MotionBlur object
+    const type_obj = c.Py_TYPE(config_obj);
+    const type_name = type_obj.*.tp_name;
+
+    if (!std.mem.eql(u8, std.mem.span(type_name), "zignal.MotionBlur")) {
+        c.PyErr_SetString(c.PyExc_TypeError, "config must be a MotionBlur object created with MotionBlur.linear(), MotionBlur.radial_zoom(), or MotionBlur.radial_spin()");
+        return null;
+    }
+
+    // Cast to MotionBlurObject to access the blur_type discriminator
+    const blur_obj = @as(*motion_blur.MotionBlurObject, @ptrCast(config_obj));
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).empty;
+
+                // Create the appropriate MotionBlur config based on the type
+                const blur_config: MotionBlur = switch (blur_obj.blur_type) {
+                    .linear => .{
+                        .linear = .{
+                            .angle = @floatCast(blur_obj.angle),
+                            .distance = @intCast(blur_obj.distance),
+                        },
+                    },
+                    .radial_zoom => .{
+                        .radial_zoom = .{
+                            .center_x = @floatCast(blur_obj.center_x),
+                            .center_y = @floatCast(blur_obj.center_y),
+                            .strength = @floatCast(blur_obj.strength),
+                        },
+                    },
+                    .radial_spin => .{
+                        .radial_spin = .{
+                            .center_x = @floatCast(blur_obj.center_x),
+                            .center_y = @floatCast(blur_obj.center_y),
+                            .strength = @floatCast(blur_obj.strength),
+                        },
+                    },
+                };
+
+                img.motionBlur(allocator, blur_config, &out) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    return null;
+                };
+
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_sobel_doc =
+    \\Apply Sobel edge detection and return the gradient magnitude.
+    \\
+    \\The result is a new grayscale image (`dtype=zignal.Grayscale`) where
+    \\each pixel encodes the edge strength at that location.
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\edges = img.sobel()
+    \\```
+;
+
+pub fn image_sobel(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+
+        var out = Image(u8).empty;
+        switch (pimg.data) {
+            inline else => |img| {
+                img.sobel(allocator, &out) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    return null;
+                };
+            },
+        }
+
+        const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+            out.deinit(allocator);
+            c.Py_DECREF(py_obj);
+            return null;
+        };
+        result.py_image = pnew;
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_blend_doc =
+    \\Blend an overlay image onto this image using the specified blend mode.
+    \\
+    \\Modifies this image in-place. Both images must have the same dimensions.
+    \\The overlay image must have an alpha channel for proper blending.
+    \\
+    \\## Parameters
+    \\- `overlay` (Image): Image to blend onto this image
+    \\- `mode` (Blending, optional): Blending mode (default: NORMAL)
+    \\
+    \\## Raises
+    \\- `ValueError`: If images have different dimensions
+    \\- `TypeError`: If overlay is not an Image object
+    \\
+    \\## Examples
+    \\```python
+    \\# Basic alpha blending
+    \\base = Image(100, 100, (255, 0, 0))
+    \\overlay = Image(100, 100, (0, 0, 255, 128))  # Semi-transparent blue
+    \\base.blend(overlay)  # Default NORMAL mode
+    \\
+    \\# Using different blend modes
+    \\base.blend(overlay, zignal.Blending.MULTIPLY)
+    \\base.blend(overlay, zignal.Blending.SCREEN)
+    \\base.blend(overlay, zignal.Blending.OVERLAY)
+    \\```
+;
+
+pub fn image_blend(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments: overlay image and optional blend mode
+    var overlay_obj: ?*c.PyObject = null;
+    var mode_obj: ?*c.PyObject = null;
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("overlay"), @constCast("mode"), null };
+    const fmt = std.fmt.comptimePrint("O|O", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, fmt.ptr, @ptrCast(&kwlist), &overlay_obj, &mode_obj) == 0) {
+        return null;
+    }
+
+    // Check if overlay is an Image instance
+    if (c.PyObject_IsInstance(overlay_obj, @ptrCast(getImageType())) <= 0) {
+        c.PyErr_SetString(c.PyExc_TypeError, "overlay must be an Image object");
+        return null;
+    }
+
+    const overlay = @as(*ImageObject, @ptrCast(overlay_obj.?));
+
+    // Get blend mode (default to normal if not specified)
+    var blend_mode = zignal.Blending.normal;
+    if (mode_obj != null and mode_obj != c.Py_None()) {
+        blend_mode = blending.convertToZigBlending(mode_obj.?) catch {
+            return null; // Error already set by convertToZigBlending
+        };
+    }
+
+    // Both images must be initialized
+    if (self.py_image == null or overlay.py_image == null) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Both images must be initialized");
+        return null;
+    }
+
+    const self_pimg = self.py_image.?;
+    const overlay_pimg = overlay.py_image.?;
+
+    // Check dimensions match
+    const self_rows = self_pimg.rows();
+    const self_cols = self_pimg.cols();
+    const overlay_rows = overlay_pimg.rows();
+    const overlay_cols = overlay_pimg.cols();
+
+    if (self_rows != overlay_rows or self_cols != overlay_cols) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Images must have the same dimensions");
+        return null;
+    }
+
+    // Overlay must be RGBA
+    const overlay_img = switch (overlay_pimg.data) {
+        .rgba => |img| img,
+        else => {
+            c.PyErr_SetString(c.PyExc_TypeError, "Overlay image must be RGBA type");
+            return null;
+        },
+    };
+
+    // Perform the blend operation based on base image type
+    switch (self_pimg.data) {
+        .grayscale => |base_img| {
+            for (0..self_rows) |row| {
+                for (0..self_cols) |col| {
+                    const base_pixel = base_img.at(row, col).*;
+                    const base_rgb: Rgb = .{ .r = base_pixel, .g = base_pixel, .b = base_pixel };
+                    base_img.at(row, col).* = base_rgb.blend(overlay_img.at(row, col).*, blend_mode).toGray();
+                }
+            }
+        },
+        inline .rgb, .rgba => |*base_img| {
+            for (0..self_rows) |row| {
+                for (0..self_cols) |col| {
+                    base_img.at(row, col).* = base_img.at(row, col).blend(overlay_img.at(row, col).*, blend_mode);
+                }
+            }
+        },
+    }
+
+    // Return None (Python convention for in-place operations)
+    c.Py_INCREF(c.Py_None());
+    return c.Py_None();
+}

--- a/bindings/python/src/image/numpy_interop.zig
+++ b/bindings/python/src/image/numpy_interop.zig
@@ -1,0 +1,488 @@
+//! NumPy array conversion for Image objects
+
+const std = @import("std");
+const zignal = @import("zignal");
+const Image = zignal.Image;
+const Rgba = zignal.Rgba;
+const Rgb = zignal.Rgb;
+
+const py_utils = @import("../py_utils.zig");
+const allocator = py_utils.allocator;
+const c = py_utils.c;
+
+const PyImageMod = @import("../PyImage.zig");
+const PyImage = PyImageMod.PyImage;
+
+// Import the ImageObject type from parent
+const ImageObject = @import("../image.zig").ImageObject;
+const getImageType = @import("../image.zig").getImageType;
+
+// ============================================================================
+// IMAGE TO NUMPY
+// ============================================================================
+
+pub const image_to_numpy_doc =
+    \\Convert the image to a NumPy array (zero-copy when possible).
+    \\
+    \\Returns an array in the image's native dtype:\n
+    \\- Grayscale → shape (rows, cols, 1)\n
+    \\- Rgb → shape (rows, cols, 3)\n
+    \\- Rgba → shape (rows, cols, 4)
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\arr = img.to_numpy()
+    \\print(arr.shape, arr.dtype)
+    \\# Example: (H, W, C) uint8 where C is 1, 3, or 4
+    \\```
+;
+
+pub fn image_to_numpy(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args; // No arguments
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            .grayscale => |img| {
+                // Import numpy
+                const np_module = c.PyImport_ImportModule("numpy") orelse {
+                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
+                    return null;
+                };
+                defer c.Py_DECREF(np_module);
+
+                // Allocate shape and strides arrays that persist for the lifetime of the array
+                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
+                    return null;
+                };
+                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    allocator.free(shape_array);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
+                    return null;
+                };
+
+                // Set shape: (rows, cols, 1)
+                shape_array[0] = @intCast(img.rows);
+                shape_array[1] = @intCast(img.cols);
+                shape_array[2] = 1;
+
+                // Set strides for proper memory layout: (stride*1, 1, 1)
+                strides_array[0] = @intCast(img.stride * @sizeOf(u8));
+                strides_array[1] = @sizeOf(u8);
+                strides_array[2] = 1;
+
+                // Create a 3D buffer view with proper strides
+                var buffer = c.Py_buffer{
+                    .buf = @ptrCast(img.data.ptr),
+                    .obj = self_obj,
+                    .len = @intCast(img.data.len * @sizeOf(u8)),
+                    .itemsize = 1,
+                    .readonly = 0,
+                    .ndim = 3,
+                    .format = @constCast("B"),
+                    .shape = @ptrCast(shape_array.ptr),
+                    .strides = @ptrCast(strides_array.ptr),
+                    .suboffsets = null,
+                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
+                };
+                c.Py_INCREF(self_obj); // Keep parent alive
+
+                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
+                    c.Py_DECREF(self_obj);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Create numpy array from memoryview
+                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(np_asarray);
+
+                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(args_tuple);
+
+                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Clean up memoryview but arrays are kept alive by numpy array
+                c.Py_DECREF(memview);
+
+                return array;
+            },
+            .rgb => |img| {
+                // Import numpy
+                const np_module = c.PyImport_ImportModule("numpy") orelse {
+                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
+                    return null;
+                };
+                defer c.Py_DECREF(np_module);
+
+                // Allocate shape and strides arrays that persist for the lifetime of the array
+                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
+                    return null;
+                };
+                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    allocator.free(shape_array);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
+                    return null;
+                };
+
+                // Set shape: (rows, cols, 3)
+                shape_array[0] = @intCast(img.rows);
+                shape_array[1] = @intCast(img.cols);
+                shape_array[2] = 3;
+
+                // Set strides for proper memory layout: (stride*3, 3, 1)
+                strides_array[0] = @intCast(img.stride * @sizeOf(Rgb));
+                strides_array[1] = @sizeOf(Rgb);
+                strides_array[2] = 1;
+
+                // Create a 3D buffer view with proper strides
+                var buffer = c.Py_buffer{
+                    .buf = @ptrCast(img.data.ptr),
+                    .obj = self_obj,
+                    .len = @intCast(img.data.len * @sizeOf(Rgb)),
+                    .itemsize = 1,
+                    .readonly = 0,
+                    .ndim = 3,
+                    .format = @constCast("B"),
+                    .shape = @ptrCast(shape_array.ptr),
+                    .strides = @ptrCast(strides_array.ptr),
+                    .suboffsets = null,
+                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
+                };
+                c.Py_INCREF(self_obj); // Keep parent alive
+
+                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
+                    c.Py_DECREF(self_obj);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Create numpy array from memoryview
+                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(np_asarray);
+
+                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(args_tuple);
+
+                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Clean up memoryview but arrays are kept alive by numpy array
+                c.Py_DECREF(memview);
+
+                return array;
+            },
+            .rgba => |img| {
+                // Import numpy
+                const np_module = c.PyImport_ImportModule("numpy") orelse {
+                    c.PyErr_SetString(c.PyExc_ImportError, "NumPy is not installed. Please install it with: pip install numpy");
+                    return null;
+                };
+                defer c.Py_DECREF(np_module);
+
+                // Allocate shape and strides arrays that persist for the lifetime of the array
+                const shape_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate shape array");
+                    return null;
+                };
+                const strides_array = allocator.alloc(c.Py_ssize_t, 3) catch {
+                    allocator.free(shape_array);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate strides array");
+                    return null;
+                };
+
+                // Set shape: (rows, cols, 4)
+                shape_array[0] = @intCast(img.rows);
+                shape_array[1] = @intCast(img.cols);
+                shape_array[2] = 4;
+
+                // Set strides for proper memory layout: (stride*4, 4, 1)
+                strides_array[0] = @intCast(img.stride * @sizeOf(Rgba));
+                strides_array[1] = @sizeOf(Rgba);
+                strides_array[2] = 1;
+
+                // Create a 3D buffer view with proper strides
+                var buffer = c.Py_buffer{
+                    .buf = @ptrCast(img.data.ptr),
+                    .obj = self_obj,
+                    .len = @intCast(img.data.len * @sizeOf(Rgba)),
+                    .itemsize = 1,
+                    .readonly = 0,
+                    .ndim = 3,
+                    .format = @constCast("B"),
+                    .shape = @ptrCast(shape_array.ptr),
+                    .strides = @ptrCast(strides_array.ptr),
+                    .suboffsets = null,
+                    .internal = @ptrCast(shape_array.ptr), // Store for cleanup
+                };
+                c.Py_INCREF(self_obj); // Keep parent alive
+
+                const memview = c.PyMemoryView_FromBuffer(&buffer) orelse {
+                    c.Py_DECREF(self_obj);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Create numpy array from memoryview
+                const np_asarray = c.PyObject_GetAttrString(np_module, "asarray") orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(np_asarray);
+
+                const args_tuple = c.Py_BuildValue("(O)", memview) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+                defer c.Py_DECREF(args_tuple);
+
+                const array = c.PyObject_CallObject(np_asarray, args_tuple) orelse {
+                    c.Py_DECREF(memview);
+                    allocator.free(shape_array);
+                    allocator.free(strides_array);
+                    return null;
+                };
+
+                // Clean up memoryview but arrays are kept alive by numpy array
+                c.Py_DECREF(memview);
+
+                return array;
+            },
+        }
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+// ============================================================================
+// IMAGE FROM NUMPY
+// ============================================================================
+
+pub const image_from_numpy_doc =
+    \\Create Image from a NumPy array with dtype uint8.
+    \\
+    \\Zero-copy is used for arrays with these shapes:
+    \\- Grayscale: (rows, cols, 1) → Image(Grayscale)
+    \\- RGB: (rows, cols, 3) → Image(Rgb)
+    \\- RGBA: (rows, cols, 4) → Image(Rgba)
+    \\
+    \\The array can have row strides (e.g., from views or slicing) as long as pixels
+    \\within each row are contiguous. For arrays with incompatible strides (e.g., transposed),
+    \\use `numpy.ascontiguousarray()` first.
+    \\
+    \\## Parameters
+    \\- `array` (NDArray[np.uint8]): NumPy array with shape (rows, cols, 1), (rows, cols, 3) or (rows, cols, 4) and dtype uint8.
+    \\  Pixels within rows must be contiguous.
+    \\
+    \\## Raises
+    \\- `TypeError`: If array is None or has wrong dtype
+    \\- `ValueError`: If array has wrong shape or incompatible strides
+    \\
+    \\## Notes
+    \\The array can have row strides (padding between rows) but pixels within
+    \\each row must be contiguous. For incompatible layouts (e.g., transposed
+    \\arrays), use np.ascontiguousarray() first:
+    \\
+    \\```python
+    \\arr = np.ascontiguousarray(arr)
+    \\img = Image.from_numpy(arr)
+    \\```
+    \\
+    \\## Examples
+    \\```python
+    \\arr = np.zeros((100, 200, 3), dtype=np.uint8)
+    \\img = Image.from_numpy(arr)
+    \\print(img.rows, img.cols)
+    \\# Output: 100 200
+    \\```
+;
+
+pub fn image_from_numpy(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var array_obj: ?*c.PyObject = undefined;
+
+    const format = std.fmt.comptimePrint("O", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &array_obj) == 0) {
+        return null;
+    }
+
+    if (array_obj == null or array_obj == c.Py_None()) {
+        c.PyErr_SetString(c.PyExc_TypeError, "Array cannot be None");
+        return null;
+    }
+
+    // Get buffer interface from the array
+    var buffer: c.Py_buffer = undefined;
+    buffer = std.mem.zeroes(c.Py_buffer);
+
+    // Request buffer with strides info
+    const flags: c_int = 0x001c; // PyBUF_ND | PyBUF_STRIDES | PyBUF_FORMAT
+    if (c.PyObject_GetBuffer(array_obj, &buffer, flags) != 0) {
+        // Error already set by PyObject_GetBuffer
+        return null;
+    }
+    defer c.PyBuffer_Release(&buffer);
+
+    // Validate buffer format if available (should be 'B' for uint8)
+    // Note: format might be null if PyBUF_FORMAT wasn't requested
+    if (buffer.format != null and (buffer.format[0] != 'B' or buffer.format[1] != 0)) {
+        c.PyErr_SetString(c.PyExc_TypeError, "Array must have dtype uint8");
+        return null;
+    }
+
+    // Validate dimensions and shape: only 3D arrays with 1, 3 or 4 channels are supported
+    const ndim: c_int = buffer.ndim;
+    if (ndim != 3) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Array must have shape (rows, cols, 1|3|4)");
+        return null;
+    }
+
+    const shape = @as([*]c.Py_ssize_t, @ptrCast(buffer.shape));
+    const rows = @as(usize, @intCast(shape[0]));
+    const cols = @as(usize, @intCast(shape[1]));
+    const channels: usize = @as(usize, @intCast(shape[2]));
+    if (!(channels == 1 or channels == 3 or channels == 4)) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Array must have 1 channel (grayscale), 3 channels (RGB) or 4 channels (RGBA)");
+        return null;
+    }
+
+    // Check if array strides are compatible (pixels must be contiguous within rows)
+    const strides = @as([*]c.Py_ssize_t, @ptrCast(buffer.strides));
+    const item = buffer.itemsize; // 1 for uint8
+
+    // Check that pixels within a row are contiguous
+    const expected_pixel_stride = item * @as(c.Py_ssize_t, @intCast(channels));
+    if (strides[2] != item or strides[1] != expected_pixel_stride) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Array pixels must be contiguous. Use numpy.ascontiguousarray() first.");
+        return null;
+    }
+
+    // Calculate row stride in pixels (not bytes)
+    const row_stride_bytes = strides[0];
+    const pixel_size: c.Py_ssize_t = @intCast(channels);
+    if (@rem(row_stride_bytes, pixel_size) != 0) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Array row stride must be a multiple of pixel size.");
+        return null;
+    }
+    const row_stride_pixels = @divExact(row_stride_bytes, pixel_size);
+
+    // Create new Python object
+    const self = @as(?*ImageObject, @ptrCast(c.PyType_GenericAlloc(@ptrCast(getImageType()), 0)));
+    if (self == null) {
+        return null;
+    }
+
+    if (channels == 1) {
+        // Zero-copy: create grayscale image that points to NumPy's data directly
+        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
+        const data_slice = data_ptr[0..@intCast(buffer.len)];
+
+        // Create image with custom stride to handle non-contiguous arrays
+        const img = Image(u8){
+            .rows = rows,
+            .cols = cols,
+            .data = data_slice,
+            .stride = @intCast(row_stride_pixels),
+        };
+
+        // Keep a reference to the NumPy array to prevent deallocation
+        c.Py_INCREF(array_obj.?);
+        self.?.numpy_ref = array_obj;
+        // Wrap as PyImage non-owning grayscale
+        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
+            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+            return null;
+        };
+        self.?.py_image = pimg;
+        self.?.parent_ref = null;
+        return @as(?*c.PyObject, @ptrCast(self));
+    } else if (channels == 4) {
+        // Zero-copy: create image that points to NumPy's data directly
+        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
+        const rgba_ptr = @as([*]Rgba, @ptrCast(@alignCast(data_ptr)));
+        const data_slice = rgba_ptr[0..@divExact(@as(usize, @intCast(buffer.len)), @sizeOf(Rgba))];
+
+        // Create image with custom stride to handle non-contiguous arrays
+        const img = Image(Rgba){
+            .rows = rows,
+            .cols = cols,
+            .data = data_slice,
+            .stride = @intCast(row_stride_pixels),
+        };
+
+        // Keep a reference to the NumPy array to prevent deallocation
+        c.Py_INCREF(array_obj.?);
+        self.?.numpy_ref = array_obj;
+        // Wrap as PyImage non-owning RGBA
+        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
+            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+            return null;
+        };
+        self.?.py_image = pimg;
+        self.?.parent_ref = null;
+        return @as(?*c.PyObject, @ptrCast(self));
+    } else if (channels == 3) {
+        // Zero-copy RGB
+        const data_ptr = @as([*]u8, @ptrCast(buffer.buf));
+        const rgb_ptr = @as([*]Rgb, @ptrCast(@alignCast(data_ptr)));
+        const data_slice = rgb_ptr[0..@divExact(@as(usize, @intCast(buffer.len)), @sizeOf(Rgb))];
+
+        // Create image with custom stride to handle non-contiguous arrays
+        const img = Image(Rgb){
+            .rows = rows,
+            .cols = cols,
+            .data = data_slice,
+            .stride = @intCast(row_stride_pixels),
+        };
+        c.Py_INCREF(array_obj.?);
+        self.?.numpy_ref = array_obj;
+        const pimg = PyImage.createFrom(allocator, img, .borrowed) orelse {
+            c.Py_DECREF(@as(*c.PyObject, @ptrCast(self)));
+            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+            return null;
+        };
+        self.?.py_image = pimg;
+        self.?.parent_ref = null;
+    } else unreachable; // validated above
+    return @as(?*c.PyObject, @ptrCast(self));
+}

--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -1,0 +1,990 @@
+//! Geometric transformations for Image objects
+
+const std = @import("std");
+const zignal = @import("zignal");
+const Image = zignal.Image;
+const Rgba = zignal.Rgba;
+const Rgb = zignal.Rgb;
+const Interpolation = zignal.Interpolation;
+const Rectangle = zignal.Rectangle;
+const Point = zignal.Point;
+
+const py_utils = @import("../py_utils.zig");
+const allocator = py_utils.allocator;
+const c = py_utils.c;
+
+const PyImageMod = @import("../PyImage.zig");
+const PyImage = PyImageMod.PyImage;
+const transforms = @import("../transforms.zig");
+
+// Import the ImageObject type from parent
+const ImageObject = @import("../image.zig").ImageObject;
+const getImageType = @import("../image.zig").getImageType;
+
+// Helper functions
+fn pythonToZigInterpolation(py_value: c_long) !Interpolation {
+    return switch (py_value) {
+        0 => .nearest_neighbor,
+        1 => .bilinear,
+        2 => .bicubic,
+        3 => .catmull_rom,
+        4 => .{ .mitchell = .{ .b = 1.0 / 3.0, .c = 1.0 / 3.0 } }, // Default Mitchell parameters
+        5 => .lanczos,
+        else => return error.InvalidInterpolation,
+    };
+}
+
+fn mapScaleError(err: anyerror) anyerror {
+    return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => error.OutOfMemory,
+    };
+}
+
+fn image_scale(self: *ImageObject, scale: f32, method: Interpolation) !*ImageObject {
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            inline else => |*img| {
+                var out = img.scale(allocator, scale, method) catch |err| return mapScaleError(err);
+                const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return error.OutOfMemory;
+                const result = @as(*ImageObject, @ptrCast(py_obj));
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                result.py_image = pnew;
+                result.numpy_ref = null;
+                result.parent_ref = null;
+                return result;
+            },
+        }
+    }
+    return error.ImageNotInitialized;
+}
+
+fn image_reshape(self: *ImageObject, rows: usize, cols: usize, method: Interpolation) !*ImageObject {
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            inline else => |*img| {
+                var out = @TypeOf(img.*).init(allocator, rows, cols) catch return error.OutOfMemory;
+                img.resize(allocator, out, method) catch return error.OutOfMemory;
+                const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return error.OutOfMemory;
+                const result = @as(*ImageObject, @ptrCast(py_obj));
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                result.py_image = pnew;
+                result.numpy_ref = null;
+                result.parent_ref = null;
+                return result;
+            },
+        }
+    }
+    return error.ImageNotInitialized;
+}
+
+fn image_letterbox_shape(self: *ImageObject, rows: usize, cols: usize, method: Interpolation) !*ImageObject {
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return error.OutOfMemory;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).init(allocator, rows, cols) catch {
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                _ = img.letterbox(allocator, &out, method) catch {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return result;
+    }
+    return error.ImageNotInitialized;
+}
+
+fn image_letterbox_square(self: *ImageObject, size: usize, method: Interpolation) !*ImageObject {
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return error.OutOfMemory;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).init(allocator, size, size) catch {
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                _ = img.letterbox(allocator, &out, method) catch {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return error.OutOfMemory;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return result;
+    }
+    return error.ImageNotInitialized;
+}
+
+// Transform functions
+pub const image_resize_doc =
+    \\Resize the image to the specified size.
+    \\
+    \\## Parameters
+    \\- `size` (float or tuple[int, int]):
+    \\  - If float: scale factor (e.g., 0.5 for half size, 2.0 for double size)
+    \\  - If tuple: target dimensions as (rows, cols)
+    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
+;
+
+pub fn image_resize(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var shape_or_scale: ?*c.PyObject = null;
+    var method_value: c_long = 1; // Default to BILINEAR
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("size"), @constCast("method"), null };
+    const format = std.fmt.comptimePrint("O|l", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &shape_or_scale, &method_value) == 0) {
+        return null;
+    }
+
+    if (shape_or_scale == null) {
+        c.PyErr_SetString(c.PyExc_TypeError, "resize() missing required argument: 'size' (pos 1)");
+        return null;
+    }
+
+    // Convert method value to Zig enum
+    const method = pythonToZigInterpolation(method_value) catch {
+        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+        return null;
+    };
+
+    // Check if argument is a number (scale) or tuple (dimensions)
+    if (c.PyFloat_Check(shape_or_scale) != 0 or c.PyLong_Check(shape_or_scale) != 0) {
+        // It's a scale factor
+        const scale = c.PyFloat_AsDouble(shape_or_scale);
+        if (scale == -1.0 and c.PyErr_Occurred() != null) {
+            return null;
+        }
+        if (scale <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Scale factor must be positive");
+            return null;
+        }
+
+        const result = image_scale(self, @floatCast(scale), method) catch return null;
+        return @ptrCast(result);
+    } else if (c.PyTuple_Check(shape_or_scale) != 0) {
+        // It's a tuple of dimensions
+        if (c.PyTuple_Size(shape_or_scale) != 2) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Size must be a 2-tuple of (rows, cols)");
+            return null;
+        }
+
+        const rows_obj = c.PyTuple_GetItem(shape_or_scale, 0);
+        const cols_obj = c.PyTuple_GetItem(shape_or_scale, 1);
+
+        const rows = c.PyLong_AsLong(rows_obj);
+        if (rows == -1 and c.PyErr_Occurred() != null) {
+            c.PyErr_SetString(c.PyExc_TypeError, "Rows must be an integer");
+            return null;
+        }
+        if (rows <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Rows must be positive");
+            return null;
+        }
+
+        const cols = c.PyLong_AsLong(cols_obj);
+        if (cols == -1 and c.PyErr_Occurred() != null) {
+            c.PyErr_SetString(c.PyExc_TypeError, "Cols must be an integer");
+            return null;
+        }
+        if (cols <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Cols must be positive");
+            return null;
+        }
+
+        const result = image_reshape(self, @intCast(rows), @intCast(cols), method) catch return null;
+        return @ptrCast(result);
+    } else {
+        c.PyErr_SetString(c.PyExc_TypeError, "resize() argument must be a number (scale) or tuple (rows, cols)");
+        return null;
+    }
+}
+
+pub const image_letterbox_doc =
+    \\Resize image to fit within the specified size while preserving aspect ratio.
+    \\
+    \\The image is scaled to fit within the target dimensions and centered with
+    \\black borders (letterboxing) to maintain the original aspect ratio.
+    \\
+    \\## Parameters
+    \\- `size` (int or tuple[int, int]):
+    \\  - If int: creates a square output of size x size
+    \\  - If tuple: target dimensions as (rows, cols)
+    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
+;
+
+pub fn image_letterbox(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var size: ?*c.PyObject = null;
+    var method_value: c_long = 1; // Default to BILINEAR
+    var kwlist = [_:null]?[*:0]u8{ @constCast("size"), @constCast("method"), null };
+    const format = std.fmt.comptimePrint("O|l", .{});
+
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &size, &method_value) == 0) {
+        return null;
+    }
+
+    if (size == null) {
+        c.PyErr_SetString(c.PyExc_TypeError, "letterbox() missing required argument: 'size' (pos 1)");
+        return null;
+    }
+
+    // Convert method value to Zig enum
+    const method = pythonToZigInterpolation(method_value) catch {
+        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+        return null;
+    };
+
+    // Check if argument is a number (square) or tuple (dimensions)
+    if (c.PyLong_Check(size) != 0) {
+        // It's an integer for square letterbox
+        const square_size = c.PyLong_AsLong(size);
+        if (square_size == -1 and c.PyErr_Occurred() != null) {
+            return null;
+        }
+        if (square_size <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Size must be positive");
+            return null;
+        }
+        const result = image_letterbox_square(self, @intCast(square_size), method) catch return null;
+        return @ptrCast(result);
+    } else if (c.PyTuple_Check(size) != 0) {
+        // It's a tuple for dimensions
+        if (c.PyTuple_Size(size) != 2) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Dimensions must be a tuple of 2 integers (rows, cols)");
+            return null;
+        }
+
+        const rows_obj = c.PyTuple_GetItem(size, 0);
+        const cols_obj = c.PyTuple_GetItem(size, 1);
+
+        if (c.PyLong_Check(rows_obj) == 0 or c.PyLong_Check(cols_obj) == 0) {
+            c.PyErr_SetString(c.PyExc_TypeError, "Dimensions must be integers");
+            return null;
+        }
+
+        const rows = c.PyLong_AsLong(rows_obj);
+        const cols = c.PyLong_AsLong(cols_obj);
+
+        if ((rows == -1 or cols == -1) and c.PyErr_Occurred() != null) {
+            return null;
+        }
+
+        if (rows <= 0 or cols <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Dimensions must be positive");
+            return null;
+        }
+
+        const result = image_letterbox_shape(self, @intCast(rows), @intCast(cols), method) catch return null;
+        return @ptrCast(result);
+    } else {
+        c.PyErr_SetString(c.PyExc_TypeError, "letterbox() argument must be an integer (square) or tuple (rows, cols)");
+        return null;
+    }
+}
+
+pub const image_rotate_doc =
+    \\Rotate the image by the specified angle around its center.
+    \\
+    \\The output image is automatically sized to fit the entire rotated image without clipping.
+    \\
+    \\## Parameters
+    \\- `angle` (float): Rotation angle in radians counter-clockwise.
+    \\- `method` (`Interpolation`, optional): Interpolation method to use. Default is `Interpolation.BILINEAR`.
+    \\
+    \\## Examples
+    \\```python
+    \\import math
+    \\img = Image.load("photo.png")
+    \\
+    \\# Rotate 45 degrees with default bilinear interpolation
+    \\rotated = img.rotate(math.radians(45))
+    \\
+    \\# Rotate 90 degrees with nearest neighbor (faster, lower quality)
+    \\rotated = img.rotate(math.radians(90), Interpolation.NEAREST_NEIGHBOR)
+    \\
+    \\# Rotate -30 degrees with Lanczos (slower, higher quality)
+    \\rotated = img.rotate(math.radians(-30), Interpolation.LANCZOS)
+    \\```
+;
+
+pub fn image_rotate(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var angle: f64 = 0;
+    var method_value: c_long = 1; // Default to BILINEAR
+    var kwlist = [_:null]?[*:0]u8{ @constCast("angle"), @constCast("method"), null };
+    const format = std.fmt.comptimePrint("d|l", .{});
+
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &angle, &method_value) == 0) {
+        return null;
+    }
+
+    // Convert method value to Zig enum
+    const method = pythonToZigInterpolation(method_value) catch {
+        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+        return null;
+    };
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).empty;
+                img.rotate(allocator, @floatCast(angle), method, &out) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    return null;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_warp_doc =
+    \\Apply a geometric transform to the image.
+    \\
+    \\This method warps an image using a geometric transform (Similarity, Affine, or Projective).
+    \\For each pixel in the output image, it applies the transform to find the corresponding
+    \\location in the source image and samples using the specified interpolation method.
+    \\
+    \\## Parameters
+    \\- `transform`: A geometric transform object (SimilarityTransform, AffineTransform, or ProjectiveTransform)
+    \\- `shape` (optional): Output image shape as (rows, cols) tuple. Defaults to input image shape.
+    \\- `method` (optional): Interpolation method. Defaults to Interpolation.BILINEAR.
+    \\
+    \\## Examples
+    \\```python
+    \\# Apply similarity transform
+    \\from_points = [(0, 0), (100, 0), (100, 100)]
+    \\to_points = [(10, 10), (110, 20), (105, 115)]
+    \\transform = SimilarityTransform(from_points, to_points)
+    \\warped = img.warp(transform)
+    \\
+    \\# Apply with custom output size and interpolation
+    \\warped = img.warp(transform, shape=(512, 512), method=Interpolation.BICUBIC)
+    \\```
+;
+
+pub fn image_warp(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var transform_obj: ?*c.PyObject = null;
+    var shape_obj: ?*c.PyObject = null;
+    var method_value: c_long = 1; // Default to BILINEAR
+
+    const keywords = [_:null]?[*:0]const u8{ "transform", "shape", "method", null };
+    const format = std.fmt.comptimePrint("O|Ol", .{});
+
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&keywords)), &transform_obj, &shape_obj, &method_value) == 0) {
+        return null;
+    }
+
+    // Check if image is initialized
+    if (self.py_image == null) {
+        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+        return null;
+    }
+
+    // Parse interpolation method
+    const method = pythonToZigInterpolation(@intCast(method_value)) catch |err| {
+        switch (err) {
+            error.InvalidInterpolation => {
+                c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+                return null;
+            },
+        }
+    };
+
+    // Determine output dimensions
+    var out_rows = self.py_image.?.rows();
+    var out_cols = self.py_image.?.cols();
+
+    if (shape_obj != null and shape_obj != c.Py_None()) {
+        // Parse shape tuple
+        if (c.PyTuple_Check(shape_obj) == 0) {
+            c.PyErr_SetString(c.PyExc_TypeError, "shape must be a tuple of (rows, cols)");
+            return null;
+        }
+
+        if (c.PyTuple_Size(shape_obj) != 2) {
+            c.PyErr_SetString(c.PyExc_ValueError, "shape must have exactly 2 elements");
+            return null;
+        }
+
+        const rows_obj = c.PyTuple_GetItem(shape_obj, 0);
+        const cols_obj = c.PyTuple_GetItem(shape_obj, 1);
+
+        const rows_val = c.PyLong_AsLong(rows_obj);
+        const cols_val = c.PyLong_AsLong(cols_obj);
+
+        if (rows_val <= 0 or cols_val <= 0) {
+            c.PyErr_SetString(c.PyExc_ValueError, "Output dimensions must be positive");
+            return null;
+        }
+
+        out_rows = @intCast(rows_val);
+        out_cols = @intCast(cols_val);
+    }
+
+    // Create output Python image object
+    const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+    const result = @as(*ImageObject, @ptrCast(py_obj));
+
+    // Create PyImage wrapper for the warped result
+    const warped_pyimage = allocator.create(PyImageMod.PyImage) catch {
+        c.Py_DECREF(py_obj);
+        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate memory for warped image");
+        return null;
+    };
+
+    // Apply warp using inline else to handle all image formats generically
+    switch (self.py_image.?.data) {
+        inline else => |img| {
+            var warped_img: @TypeOf(img) = .empty;
+
+            // Determine transform type and apply warp
+            if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.SimilarityTransformType)) > 0) {
+                const transform = @as(*transforms.SimilarityTransformObject, @ptrCast(transform_obj));
+                const zignal_transform: zignal.SimilarityTransform(f32) = .{
+                    .matrix = .init(.{
+                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]) },
+                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]) },
+                    }),
+                    .bias = .init(.{
+                        .{@floatCast(transform.bias[0])},
+                        .{@floatCast(transform.bias[1])},
+                    }),
+                };
+                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
+                    c.Py_DECREF(py_obj);
+                    allocator.destroy(warped_pyimage);
+                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
+                    return null;
+                };
+            } else if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.AffineTransformType)) > 0) {
+                const transform = @as(*transforms.AffineTransformObject, @ptrCast(transform_obj));
+                const zignal_transform: zignal.AffineTransform(f32) = .{
+                    .matrix = .init(.{
+                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]) },
+                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]) },
+                    }),
+                    .bias = .init(.{
+                        .{@floatCast(transform.bias[0])},
+                        .{@floatCast(transform.bias[1])},
+                    }),
+                    .allocator = allocator,
+                };
+                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
+                    c.Py_DECREF(py_obj);
+                    allocator.destroy(warped_pyimage);
+                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
+                    return null;
+                };
+            } else if (c.PyObject_IsInstance(transform_obj, @ptrCast(&transforms.ProjectiveTransformType)) > 0) {
+                const transform = @as(*transforms.ProjectiveTransformObject, @ptrCast(transform_obj));
+                const zignal_transform: zignal.ProjectiveTransform(f32) = .{
+                    .matrix = .init(.{
+                        .{ @floatCast(transform.matrix[0][0]), @floatCast(transform.matrix[0][1]), @floatCast(transform.matrix[0][2]) },
+                        .{ @floatCast(transform.matrix[1][0]), @floatCast(transform.matrix[1][1]), @floatCast(transform.matrix[1][2]) },
+                        .{ @floatCast(transform.matrix[2][0]), @floatCast(transform.matrix[2][1]), @floatCast(transform.matrix[2][2]) },
+                    }),
+                };
+                img.warp(allocator, zignal_transform, method, &warped_img, out_rows, out_cols) catch {
+                    c.Py_DECREF(py_obj);
+                    allocator.destroy(warped_pyimage);
+                    c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to warp image");
+                    return null;
+                };
+            } else {
+                c.Py_DECREF(py_obj);
+                allocator.destroy(warped_pyimage);
+                c.PyErr_SetString(c.PyExc_TypeError, "transform must be a SimilarityTransform, AffineTransform, or ProjectiveTransform");
+                return null;
+            }
+
+            // Create PyImage wrapper for the warped result based on image type
+            warped_pyimage.* = switch (@TypeOf(img)) {
+                zignal.Image(u8) => .{ .data = .{ .grayscale = warped_img }, .ownership = .owned },
+                zignal.Image(Rgb) => .{ .data = .{ .rgb = warped_img }, .ownership = .owned },
+                zignal.Image(Rgba) => .{ .data = .{ .rgba = warped_img }, .ownership = .owned },
+                else => unreachable,
+            };
+        },
+    }
+
+    result.py_image = warped_pyimage;
+    result.numpy_ref = null;
+    result.parent_ref = null;
+
+    return py_obj;
+}
+
+pub const image_flip_left_right_doc =
+    \\Flip image left-to-right (horizontal mirror).
+    \\
+    \\Returns a new image that is a horizontal mirror of the original.
+    \\```python
+    \\flipped = img.flip_left_right()
+    \\```
+;
+
+pub fn image_flip_left_right(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = img.dupe(allocator) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                out.flipLeftRight();
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_flip_top_bottom_doc =
+    \\Flip image top-to-bottom (vertical mirror).
+    \\
+    \\Returns a new image that is a vertical mirror of the original.
+    \\```python
+    \\flipped = img.flip_top_bottom()
+    \\```
+;
+
+pub fn image_flip_top_bottom(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    _ = args;
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = img.dupe(allocator) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                out.flipTopBottom();
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_crop_doc =
+    \\Extract a rectangular region from the image.
+    \\
+    \\Returns a new Image containing the cropped region. Pixels outside the original
+    \\image bounds are filled with transparent black (0, 0, 0, 0).
+    \\
+    \\## Parameters
+    \\- `rect` (Rectangle): The rectangular region to extract
+    \\
+    \\## Examples
+    \\```python
+    \\img = Image.load("photo.png")
+    \\rect = Rectangle(10, 10, 110, 110)  # 100x100 region starting at (10, 10)
+    \\cropped = img.crop(rect)
+    \\print(cropped.rows, cropped.cols)  # 100 100
+    \\```
+;
+
+pub fn image_crop(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse Rectangle argument
+    var rect_obj: ?*c.PyObject = undefined;
+    const format = std.fmt.comptimePrint("O", .{});
+    if (c.PyArg_ParseTuple(args, format.ptr, &rect_obj) == 0) {
+        return null;
+    }
+
+    // Parse the Rectangle object
+    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |*img| {
+                var out = @TypeOf(img.*).init(allocator, img.rows, img.cols) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                img.crop(allocator, rect, &out) catch {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate cropped image");
+                    return null;
+                };
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image");
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_extract_doc =
+    \\Extract a rotated rectangular region from the image and resample it.
+    \\
+    \\Returns a new Image containing the extracted and resampled region.
+    \\
+    \\## Parameters
+    \\- `rect` (Rectangle): The rectangular region to extract (before rotation)
+    \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
+    \\- `size` (int or tuple[int, int], optional). If not specified, uses the rectangle's dimensions.
+    \\  - If int: output is a square of side `size`
+    \\  - If tuple: output size as (rows, cols)
+    \\- `method` (Interpolation, optional): Interpolation method. Default: BILINEAR
+    \\
+    \\## Examples
+    \\```python
+    \\import math
+    \\img = Image.load("photo.png")
+    \\rect = Rectangle(10, 10, 110, 110)
+    \\
+    \\# Extract without rotation
+    \\extracted = img.extract(rect)
+    \\
+    \\# Extract with 45-degree rotation
+    \\rotated = img.extract(rect, angle=math.radians(45))
+    \\
+    \\# Extract and resize to specific dimensions
+    \\resized = img.extract(rect, size=(50, 75))
+    \\
+    \\# Extract to a 64x64 square
+    \\square = img.extract(rect, size=64)
+    \\```
+;
+
+pub fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var rect_obj: ?*c.PyObject = undefined;
+    var angle: f64 = 0.0;
+    var size_obj: ?*c.PyObject = null;
+    var method_value: c_long = 1; // Default to BILINEAR
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("rect"), @constCast("angle"), @constCast("size"), @constCast("method"), null };
+    const format = std.fmt.comptimePrint("O|dOl", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &rect_obj, &angle, &size_obj, &method_value) == 0) {
+        return null;
+    }
+
+    // Parse the Rectangle object
+    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
+
+    // Convert method value to Zig enum
+    const method = pythonToZigInterpolation(method_value) catch {
+        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+        return null;
+    };
+
+    // Determine output size
+    var out_rows: usize = @intFromFloat(@round(rect.height()));
+    var out_cols: usize = @intFromFloat(@round(rect.width()));
+
+    if (size_obj != null and size_obj != c.Py_None()) {
+        // Accept either an integer (square) or a tuple (rows, cols)
+        if (c.PyLong_Check(size_obj) != 0) {
+            const square = c.PyLong_AsLong(size_obj);
+            if (square == -1 and c.PyErr_Occurred() != null) {
+                return null;
+            }
+            if (square <= 0) {
+                c.PyErr_SetString(c.PyExc_ValueError, "size must be positive");
+                return null;
+            }
+            out_rows = @intCast(square);
+            out_cols = @intCast(square);
+        } else if (c.PyTuple_Check(size_obj) != 0) {
+            if (c.PyTuple_Size(size_obj) != 2) {
+                c.PyErr_SetString(c.PyExc_ValueError, "size must be a 2-tuple of (rows, cols)");
+                return null;
+            }
+
+            const rows_obj = c.PyTuple_GetItem(size_obj, 0);
+            const cols_obj = c.PyTuple_GetItem(size_obj, 1);
+
+            const rows = c.PyLong_AsLong(rows_obj);
+            if (rows == -1 and c.PyErr_Occurred() != null) {
+                c.PyErr_SetString(c.PyExc_TypeError, "Rows must be an integer");
+                return null;
+            }
+            if (rows <= 0) {
+                c.PyErr_SetString(c.PyExc_ValueError, "Rows must be positive");
+                return null;
+            }
+
+            const cols = c.PyLong_AsLong(cols_obj);
+            if (cols == -1 and c.PyErr_Occurred() != null) {
+                c.PyErr_SetString(c.PyExc_TypeError, "Cols must be an integer");
+                return null;
+            }
+            if (cols <= 0) {
+                c.PyErr_SetString(c.PyExc_ValueError, "Cols must be positive");
+                return null;
+            }
+
+            out_rows = @intCast(rows);
+            out_cols = @intCast(cols);
+        } else {
+            c.PyErr_SetString(c.PyExc_TypeError, "size must be an int (square) or a tuple (rows, cols)");
+            return null;
+        }
+    }
+
+    if (self.py_image) |pimg| {
+        const py_obj = c.PyType_GenericAlloc(@ptrCast(getImageType()), 0) orelse return null;
+        const result = @as(*ImageObject, @ptrCast(py_obj));
+        switch (pimg.data) {
+            inline else => |img| {
+                var out = @TypeOf(img).init(allocator, out_rows, out_cols) catch {
+                    c.Py_DECREF(py_obj);
+                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    return null;
+                };
+                img.extract(rect, @floatCast(angle), out, method);
+                const pnew = PyImage.createFrom(allocator, out, .owned) orelse {
+                    out.deinit(allocator);
+                    c.Py_DECREF(py_obj);
+                    return null;
+                };
+                result.py_image = pnew;
+            },
+        }
+        result.numpy_ref = null;
+        result.parent_ref = null;
+        return py_obj;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}
+
+pub const image_insert_doc =
+    \\Insert a source image into this image at a specified rectangle with optional rotation.
+    \\
+    \\This method modifies the image in-place.
+    \\
+    \\## Parameters
+    \\- `source` (Image): The image to insert
+    \\- `rect` (Rectangle): Destination rectangle where the source will be placed
+    \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
+    \\- `method` (Interpolation, optional): Interpolation method. Default: BILINEAR
+    \\
+    \\## Examples
+    \\```python
+    \\import math
+    \\canvas = Image(500, 500)
+    \\logo = Image.load("logo.png")
+    \\
+    \\# Insert at top-left
+    \\rect = Rectangle(10, 10, 110, 110)
+    \\canvas.insert(logo, rect)
+    \\
+    \\# Insert with rotation
+    \\rect2 = Rectangle(200, 200, 300, 300)
+    \\canvas.insert(logo, rect2, angle=math.radians(45))
+    \\```
+;
+
+pub fn image_insert(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+
+    // Parse arguments
+    var source_obj: ?*c.PyObject = undefined;
+    var rect_obj: ?*c.PyObject = undefined;
+    var angle: f64 = 0.0;
+    var method_value: c_long = 1; // Default to BILINEAR
+
+    var kwlist = [_:null]?[*:0]u8{ @constCast("source"), @constCast("rect"), @constCast("angle"), @constCast("method"), null };
+    const format = std.fmt.comptimePrint("OO|dl", .{});
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(&kwlist), &source_obj, &rect_obj, &angle, &method_value) == 0) {
+        return null;
+    }
+
+    // Check if source is an Image object
+    if (c.PyObject_IsInstance(source_obj, @ptrCast(getImageType())) <= 0) {
+        c.PyErr_SetString(c.PyExc_TypeError, "source must be an Image object");
+        return null;
+    }
+
+    const source = @as(*ImageObject, @ptrCast(source_obj.?));
+
+    // Parse the Rectangle object
+    const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
+
+    // Convert method value to Zig enum
+    const method = pythonToZigInterpolation(method_value) catch {
+        c.PyErr_SetString(c.PyExc_ValueError, "Invalid interpolation method");
+        return null;
+    };
+
+    // Variant-aware in-place insert
+    if (self.py_image) |pimg| {
+        switch (pimg.data) {
+            .grayscale => |*dst| {
+                var src_u8: Image(u8) = undefined;
+                if (source.py_image == null) {
+                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
+                    return null;
+                }
+                const src_pimg = source.py_image.?;
+                switch (src_pimg.data) {
+                    .grayscale => |img| src_u8 = img,
+                    .rgb => |img| src_u8 = img.convert(u8, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                    .rgba => |img| src_u8 = img.convert(u8, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                }
+                defer src_u8.deinit(allocator);
+                dst.insert(src_u8, rect, @floatCast(angle), method);
+            },
+            .rgb => |*dst| {
+                var src_rgb: Image(Rgb) = undefined;
+                if (source.py_image == null) {
+                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
+                    return null;
+                }
+                const src_pimg = source.py_image.?;
+                switch (src_pimg.data) {
+                    .rgb => |img| src_rgb = img,
+                    .grayscale => |img| src_rgb = img.convert(Rgb, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                    .rgba => |img| src_rgb = img.convert(Rgb, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                }
+                defer src_rgb.deinit(allocator);
+                dst.insert(src_rgb, rect, @floatCast(angle), method);
+            },
+            .rgba => |*dst| {
+                var src_rgba: Image(Rgba) = undefined;
+                if (source.py_image == null) {
+                    c.PyErr_SetString(c.PyExc_TypeError, "Source image not initialized");
+                    return null;
+                }
+                const src_pimg = source.py_image.?;
+                switch (src_pimg.data) {
+                    .rgba => |img| src_rgba = img,
+                    .grayscale => |img| src_rgba = img.convert(Rgba, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                    .rgb => |img| src_rgba = img.convert(Rgba, allocator) catch {
+                        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to convert source image");
+                        return null;
+                    },
+                }
+                dst.insert(src_rgba, rect, @floatCast(angle), method);
+            },
+        }
+        const none = c.Py_None();
+        c.Py_INCREF(none);
+        return none;
+    }
+    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    return null;
+}

--- a/bindings/python/src/py_utils.zig
+++ b/bindings/python/src/py_utils.zig
@@ -302,7 +302,13 @@ pub fn parseRectangle(comptime T: type, rect_obj: ?*c.PyObject) !zignal.Rectangl
     }
 
     const rect = @as(*rectangle.RectangleObject, @ptrCast(rect_obj.?));
-    return zignal.Rectangle(T).init(@as(T, @floatCast(rect.left)), @as(T, @floatCast(rect.top)), @as(T, @floatCast(rect.right)), @as(T, @floatCast(rect.bottom)));
+    // Handle integer vs float types
+    const info = @typeInfo(T);
+    return switch (info) {
+        .int => zignal.Rectangle(T).init(@as(T, @intFromFloat(rect.left)), @as(T, @intFromFloat(rect.top)), @as(T, @intFromFloat(rect.right)), @as(T, @intFromFloat(rect.bottom))),
+        .float => zignal.Rectangle(T).init(@as(T, @floatCast(rect.left)), @as(T, @floatCast(rect.top)), @as(T, @floatCast(rect.right)), @as(T, @floatCast(rect.bottom))),
+        else => @compileError("Rectangle type must be integer or float"),
+    };
 }
 
 /// Parse a Python list of point tuples to an allocated slice of Point(2, T)


### PR DESCRIPTION
Moves image functionality into dedicated sub-modules for better organization: `core`, `numpy_interop`, `transforms`, and `filtering`.

Updates `py_utils.zig` for integer rectangle parsing and fixes an example in `image_init` docstring.