### PR TITLE
feat(python): add iou/overlaps, extend intersect with tuple support

### DIFF
--- a/bindings/python/tests/test_rectangle.py
+++ b/bindings/python/tests/test_rectangle.py
@@ -10,3 +10,8 @@ def test_rectangle_smoke():
     assert isinstance(r.is_empty(), bool)
     r2 = zignal.Rectangle.init_center(20, 20, 10, 10)
     assert isinstance(r.intersect(r2) or r, zignal.Rectangle)
+    assert isinstance(r.intersect((15, 25, 35, 45)) or r, zignal.Rectangle)  # tuple support
+    assert isinstance(r.iou(r2), float)
+    assert isinstance(r.iou((15, 25, 35, 45)), float)  # tuple support
+    assert isinstance(r.overlaps(r2), bool)
+    assert isinstance(r.overlaps((15, 25, 35, 45), iou_thresh=0.1), bool)  # tuple and kwargs


### PR DESCRIPTION
Introduce `iou` for calculating Intersection over Union and `overlaps` for checking rectangle overlap with configurable thresholds.

The `intersect` method, along with the new `iou` and `overlaps` methods, now accepts rectangle coordinates as a tuple `(left, top, right, bottom)` in addition to `Rectangle` objects.