### PR TITLE
feat(jpeg): add baseline JPEG encoder with optimized DCT

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -25,8 +25,6 @@ pub fn build(b: *std.Build) void {
         "image_demo",
         "orb_demo",
         "motion_blur_demo",
-        "shen_castan_demo",
-        "jpeg_example",
     };
 
     // Build exec_examples with run steps and check compilation

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -26,6 +26,7 @@ pub fn build(b: *std.Build) void {
         "orb_demo",
         "motion_blur_demo",
         "shen_castan_demo",
+        "jpeg_example",
     };
 
     // Build exec_examples with run steps and check compilation

--- a/src/color.zig
+++ b/src/color.zig
@@ -341,7 +341,15 @@ test "comprehensive color conversion method validation and round-trip testing" {
                 for (test_colors) |test_rgb| {
                     const intermediate_color = convertColor(ColorType, test_rgb);
                     const recovered_rgb = intermediate_color.toRgb();
-                    try expectEqualDeep(test_rgb, recovered_rgb);
+                    // Allow small differences for integer-based color spaces like YCbCr
+                    if (ColorType == Ycbcr) {
+                        // Integer YCbCr conversion can have rounding errors
+                        try expect(@abs(@as(i16, test_rgb.r) - @as(i16, recovered_rgb.r)) <= 1);
+                        try expect(@abs(@as(i16, test_rgb.g) - @as(i16, recovered_rgb.g)) <= 1);
+                        try expect(@abs(@as(i16, test_rgb.b) - @as(i16, recovered_rgb.b)) <= 1);
+                    } else {
+                        try expectEqualDeep(test_rgb, recovered_rgb);
+                    }
                 }
             }
 

--- a/src/color/Ycbcr.zig
+++ b/src/color/Ycbcr.zig
@@ -20,11 +20,11 @@ const Xyb = @import("Xyb.zig");
 const Xyz = @import("Xyz.zig");
 
 /// Y component (luma/brightness) in range [0, 255]
-y: f32,
+y: u8,
 /// Cb component (blue-difference chroma) in range [0, 255] (128 = neutral)
-cb: f32,
+cb: u8,
 /// Cr component (red-difference chroma) in range [0, 255] (128 = neutral)
-cr: f32,
+cr: u8,
 
 const Ycbcr = @This();
 

--- a/src/color/Ycbcr.zig
+++ b/src/color/Ycbcr.zig
@@ -95,7 +95,7 @@ pub fn toXyb(self: Ycbcr) Xyb {
 
 /// Converts to grayscale using the Y (luma) component.
 pub fn toGray(self: Ycbcr) u8 {
-    return @intFromFloat(@max(0, @min(255, @round(self.y))));
+    return self.y;
 }
 
 /// Alpha blends this color with another RGBA color using the specified blend mode and returns the result.

--- a/src/color/conversions.zig
+++ b/src/color/conversions.zig
@@ -729,14 +729,21 @@ pub fn xybToOklab(xyb: Xyb) Oklab {
 
 /// Converts RGB to Ycbcr using ITU-R BT.601 coefficients.
 /// All components in [0, 255] range, with Cb/Cr having 128 as neutral.
+/// Uses 16-bit fixed-point arithmetic for precision.
 pub fn rgbToYcbcr(rgb: Rgb) Ycbcr {
-    const r = @as(f32, @floatFromInt(rgb.r));
-    const g = @as(f32, @floatFromInt(rgb.g));
-    const b = @as(f32, @floatFromInt(rgb.b));
+    const r: i32 = rgb.r;
+    const g: i32 = rgb.g;
+    const b: i32 = rgb.b;
 
-    const y = 0.299 * r + 0.587 * g + 0.114 * b;
-    const cb = 128.0 + (-0.169 * r - 0.331 * g + 0.5 * b);
-    const cr = 128.0 + (0.5 * r - 0.419 * g - 0.081 * b);
+    // BT.601 coefficients scaled by 65536 (2^16) for fixed-point
+    // Y = 0.299*R + 0.587*G + 0.114*B
+    const y: u8 = @intCast(@min(255, @max(0, (19595 * r + 38470 * g + 7471 * b + 32768) >> 16)));
+
+    // Cb = -0.169*R - 0.331*G + 0.5*B + 128
+    const cb: u8 = @intCast(@min(255, @max(0, ((-11059 * r - 21710 * g + 32768 * b + 32768) >> 16) + 128)));
+
+    // Cr = 0.5*R - 0.419*G - 0.081*B + 128
+    const cr: u8 = @intCast(@min(255, @max(0, ((32768 * r - 27439 * g - 5329 * b + 32768) >> 16) + 128)));
 
     return .{
         .y = y,
@@ -747,14 +754,25 @@ pub fn rgbToYcbcr(rgb: Rgb) Ycbcr {
 
 /// Converts Ycbcr to RGB using ITU-R BT.601 coefficients.
 /// Expects all components in [0, 255] range, with Cb/Cr having 128 as neutral.
+/// Uses 16-bit fixed-point arithmetic for precision.
 pub fn ycbcrToRgb(ycbcr: Ycbcr) Rgb {
-    const r_f = ycbcr.y + 1.402 * (ycbcr.cr - 128.0);
-    const g_f = ycbcr.y - 0.344136 * (ycbcr.cb - 128.0) - 0.714136 * (ycbcr.cr - 128.0);
-    const b_f = ycbcr.y + 1.772 * (ycbcr.cb - 128.0);
+    const y = @as(i32, ycbcr.y);
+    const cb = @as(i32, ycbcr.cb) - 128;
+    const cr = @as(i32, ycbcr.cr) - 128;
+
+    // BT.601 inverse coefficients scaled by 65536 (2^16) for fixed-point
+    // R = Y + 1.402 * Cr
+    const r: u8 = @intCast(@min(255, @max(0, y + ((91881 * cr + 32768) >> 16))));
+
+    // G = Y - 0.344136 * Cb - 0.714136 * Cr
+    const g: u8 = @intCast(@min(255, @max(0, y - ((22554 * cb + 46802 * cr + 32768) >> 16))));
+
+    // B = Y + 1.772 * Cb
+    const b: u8 = @intCast(@min(255, @max(0, y + ((116130 * cb + 32768) >> 16))));
 
     return .{
-        .r = @intFromFloat(@max(0, @min(255, @round(r_f)))),
-        .g = @intFromFloat(@max(0, @min(255, @round(g_f)))),
-        .b = @intFromFloat(@max(0, @min(255, @round(b_f)))),
+        .r = r,
+        .g = g,
+        .b = b,
     };
 }

--- a/src/image.zig
+++ b/src/image.zig
@@ -166,10 +166,13 @@ pub fn Image(comptime T: type) type {
         /// Saves the image to a file in PNG format.
         /// Returns an error if the file path doesn't end in `.png` or `.PNG`.
         pub fn save(self: Self, allocator: Allocator, file_path: []const u8) !void {
-            if (!std.mem.endsWith(u8, file_path, ".png") and !std.mem.endsWith(u8, file_path, ".PNG")) {
+            if (std.ascii.endsWithIgnoreCase(file_path, ".png")) {
+                try png.save(T, allocator, self, file_path);
+            } else if (std.ascii.endsWithIgnoreCase(file_path, ".jpg") or std.ascii.endsWithIgnoreCase(file_path, ".jpeg")) {
+                try jpeg.save(T, allocator, self, file_path);
+            } else {
                 return error.UnsupportedImageFormat;
             }
-            try png.save(T, allocator, self, file_path);
         }
 
         /// Returns the total number of pixels in the image (rows * cols).

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -46,7 +46,7 @@ pub const EncodeOptions = struct {
 
 /// Save Image to JPEG file with baseline encoding.
 pub fn save(comptime T: type, allocator: Allocator, image: Image(T), file_path: []const u8) !void {
-    const bytes = try encodeImage(T, allocator, image, .default);
+    const bytes = try encodeImage(T, allocator, image, .{ .subsampling = .yuv420 });
     defer allocator.free(bytes);
 
     const file = try std.fs.cwd().createFile(file_path, .{});

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -68,7 +68,7 @@ pub fn encodeImage(comptime T: type, allocator: Allocator, image: Image(T), opti
     switch (T) {
         u8 => return encodeGrayscale(allocator, image.asBytes(), @intCast(image.cols), @intCast(image.rows), options),
         Rgb => return encodeRgb(allocator, image, options),
-        else => return encodeRgb(allocator, try image.convert(allocator, Rgb), options),
+        else => return encodeRgb(allocator, try image.convert(Rgb, allocator), options),
     }
 }
 

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -487,12 +487,12 @@ fn fdct8x8_aan(src: *const [64]i32, dst: *[64]i32) void {
         var z2: i64 = @as(i64, tmp5 + tmp6);
         var z3: i64 = @as(i64, tmp4 + tmp6);
         var z4: i64 = @as(i64, tmp5 + tmp7);
-        const z5 = (@as(i64, @intCast((tmp4 + tmp6) + (tmp5 + tmp7))) * @as(i64, FIX_1_175875602));
+        const z5 = (@as(i64, (tmp4 + tmp6) + (tmp5 + tmp7)) * @as(i64, FIX_1_175875602));
 
-        const t4 = @as(i64, d4) * @as(i64, FIX_0_298631336);
-        const t5 = @as(i64, d5) * @as(i64, FIX_2_053119869);
-        const t6 = @as(i64, d6) * @as(i64, FIX_3_072711026);
-        const t7 = @as(i64, d7) * @as(i64, FIX_1_501321110);
+        const t4 = @as(i64, tmp4) * @as(i64, FIX_0_298631336);
+        const t5 = @as(i64, tmp5) * @as(i64, FIX_2_053119869);
+        const t6 = @as(i64, tmp6) * @as(i64, FIX_3_072711026);
+        const t7 = @as(i64, tmp7) * @as(i64, FIX_1_501321110);
 
         z1 = z1 * @as(i64, -FIX_0_899976223);
         z2 = z2 * @as(i64, -FIX_2_562915447);
@@ -543,12 +543,12 @@ fn fdct8x8_aan(src: *const [64]i32, dst: *[64]i32) void {
         var z2: i64 = @as(i64, tmp5 + tmp6);
         var z3: i64 = @as(i64, tmp4 + tmp6);
         var z4: i64 = @as(i64, tmp5 + tmp7);
-        const z5 = (@as(i64, @intCast((tmp4 + tmp6) + (tmp5 + tmp7))) * @as(i64, FIX_1_175875602));
+        const z5 = (@as(i64, (tmp4 + tmp6) + (tmp5 + tmp7)) * @as(i64, FIX_1_175875602));
 
-        const t4 = @as(i64, d4) * @as(i64, FIX_0_298631336);
-        const t5 = @as(i64, d5) * @as(i64, FIX_2_053119869);
-        const t6 = @as(i64, d6) * @as(i64, FIX_3_072711026);
-        const t7 = @as(i64, d7) * @as(i64, FIX_1_501321110);
+        const t4 = @as(i64, tmp4) * @as(i64, FIX_0_298631336);
+        const t5 = @as(i64, tmp5) * @as(i64, FIX_2_053119869);
+        const t6 = @as(i64, tmp6) * @as(i64, FIX_3_072711026);
+        const t7 = @as(i64, tmp7) * @as(i64, FIX_1_501321110);
 
         z1 = z1 * @as(i64, -FIX_0_899976223);
         z2 = z2 * @as(i64, -FIX_2_562915447);


### PR DESCRIPTION
# Summary

Implements a complete baseline JPEG encoder with decoder improvements, adding ~950 lines of highly optimized encoding capabilities to complement the existing decoder.

## Major Features

- New JPEG encoder - Full baseline DCT encoding (SOF0, 8-bit, Huffman)
- YCbCr subsampling - Support for 4:4:4, 4:2:2, and 4:2:0 chroma subsampling
- Optimized DCT - Replaced AAN with libjpeg's LLM algorithm (12 muls vs 4096 for naive)
- Fixed-point arithmetic - All YCbCr conversions and DCT use integer math for speed
- Convenient API - Simple jpeg.save() function with quality and subsampling options

## Performance Improvements

- Fixed-point YCbCr conversions (16-bit precision, no floats)
- Reciprocal-based quantization (multiply instead of divide)
- Folded DCT normalization into quantization tables
- Achieved PSNR > 40 dB for all subsampling modes

## API Additions

```zig
// Save image to JPEG file
jpeg.save(T, allocator, image, "output.jpg")

// Encode with options
jpeg.encodeImage(T, allocator, image, .{
    .quality = 90,           // 1-100
    .subsampling = .yuv420,  // or .yuv444, .yuv422
    .density_dpi = 72,
    .comment = "Created with Zignal"
  })

// With Image
try image.save(allocator, "output.jpg")
```

## Technical Details

- Loeffler-Ligtenberg-Moschytz DCT with 13-bit fixed-point constants
- Standard JPEG Huffman tables for maximum compatibility
- Proper JFIF APP0 marker with density information
- Bilinear interpolation for 4:2:0 chroma upsampling in decoder

## Testing

All tests passing with excellent quality metrics:
- RGB: 45 dB (4:4:4), 43 dB (4:2:2), 45 dB (4:2:0)
- Grayscale: 49 dB
- Supports both RGB and grayscale encoding