### PR TITLE
feat(image): add image invert method

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1039,6 +1039,14 @@ pub const image_methods_metadata = blk: {
             .returns = "Image",
         },
         .{
+            .name = "invert",
+            .meth = @ptrCast(&filtering.image_invert),
+            .flags = c.METH_NOARGS,
+            .doc = filtering.image_invert_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
             .name = "motion_blur",
             .meth = @ptrCast(&filtering.image_motion_blur),
             .flags = c.METH_VARARGS,

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -221,6 +221,23 @@ class TestImageSmoke:
         warped = gray.warp(sim)
         assert warped is not None
 
+    def test_invert(self):
+        """Test color inversion"""
+        # Test grayscale
+        gray = zignal.Image(2, 2, 100, dtype=zignal.Grayscale)
+        inverted = gray.invert()
+        assert inverted[0, 0] == 155  # 255 - 100
+
+        # Test RGB
+        rgb = zignal.Image(1, 1, (0, 128, 255), dtype=zignal.Rgb)
+        inverted = rgb.invert()
+        assert inverted[0, 0].item() == zignal.Rgb(255, 127, 0)
+
+        # Test RGBA (alpha should be preserved)
+        rgba = zignal.Image(1, 1, (0, 128, 255, 64), dtype=zignal.Rgba)
+        inverted = rgba.invert()
+        assert inverted[0, 0].item() == zignal.Rgba(255, 127, 0, 64)
+
     def test_motion_blur_smoke(self):
         """Test motion blur API basics"""
         # Create test image

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -25,6 +25,7 @@ pub fn build(b: *std.Build) void {
         "image_demo",
         "orb_demo",
         "motion_blur_demo",
+        "shen_castan_demo",
     };
 
     // Build exec_examples with run steps and check compilation

--- a/src/image.zig
+++ b/src/image.zig
@@ -368,6 +368,29 @@ pub fn Image(comptime T: type) type {
             return Transform(T).flipTopBottom(self);
         }
 
+        /// Inverts the colors of an image in-place.
+        /// For grayscale (u8): inverts as 255 - value
+        /// For RGB colors: inverts each channel as 255 - channel
+        /// For RGBA colors: inverts RGB channels but preserves alpha
+        pub fn invert(self: Self) void {
+            const color = @import("color.zig");
+
+            for (0..self.rows) |r| {
+                for (0..self.cols) |c| {
+                    const pixel = self.at(r, c);
+                    switch (T) {
+                        u8 => pixel.* = 255 - pixel.*,
+                        color.Rgb, color.Rgba => {
+                            pixel.r = 255 - pixel.r;
+                            pixel.g = 255 - pixel.g;
+                            pixel.b = 255 - pixel.b;
+                        },
+                        else => @compileError("invert() currently only supports u8, Rgb, and Rgba pixel types"),
+                    }
+                }
+            }
+        }
+
         /// Performs interpolation at position x, y using the specified method.
         /// Returns `null` if the coordinates are outside valid bounds for the chosen method.
         pub fn interpolate(self: Self, x: f32, y: f32, method: @import("image/interpolation.zig").Interpolation) ?T {

--- a/src/image/tests/filters.zig
+++ b/src/image/tests/filters.zig
@@ -9,6 +9,40 @@ const Rgb = color.Rgb;
 const Rectangle = @import("../../geometry.zig").Rectangle;
 const Image = @import("../../image.zig").Image;
 
+test "invert" {
+    // Test grayscale
+    var gray: Image(u8) = try .init(std.testing.allocator, 2, 2);
+    defer gray.deinit(std.testing.allocator);
+
+    gray.at(0, 0).* = 0;
+    gray.at(0, 1).* = 255;
+    gray.at(1, 0).* = 100;
+    gray.at(1, 1).* = 128;
+
+    gray.invert();
+
+    try expectEqual(@as(u8, 255), gray.at(0, 0).*);
+    try expectEqual(@as(u8, 0), gray.at(0, 1).*);
+    try expectEqual(@as(u8, 155), gray.at(1, 0).*);
+    try expectEqual(@as(u8, 127), gray.at(1, 1).*);
+
+    // Test RGB
+    var rgb: Image(Rgb) = try .init(std.testing.allocator, 1, 1);
+    defer rgb.deinit(std.testing.allocator);
+
+    rgb.at(0, 0).* = Rgb{ .r = 0, .g = 128, .b = 255 };
+    rgb.invert();
+    try expectEqualDeep(Rgb{ .r = 255, .g = 127, .b = 0 }, rgb.at(0, 0).*);
+
+    // Test RGBA preserves alpha
+    var rgba: Image(color.Rgba) = try .init(std.testing.allocator, 1, 1);
+    defer rgba.deinit(std.testing.allocator);
+
+    rgba.at(0, 0).* = color.Rgba{ .r = 0, .g = 128, .b = 255, .a = 64 };
+    rgba.invert();
+    try expectEqualDeep(color.Rgba{ .r = 255, .g = 127, .b = 0, .a = 64 }, rgba.at(0, 0).*);
+}
+
 test "boxBlur radius 0 with views" {
     var image: Image(u8) = try .init(std.testing.allocator, 6, 8);
     defer image.deinit(std.testing.allocator);


### PR DESCRIPTION
Implement `invert()` for the `Image` struct in Zig, allowing in-place color inversion for grayscale, RGB, and RGBA images. Expose this functionality via Python bindings and add tests.