### PR TITLE
feat(image): add histogram equalization

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1138,6 +1138,14 @@ pub const image_methods_metadata = blk: {
             .returns = "Image",
         },
         .{
+            .name = "equalize",
+            .meth = @ptrCast(&filtering.image_equalize),
+            .flags = c.METH_NOARGS,
+            .doc = filtering.image_equalize_doc,
+            .params = "self",
+            .returns = "Image",
+        },
+        .{
             .name = "motion_blur",
             .meth = @ptrCast(&filtering.image_motion_blur),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -303,3 +303,37 @@ class TestImageSmoke:
 
         with pytest.raises(ValueError):
             img.shen_castan(high_ratio=0.0)  # Must be in (0, 1)
+
+    def test_autocontrast_smoke(self):
+        """Smoke test for autocontrast method"""
+        # Grayscale
+        gray = zignal.Image(5, 5, 128, dtype=zignal.Grayscale)
+        enhanced = gray.autocontrast()
+        assert enhanced.rows == 5 and enhanced.cols == 5
+
+        # RGB
+        rgb = zignal.Image(5, 5, (100, 150, 200), dtype=zignal.Rgb)
+        enhanced_rgb = rgb.autocontrast(cutoff=2.0)
+        assert enhanced_rgb.rows == 5 and enhanced_rgb.cols == 5
+
+        # RGBA
+        rgba = zignal.Image(5, 5, (100, 150, 200, 255), dtype=zignal.Rgba)
+        enhanced_rgba = rgba.autocontrast()
+        assert enhanced_rgba.rows == 5 and enhanced_rgba.cols == 5
+
+    def test_equalize_smoke(self):
+        """Smoke test for equalize method"""
+        # Grayscale
+        gray = zignal.Image(5, 5, 128, dtype=zignal.Grayscale)
+        equalized = gray.equalize()
+        assert equalized.rows == 5 and equalized.cols == 5
+
+        # RGB
+        rgb = zignal.Image(5, 5, (100, 150, 200), dtype=zignal.Rgb)
+        equalized_rgb = rgb.equalize()
+        assert equalized_rgb.rows == 5 and equalized_rgb.cols == 5
+
+        # RGBA
+        rgba = zignal.Image(5, 5, (100, 150, 200, 255), dtype=zignal.Rgba)
+        equalized_rgba = rgba.equalize()
+        assert equalized_rgba.rows == 5 and equalized_rgba.cols == 5

--- a/src/image.zig
+++ b/src/image.zig
@@ -562,6 +562,30 @@ pub fn Image(comptime T: type) type {
             return Filter(T).autocontrast(self, allocator, cutoff);
         }
 
+        /// Equalizes the histogram of an image to improve contrast.
+        ///
+        /// This function redistributes pixel intensities to achieve a more uniform histogram,
+        /// which typically enhances contrast in images with poor contrast or uneven lighting.
+        /// The technique maps the cumulative distribution function (CDF) of pixel values to
+        /// create a more even spread of intensities across the full range.
+        ///
+        /// For color images (RGB/RGBA), each channel is equalized independently.
+        ///
+        /// Parameters:
+        /// - `allocator`: The allocator to use for the new image
+        ///
+        /// Returns: A new image with equalized histogram
+        ///
+        /// Example usage:
+        /// ```zig
+        /// var img = try Image(u8).load(allocator, "low_contrast.png");
+        /// var equalized = try img.equalize(allocator);
+        /// defer equalized.deinit(allocator);
+        /// ```
+        pub fn equalize(self: Self, allocator: Allocator) !Self {
+            return Filter(T).equalize(self, allocator);
+        }
+
         /// Applies a 2D convolution with the given kernel to the image.
         ///
         /// Parameters:

--- a/src/image/filtering.zig
+++ b/src/image/filtering.zig
@@ -282,6 +282,185 @@ pub fn Filter(comptime T: type) type {
             return result;
         }
 
+        /// Equalizes the histogram to improve contrast.
+        pub fn equalize(self: Self, allocator: Allocator) !Self {
+            var result = try Self.init(allocator, self.rows, self.cols);
+            errdefer result.deinit(allocator);
+
+            const total_pixels: u32 = @intCast(self.rows * self.cols);
+
+            switch (@typeInfo(T)) {
+                .int => {
+                    // For grayscale images
+                    const hist = self.histogram();
+
+                    // Calculate cumulative distribution function (CDF)
+                    var cdf: [256]u32 = undefined;
+                    cdf[0] = hist.values[0];
+                    for (1..256) |i| {
+                        cdf[i] = cdf[i - 1] + hist.values[i];
+                    }
+
+                    // Find the first non-zero CDF value (for normalization)
+                    var cdf_min: u32 = 0;
+                    for (cdf) |val| {
+                        if (val > 0) {
+                            cdf_min = val;
+                            break;
+                        }
+                    }
+
+                    // Create lookup table for equalization
+                    var lut: [256]u8 = undefined;
+                    const denominator = total_pixels - cdf_min;
+                    if (denominator == 0) {
+                        // All pixels have the same value
+                        for (0..256) |i| {
+                            lut[i] = @intCast(i);
+                        }
+                    } else {
+                        for (0..256) |i| {
+                            if (cdf[i] >= cdf_min) {
+                                const numerator = (cdf[i] - cdf_min) * 255;
+                                lut[i] = @intCast(numerator / denominator);
+                            } else {
+                                lut[i] = 0;
+                            }
+                        }
+                    }
+
+                    // Apply the lookup table
+                    for (0..self.rows) |r| {
+                        for (0..self.cols) |c| {
+                            const val = self.at(r, c).*;
+                            result.at(r, c).* = lut[val];
+                        }
+                    }
+                },
+                .@"struct" => {
+                    // For RGB/RGBA images, process each channel independently
+                    const Rgb = @import("../color.zig").Rgb;
+                    const Rgba = @import("../color.zig").Rgba;
+
+                    if (T == Rgb or T == Rgba) {
+                        const hist = self.histogram();
+
+                        // Calculate CDF for each channel
+                        var cdf_r: [256]u32 = undefined;
+                        var cdf_g: [256]u32 = undefined;
+                        var cdf_b: [256]u32 = undefined;
+                        var cdf_a: [256]u32 = undefined;
+
+                        cdf_r[0] = hist.r[0];
+                        cdf_g[0] = hist.g[0];
+                        cdf_b[0] = hist.b[0];
+                        if (T == Rgba) {
+                            cdf_a[0] = hist.a[0];
+                        }
+
+                        for (1..256) |i| {
+                            cdf_r[i] = cdf_r[i - 1] + hist.r[i];
+                            cdf_g[i] = cdf_g[i - 1] + hist.g[i];
+                            cdf_b[i] = cdf_b[i - 1] + hist.b[i];
+                            if (T == Rgba) {
+                                cdf_a[i] = cdf_a[i - 1] + hist.a[i];
+                            }
+                        }
+
+                        // Find minimum CDF values for each channel
+                        var cdf_min_r: u32 = 0;
+                        var cdf_min_g: u32 = 0;
+                        var cdf_min_b: u32 = 0;
+                        var cdf_min_a: u32 = 0;
+
+                        for (cdf_r) |val| {
+                            if (val > 0) {
+                                cdf_min_r = val;
+                                break;
+                            }
+                        }
+                        for (cdf_g) |val| {
+                            if (val > 0) {
+                                cdf_min_g = val;
+                                break;
+                            }
+                        }
+                        for (cdf_b) |val| {
+                            if (val > 0) {
+                                cdf_min_b = val;
+                                break;
+                            }
+                        }
+                        if (T == Rgba) {
+                            for (cdf_a) |val| {
+                                if (val > 0) {
+                                    cdf_min_a = val;
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Create lookup tables for each channel
+                        var lut_r: [256]u8 = undefined;
+                        var lut_g: [256]u8 = undefined;
+                        var lut_b: [256]u8 = undefined;
+                        var lut_a: [256]u8 = undefined;
+
+                        const createLut = struct {
+                            fn apply(cdf: *const [256]u32, cdf_min: u32, total: u32) [256]u8 {
+                                var lut: [256]u8 = undefined;
+                                const denominator = total - cdf_min;
+                                if (denominator == 0) {
+                                    for (0..256) |i| {
+                                        lut[i] = @intCast(i);
+                                    }
+                                } else {
+                                    for (0..256) |i| {
+                                        if (cdf[i] >= cdf_min) {
+                                            const numerator = (cdf[i] - cdf_min) * 255;
+                                            lut[i] = @intCast(numerator / denominator);
+                                        } else {
+                                            lut[i] = 0;
+                                        }
+                                    }
+                                }
+                                return lut;
+                            }
+                        }.apply;
+
+                        lut_r = createLut(&cdf_r, cdf_min_r, total_pixels);
+                        lut_g = createLut(&cdf_g, cdf_min_g, total_pixels);
+                        lut_b = createLut(&cdf_b, cdf_min_b, total_pixels);
+                        if (T == Rgba) {
+                            lut_a = createLut(&cdf_a, cdf_min_a, total_pixels);
+                        }
+
+                        // Apply the lookup tables
+                        for (0..self.rows) |r| {
+                            for (0..self.cols) |c| {
+                                const pixel = self.at(r, c).*;
+                                var new_pixel = pixel;
+
+                                new_pixel.r = lut_r[pixel.r];
+                                new_pixel.g = lut_g[pixel.g];
+                                new_pixel.b = lut_b[pixel.b];
+                                if (T == Rgba) {
+                                    new_pixel.a = lut_a[pixel.a];
+                                }
+
+                                result.at(r, c).* = new_pixel;
+                            }
+                        }
+                    } else {
+                        return error.UnsupportedType;
+                    }
+                },
+                else => return error.UnsupportedType,
+            }
+
+            return result;
+        }
+
         pub fn sharpen(self: Self, allocator: std.mem.Allocator, sharpened: *Self, radius: usize) !void {
             if (!self.hasSameShape(sharpened.*)) {
                 sharpened.* = try .init(allocator, self.rows, self.cols);


### PR DESCRIPTION
Implements the `equalize` method for image contrast enhancement in Zig. Provides Python bindings and adds smoke tests for both `equalize` and `autocontrast` methods.