### PR TITLE
feat(python): add Shen-Castan edge detection

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1055,6 +1055,14 @@ pub const image_methods_metadata = blk: {
             .returns = "Image",
         },
         .{
+            .name = "shen_castan",
+            .meth = @ptrCast(&filtering.image_shen_castan),
+            .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+            .doc = filtering.image_shen_castan_doc,
+            .params = "self, smooth: float = 0.9, window_size: int = 7, high_ratio: float = 0.99, low_rel: float = 0.5, hysteresis: bool = True, use_nms: bool = False",
+            .returns = "Image",
+        },
+        .{
             .name = "blend",
             .meth = @ptrCast(&filtering.image_blend),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -240,3 +240,49 @@ class TestImageSmoke:
         spin_config = zignal.MotionBlur.radial_spin(center=(0.3, 0.7), strength=0.8)
         blurred = img.motion_blur(spin_config)
         assert blurred.rows == 10 and blurred.cols == 10
+
+    def test_shen_castan_smoke(self):
+        """Test Shen-Castan edge detection API basics"""
+        # Create test image with some structure
+        img = zignal.Image(20, 20, (128, 128, 128), dtype=zignal.Rgb)
+
+        # Test with default parameters
+        edges = img.shen_castan()
+        assert edges.rows == 20 and edges.cols == 20
+        # Result should be grayscale
+        assert edges.dtype == zignal.Grayscale
+
+        # Test with custom parameters - equivalent to old presets
+        # Low noise preset equivalent
+        edges = img.shen_castan(smooth=0.95, high_ratio=0.98)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # High noise preset equivalent
+        edges = img.shen_castan(smooth=0.7, window_size=11)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # Heavy smooth preset equivalent (for very noisy images)
+        edges = img.shen_castan(smooth=0.5, window_size=9, high_ratio=0.95)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # Sensitive preset equivalent
+        edges = img.shen_castan(high_ratio=0.97, low_rel=0.4)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # NMS thinning
+        edges = img.shen_castan(use_nms=True)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # No hysteresis (strong edges only)
+        edges = img.shen_castan(hysteresis=False)
+        assert edges.rows == 20 and edges.cols == 20
+
+        # Test parameter validation
+        with pytest.raises(ValueError):
+            img.shen_castan(smooth=1.5)  # Must be in (0, 1)
+
+        with pytest.raises(ValueError):
+            img.shen_castan(window_size=4)  # Must be odd
+
+        with pytest.raises(ValueError):
+            img.shen_castan(high_ratio=0.0)  # Must be in (0, 1)

--- a/src/image/ShenCastan.zig
+++ b/src/image/ShenCastan.zig
@@ -1,123 +1,94 @@
 //! Configuration for the Shen–Castan (ISEF) edge detector.
 //!
-//! - Applies ISEF smoothing, detects zero‑crossings of (smoothed − original) sign,
-//!   computes adaptive gradient magnitudes in a local window, then links edges via
-//!   hysteresis (when enabled). By default, zero‑crossings are thinned for cleaner,
-//!   single‑pixel edges.
-//! - Thresholds operate on raw luminance differences in the 0–255 range.
-//! - The outermost border pixels are not considered for zero‑crossings.
+//! Applies ISEF smoothing, detects zero‑crossings, computes adaptive gradient
+//! magnitudes in a local window, then links edges via hysteresis.
+//! Uses percentile-based thresholds that automatically adapt to image content.
 
 const ShenCastan = @This();
 
-// Core parameters
-/// ISEF smoothing factor `b` (0 < b < 1).
+/// ISEF smoothing factor (0 < smooth < 1).
 /// Higher values preserve more detail (less smoothing). Typical range: 0.7–0.9.
 smooth: f32 = 0.9,
 
-/// Odd window size used to compute local mean differences across the zero‑crossing.
+/// Odd window size for computing local gradient statistics.
 /// Must be ≥ 3. Larger windows (e.g. 9–11) are more robust to noise.
-windowSize: usize = 7,
+window_size: usize = 7,
 
-/// Thresholding mode: percentile‑based (ratio, default) or explicit absolute values.
-thresholds: Thresholds = .{ .ratio = .{} },
+/// Percentile for high threshold selection (0 < high_ratio < 1).
+/// E.g. 0.99 means only the top 1% of gradients are considered strong edges.
+high_ratio: f32 = 0.99,
 
-/// When true (default), performs BFS hysteresis to link weak edges connected to
-/// strong ones. When false, only strong edges are returned.
+/// Low threshold as a fraction of high threshold (0 < low_rel < 1).
+/// E.g. 0.5 means low threshold = 0.5 * high threshold.
+low_rel: f32 = 0.5,
+
+/// Enable hysteresis edge linking.
+/// When true, weak edges connected to strong edges are preserved.
 hysteresis: bool = true,
 
-/// Zero‑crossing thinning strategy.
-/// `.forward` marks only forward neighbor transitions (E/S/SE/SW) for thinner edges.
-/// `.none` marks any 4‑neighbor transition (thicker, useful for debugging).
-/// `.nms` applies non‑maximum suppression along local gradient direction.
-thin: Thin = .forward,
+/// Use non-maximum suppression for single-pixel edges.
+/// When false, uses forward-neighbor thinning (faster).
+/// When true, uses NMS for cleaner single-pixel edges (slower).
+use_nms: bool = false,
 
-/// Available thinning strategies for zero‑crossing marking.
-pub const Thin = enum {
-    /// Thicker map: mark any 4‑neighbor transition around the center.
-    none,
-    /// Thinner map: mark only forward neighbor transitions (E/S/SE/SW).
-    forward,
-    /// Non‑maximum suppression along local gradient direction for true single‑pixel edges.
-    nms,
-};
-
-/// Percentile‑based threshold selection.
-/// `high` is set to the gradient magnitude at `highRatio` quantile across edge
-/// candidates; `low` is derived as `lowRel * high`.
-pub const Ratio = struct {
-    /// Quantile in (0, 1) used to select `high` (e.g. 0.99 → top 1% are strong).
-    highRatio: f32 = 0.99,
-    /// Relative factor in (0, 1) so that `low = lowRel * high`.
-    lowRel: f32 = 0.5,
-};
-
-/// Explicit absolute thresholds (0–255). Must satisfy `0 < low < high`.
-pub const Explicit = struct {
-    /// Lower hysteresis threshold.
-    low: f32,
-    /// Upper hysteresis threshold.
-    high: f32,
-};
-
-/// Selects thresholding strategy: percentile‑based (`ratio`) or explicit values.
-pub const Thresholds = union(enum) {
-    /// Percentile‑based thresholds using image content.
-    ratio: Ratio,
-    /// Explicit absolute thresholds in gradient units.
-    explicit: Explicit,
-};
-
-/// Validates option values and returns a descriptive error on invalid input:
+/// Validates option values and returns descriptive errors:
 /// - `InvalidBParameter`: if `smooth` is not in (0, 1)
-/// - `WindowSizeMustBeOdd`: if `windowSize` is even
-/// - `WindowSizeTooSmall`: if `windowSize` < 3
-/// - `InvalidThreshold`: for invalid ratio/explicit ranges
-/// - `InvalidThresholdOrder`: if `explicit.low >= explicit.high`
+/// - `WindowSizeMustBeOdd`: if `window_size` is even
+/// - `WindowSizeTooSmall`: if `window_size` < 3
+/// - `InvalidThreshold`: if thresholds are out of range
 pub fn validate(self: ShenCastan) !void {
     if (!(self.smooth > 0 and self.smooth < 1)) return error.InvalidBParameter;
-    if (self.windowSize % 2 == 0) return error.WindowSizeMustBeOdd;
-    if (self.windowSize < 3) return error.WindowSizeTooSmall;
-    switch (self.thresholds) {
-        .ratio => |r| {
-            if (!(r.highRatio > 0 and r.highRatio < 1)) return error.InvalidThreshold;
-            if (!(r.lowRel > 0 and r.lowRel < 1)) return error.InvalidThreshold;
-        },
-        .explicit => |e| {
-            if (!(e.low > 0 and e.high > 0)) return error.InvalidThreshold;
-            if (e.low >= e.high) return error.InvalidThresholdOrder;
-        },
-    }
+    if (self.window_size % 2 == 0) return error.WindowSizeMustBeOdd;
+    if (self.window_size < 3) return error.WindowSizeTooSmall;
+    if (!(self.high_ratio > 0 and self.high_ratio < 1)) return error.InvalidThreshold;
+    if (!(self.low_rel > 0 and self.low_rel < 1)) return error.InvalidThreshold;
 }
 
-/// Sensible defaults (auto thresholds, forward thinning, hysteresis on).
-pub const default: ShenCastan = .{};
+// ============================================================================
+// Preset Configurations
+// ============================================================================
 
-/// Preset tuned for low‑noise images (retain detail, fewer strong edges by percentile).
-pub const low_noise: ShenCastan = .{
-    .smooth = 0.9,
-    .windowSize = 7,
-    .thresholds = .{ .ratio = .{ .highRatio = 0.995, .lowRel = 0.5 } },
+/// Default configuration with balanced settings.
+/// Good starting point for most images.
+pub const default = ShenCastan{};
+
+/// Optimized for low-noise, high-quality images.
+/// Less smoothing to preserve fine details, stricter edge thresholds.
+pub const low_noise = ShenCastan{
+    .smooth = 0.95,
+    .high_ratio = 0.98,
 };
 
-/// Preset tuned for high‑noise images (more smoothing, larger window).
-pub const high_noise: ShenCastan = .{
-    .smooth = 0.8,
-    .windowSize = 11,
-    .thresholds = .{ .ratio = .{ .highRatio = 0.99, .lowRel = 0.5 } },
+/// Optimized for noisy images.
+/// More aggressive smoothing with larger window to suppress noise.
+pub const high_noise = ShenCastan{
+    .smooth = 0.7,
+    .window_size = 11,
 };
 
-/// Preset for higher sensitivity (more edges): lower percentile and lower relative low.
-pub const sensitive: ShenCastan = .{
-    .smooth = 0.9,
-    .windowSize = 7,
-    .thresholds = .{ .ratio = .{ .highRatio = 0.97, .lowRel = 0.4 } },
+/// Heavy smoothing for very noisy or low-quality images.
+/// Uses strong ISEF smoothing with moderate thresholds to suppress artifacts.
+pub const heavy_smooth = ShenCastan{
+    .smooth = 0.5,
+    .window_size = 9,
+    .high_ratio = 0.95,
 };
 
-/// Preset to visualize thicker transitions (debug/visualization): disables thinning.
-pub const thick: ShenCastan = .{ .thin = .none };
+/// Higher sensitivity configuration.
+/// Detects more edges by using lower thresholds.
+pub const sensitive = ShenCastan{
+    .high_ratio = 0.97,
+    .low_rel = 0.4,
+};
 
-/// Preset to enable non‑maximum suppression thinning for single‑pixel edges.
-pub const nms_thin: ShenCastan = .{ .thin = .nms };
+/// Produces single-pixel wide edges using non-maximum suppression.
+/// Slower but gives cleaner, thinner edge lines.
+pub const thin = ShenCastan{
+    .use_nms = true,
+};
 
-/// Preset to return only strong edges (no linking).
-pub const strong_only: ShenCastan = .{ .hysteresis = false };
+/// Detects only strong edges without hysteresis linking.
+/// Useful when you want only the most prominent edges.
+pub const strong_only = ShenCastan{
+    .hysteresis = false,
+};


### PR DESCRIPTION
Exposes the Shen-Castan edge detection algorithm to Python.

This involved a significant refactor of the underlying Zig ShenCastan configuration struct. Nested thresholding and thinning options were removed, simplifying its API. Parameters like `highRatio`, `lowRel`, `windowSize` are now direct fields (`high_ratio`, `low_rel`, `window_size`), and `use_nms` has been added. These are directly exposed in the Python binding.

Updates Zig tests and adds comprehensive Python tests.

BREAKING CHANGE: The 'ShenCastan' struct in 'src/image/ShenCastan.zig' has been refactored. The 'thresholds' union and 'thin' enum fields have been removed. Direct users of the Zig 'ShenCastan' struct will need to update their code to use the new direct fields: 'smooth', 'window_size', 'high_ratio', 'low_rel', 'hysteresis', 'use_nms'.