### PR TITLE
refactor(python): standardize object lifecycle and error handling

### DIFF
--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -216,7 +216,7 @@ fn canvas_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 }
 
 fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     // Parse arguments - expect an Image object
     const Params = struct {
@@ -230,7 +230,7 @@ fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
 
     // Check if it's an Image instance
     if (c.PyObject_IsInstance(params.image, @ptrCast(&image_module.ImageType)) <= 0) {
-        c.PyErr_SetString(c.PyExc_TypeError, "Argument must be an Image instance");
+        py_utils.setTypeError("Image instance", args);
         return -1;
     }
 
@@ -244,14 +244,14 @@ fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
     if (image.py_image) |pimg| {
         const py_canvas = allocator.create(PyCanvas) catch {
             c.Py_DECREF(params.image.?);
-            c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate PyCanvas");
+            py_utils.setMemoryError("PyCanvas");
             return -1;
         };
         py_canvas.* = PyCanvas.initFromPyImage(allocator, pimg);
         self.py_canvas = py_canvas;
     } else {
         c.Py_DECREF(params.image.?);
-        c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+        py_utils.setValueError("Image not initialized", .{});
         return -1;
     }
 
@@ -259,7 +259,7 @@ fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
 }
 
 fn canvas_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     // Free the PyCanvas
     if (self.py_canvas) |ptr| {
@@ -275,7 +275,7 @@ fn canvas_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 }
 
 fn canvas_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     if (self.py_canvas) |canvas| {
         var buffer: [64]u8 = undefined;
@@ -313,7 +313,7 @@ const canvas_fill_doc =
 ;
 
 fn canvas_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     // Parse color argument
     var color_obj: ?*c.PyObject = undefined;
@@ -328,7 +328,7 @@ fn canvas_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
     if (self.py_canvas) |canvas| {
         canvas.fill(rgba);
     } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Canvas not initialized");
+        py_utils.setValueError("Canvas not initialized", .{});
         return null;
     }
 
@@ -337,7 +337,7 @@ fn canvas_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
 
 // Draw methods
 fn canvas_draw_line(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         p1: ?*c.PyObject,
@@ -374,7 +374,7 @@ const canvas_draw_line_doc =
 ;
 
 fn canvas_draw_rectangle(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         rect: ?*c.PyObject,
@@ -408,7 +408,7 @@ const canvas_draw_rectangle_doc =
 ;
 
 fn canvas_draw_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         points: ?*c.PyObject,
@@ -443,7 +443,7 @@ const canvas_draw_polygon_doc =
 ;
 
 fn canvas_draw_circle(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         center: ?*c.PyObject,
@@ -481,7 +481,7 @@ const canvas_draw_circle_doc =
 
 // Fill methods
 fn canvas_fill_rectangle(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         rect: ?*c.PyObject,
@@ -512,7 +512,7 @@ const canvas_fill_rectangle_doc =
 ;
 
 fn canvas_fill_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         points: ?*c.PyObject,
@@ -530,7 +530,7 @@ fn canvas_fill_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyO
 
     const canvas = py_utils.validateNonNull(*PyCanvas, self.py_canvas, "Canvas") catch return null;
     canvas.fillPolygon(points, rgba, draw_mode) catch {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to fill polygon");
+        py_utils.setRuntimeError("Failed to fill polygon", .{});
         return null;
     };
 
@@ -547,7 +547,7 @@ const canvas_fill_polygon_doc =
 ;
 
 fn canvas_fill_circle(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         center: ?*c.PyObject,
@@ -582,7 +582,7 @@ const canvas_fill_circle_doc =
 
 // Special methods that need custom handling
 fn canvas_draw_quadratic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         p0: ?*c.PyObject,
@@ -610,7 +610,7 @@ fn canvas_draw_quadratic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds
 }
 
 fn canvas_draw_cubic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         p0: ?*c.PyObject,
@@ -640,7 +640,7 @@ fn canvas_draw_cubic_bezier(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*
 }
 
 fn canvas_draw_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         points: ?*c.PyObject,
@@ -667,7 +667,7 @@ fn canvas_draw_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: 
 }
 
 fn canvas_fill_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         points: ?*c.PyObject,
@@ -687,7 +687,7 @@ fn canvas_fill_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: 
 
     const canvas = py_utils.validateNonNull(*PyCanvas, self.py_canvas, "Canvas") catch return null;
     canvas.fillSplinePolygon(points, rgba, tension_val, draw_mode) catch {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to fill spline polygon");
+        py_utils.setRuntimeError("Failed to fill spline polygon", .{});
         return null;
     };
 
@@ -695,7 +695,7 @@ fn canvas_fill_spline_polygon(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: 
 }
 
 fn canvas_draw_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         center: ?*c.PyObject,
@@ -720,7 +720,7 @@ fn canvas_draw_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 
     const canvas = py_utils.validateNonNull(*PyCanvas, self.py_canvas, "Canvas") catch return null;
     canvas.drawArc(center, radius_val, start_angle_val, end_angle_val, rgba, width_val, draw_mode) catch {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to draw arc");
+        py_utils.setRuntimeError("Failed to draw arc", .{});
         return null;
     };
 
@@ -728,7 +728,7 @@ fn canvas_draw_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 }
 
 fn canvas_fill_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     const Params = struct {
         center: ?*c.PyObject,
@@ -752,7 +752,7 @@ fn canvas_fill_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 
     const canvas = py_utils.validateNonNull(*PyCanvas, self.py_canvas, "Canvas") catch return null;
     canvas.fillArc(center, radius_val, start_angle_val, end_angle_val, rgba, draw_mode) catch {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to fill arc");
+        py_utils.setRuntimeError("Failed to fill arc", .{});
         return null;
     };
 
@@ -760,7 +760,7 @@ fn canvas_fill_arc(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 }
 
 fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     // Parse arguments using struct-based parseArgs
     const Params = struct {
@@ -775,7 +775,7 @@ fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
     const text_cstr = c.PyUnicode_AsUTF8(params.text) orelse {
-        c.PyErr_SetString(c.PyExc_TypeError, "text must be a string");
+        py_utils.setTypeError("string", params.text);
         return null;
     };
     const text = std.mem.span(text_cstr);
@@ -792,7 +792,7 @@ fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
         const bitmap_font_module = @import("bitmap_font.zig");
         if (c.PyObject_IsInstance(font, @ptrCast(&bitmap_font_module.BitmapFontType)) <= 0) {
             if (c.PyErr_Occurred() == null) {
-                c.PyErr_SetString(c.PyExc_TypeError, "font must be a BitmapFont instance or None");
+                py_utils.setTypeError("BitmapFont instance or None", font);
             }
             return null;
         }
@@ -802,7 +802,7 @@ fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
         py_canvas.drawText(text, position, rgba, font_ptr.*, @floatCast(params.scale), draw_mode);
     } else {
         const font = getFont8x8() catch {
-            c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to initialize default font");
+            py_utils.setRuntimeError("Failed to initialize default font", .{});
             return null;
         };
         py_canvas.drawText(text, position, rgba, font, @floatCast(params.scale), draw_mode);
@@ -814,7 +814,7 @@ fn canvas_draw_text(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
 // Property getters
 fn canvas_get_rows(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     if (self.py_canvas) |canvas| {
         return c.PyLong_FromLong(@intCast(canvas.rows()));
@@ -825,7 +825,7 @@ fn canvas_get_rows(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*
 
 fn canvas_get_cols(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     if (self.py_canvas) |canvas| {
         return c.PyLong_FromLong(@intCast(canvas.cols()));
@@ -836,13 +836,13 @@ fn canvas_get_cols(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*
 
 fn canvas_get_image(self_obj: ?*c.PyObject, closure: ?*anyopaque) callconv(.c) ?*c.PyObject {
     _ = closure;
-    const self = @as(*CanvasObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(CanvasObject, self_obj);
 
     if (self.image_ref) |img_ref| {
         c.Py_INCREF(img_ref);
         return img_ref;
     } else {
-        c.PyErr_SetString(c.PyExc_ValueError, "Canvas not initialized");
+        py_utils.setValueError("Canvas not initialized", .{});
         return null;
     }
 }

--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -230,7 +230,7 @@ fn canvas_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
 
     // Check if it's an Image instance
     if (c.PyObject_IsInstance(params.image, @ptrCast(&image_module.ImageType)) <= 0) {
-        py_utils.setTypeError("Image instance", args);
+        py_utils.setTypeError("Image instance", params.image);
         return -1;
     }
 

--- a/bindings/python/src/convex_hull.zig
+++ b/bindings/python/src/convex_hull.zig
@@ -11,42 +11,26 @@ pub const ConvexHullObject = extern struct {
     hull: ?*ConvexHull(f32),
 };
 
-fn convex_hull_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    _ = args;
-    _ = kwds;
-
-    const self = @as(?*ConvexHullObject, @ptrCast(c.PyType_GenericAlloc(type_obj, 0)));
-    if (self) |obj| {
-        obj.hull = null;
-    }
-    return @as(?*c.PyObject, @ptrCast(self));
-}
+// Using genericNew helper for standard object creation
+const convex_hull_new = py_utils.genericNew(ConvexHullObject);
 
 fn convex_hull_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
     _ = args;
     _ = kwds;
-    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ConvexHullObject, self_obj);
 
-    const hull = py_utils.allocator.create(ConvexHull(f32)) catch {
-        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate ConvexHull");
-        return -1;
-    };
-    hull.* = ConvexHull(f32).init(py_utils.allocator);
-    self.hull = hull;
-
+    // Using createHeapObject helper for allocation with error handling
+    self.hull = py_utils.createHeapObject(ConvexHull(f32), .{py_utils.allocator}) catch return -1;
     return 0;
 }
 
-fn convex_hull_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
-    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
-
-    if (self.hull) |hull| {
-        hull.deinit();
-        py_utils.allocator.destroy(hull);
-    }
-
-    c.Py_TYPE(self_obj).*.tp_free.?(self_obj);
+// Helper function for custom cleanup
+fn convexHullDeinit(self: *ConvexHullObject) void {
+    py_utils.destroyHeapObject(ConvexHull(f32), self.hull);
 }
+
+// Using genericDealloc helper
+const convex_hull_dealloc = py_utils.genericDealloc(ConvexHullObject, convexHullDeinit);
 
 fn convex_hull_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     _ = self_obj;
@@ -75,13 +59,10 @@ const convex_hull_find_doc =
 ;
 
 fn convex_hull_find(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ConvexHullObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ConvexHullObject, self_obj);
 
-    // Check if hull is initialized
-    if (self.hull == null) {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "ConvexHull not initialized");
-        return null;
-    }
+    // Using validateNonNull helper for null check with error message
+    const hull = py_utils.validateNonNull(*ConvexHull(f32), self.hull, "ConvexHull") catch return null;
 
     // Parse points argument
     const Params = struct {
@@ -98,17 +79,15 @@ fn convex_hull_find(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     };
     defer py_utils.allocator.free(points);
 
-    // Find convex hull
-    const hull_points = self.hull.?.find(points) catch {
-        c.PyErr_SetString(c.PyExc_RuntimeError, "Failed to compute convex hull");
+    // Find convex hull with improved error handling
+    const hull_points = hull.find(points) catch |err| {
+        py_utils.setRuntimeError("Failed to compute convex hull: {s}", .{@errorName(err)});
         return null;
     };
 
     // Check if hull is degenerate
     if (hull_points == null) {
-        const none = c.Py_None();
-        c.Py_INCREF(none);
-        return none;
+        return py_utils.getPyNone();
     }
 
     // Convert hull points to Python list of tuples
@@ -201,18 +180,14 @@ pub const convex_hull_special_methods_metadata = [_]stub_metadata.MethodInfo{
     },
 };
 
-pub var ConvexHullType = c.PyTypeObject{
-    .ob_base = .{
-        .ob_base = .{},
-        .ob_size = 0,
-    },
-    .tp_name = "zignal.ConvexHull",
-    .tp_basicsize = @sizeOf(ConvexHullObject),
-    .tp_dealloc = convex_hull_dealloc,
-    .tp_repr = convex_hull_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = convex_hull_class_doc,
-    .tp_methods = @ptrCast(&convex_hull_methods),
-    .tp_init = convex_hull_init,
-    .tp_new = convex_hull_new,
-};
+// Using buildTypeObject helper for cleaner initialization
+pub var ConvexHullType = py_utils.buildTypeObject(.{
+    .name = "zignal.ConvexHull",
+    .basicsize = @sizeOf(ConvexHullObject),
+    .doc = convex_hull_class_doc,
+    .methods = @ptrCast(&convex_hull_methods),
+    .new = convex_hull_new,
+    .init = convex_hull_init,
+    .dealloc = convex_hull_dealloc,
+    .repr = convex_hull_repr,
+});

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -391,11 +391,11 @@ fn image_getitem(self_obj: ?*c.PyObject, key: ?*c.PyObject) callconv(.c) ?*c.PyO
     // Bounds checking
     if (pimg_opt) |pimg| {
         if (row < 0 or row >= pimg.rows()) {
-            py_utils.setValueError("Row index out of bounds", .{});
+            py_utils.setIndexError("Row index out of bounds", .{});
             return null;
         }
         if (col < 0 or col >= pimg.cols()) {
-            py_utils.setValueError("Column index out of bounds", .{});
+            py_utils.setIndexError("Column index out of bounds", .{});
             return null;
         }
     } else {
@@ -442,7 +442,7 @@ fn image_setitem(self_obj: ?*c.PyObject, key: ?*c.PyObject, value: ?*c.PyObject)
             (step == 1);
 
         if (!is_full_slice) {
-            py_utils.setRuntimeError("Only full slice [:] assignment is currently supported", .{});
+            c.PyErr_SetString(c.PyExc_NotImplementedError, "Only full slice [:] assignment is currently supported");
             return -1;
         }
 
@@ -510,11 +510,11 @@ fn image_setitem(self_obj: ?*c.PyObject, key: ?*c.PyObject, value: ?*c.PyObject)
     // Bounds checking
     if (pimg_opt) |pimg| {
         if (row < 0 or row >= pimg.rows()) {
-            py_utils.setValueError("Row index out of bounds", .{});
+            py_utils.setIndexError("Row index out of bounds", .{});
             return -1;
         }
         if (col < 0 or col >= pimg.cols()) {
-            py_utils.setValueError("Column index out of bounds", .{});
+            py_utils.setIndexError("Column index out of bounds", .{});
             return -1;
         }
     } else {

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -363,8 +363,8 @@ fn image_getitem(self_obj: ?*c.PyObject, key: ?*c.PyObject) callconv(.c) ?*c.PyO
 
     const coords = py_utils.expectTupleLen(2, key, "tuple of (row, col)") catch return null;
 
-    const row_obj = coords[0] orelse return null;
-    const col_obj = coords[1] orelse return null;
+    const row_obj = coords[0];
+    const col_obj = coords[1];
 
     const row = c.PyLong_AsLong(row_obj);
     if (row == -1 and c.PyErr_Occurred() != null) {
@@ -475,8 +475,8 @@ fn image_setitem(self_obj: ?*c.PyObject, key: ?*c.PyObject, value: ?*c.PyObject)
 
     const coords = py_utils.expectTupleLen(2, key, "tuple of (row, col)") catch return -1;
 
-    const row_obj = coords[0] orelse return -1;
-    const col_obj = coords[1] orelse return -1;
+    const row_obj = coords[0];
+    const col_obj = coords[1];
 
     const row = c.PyLong_AsLong(row_obj);
     if (row == -1 and c.PyErr_Occurred() != null) {

--- a/bindings/python/src/image/filtering.zig
+++ b/bindings/python/src/image/filtering.zig
@@ -30,7 +30,7 @@ pub const image_box_blur_doc =
 ;
 
 pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
     var radius_long: c_long = 0;
@@ -48,7 +48,7 @@ pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
             inline else => |img| {
                 var out = @TypeOf(img).empty;
                 img.boxBlur(allocator, &out, @intCast(radius)) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
                 return @ptrCast(moveImageToPython(out) orelse return null);
@@ -56,7 +56,7 @@ pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
         }
         return null;
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -75,7 +75,7 @@ pub const image_gaussian_blur_doc =
 ;
 
 pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
     var sigma: f64 = 0;
@@ -88,7 +88,7 @@ pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c
 
     // Validate sigma: must be finite and > 0
     if (!std.math.isFinite(sigma)) {
-        c.PyErr_SetString(c.PyExc_ValueError, "sigma must be finite");
+        py_utils.setValueError("sigma must be finite", .{});
         return null;
     }
     const sigma_pos = py_utils.validatePositive(f64, sigma, "sigma") catch return null;
@@ -99,9 +99,9 @@ pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c
                 var out = @TypeOf(img).empty;
                 img.gaussianBlur(allocator, @floatCast(sigma_pos), &out) catch |err| {
                     if (err == error.InvalidSigma) {
-                        c.PyErr_SetString(c.PyExc_ValueError, "Invalid sigma value");
+                        py_utils.setValueError("Invalid sigma value", .{});
                     } else {
-                        c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                        py_utils.setMemoryError("image operation");
                     }
                     return null;
                 };
@@ -110,7 +110,7 @@ pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c
         }
         return null;
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -135,13 +135,13 @@ pub const image_invert_doc =
 
 pub fn image_invert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     _ = args;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
             inline else => |img| {
                 var out = img.dupe(allocator) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Failed to allocate image data");
+                    py_utils.setMemoryError("image data");
                     return null;
                 };
                 out.invert();
@@ -151,7 +151,7 @@ pub fn image_invert(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c
         return null;
     }
 
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -170,7 +170,7 @@ pub const image_sharpen_doc =
 ;
 
 pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
     var radius_long: c_long = 0;
@@ -187,7 +187,7 @@ pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
             inline else => |img| {
                 var out = @TypeOf(img).empty;
                 img.sharpen(allocator, &out, @intCast(radius)) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
                 return @ptrCast(moveImageToPython(out) orelse return null);
@@ -195,7 +195,7 @@ pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
         }
         return null;
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -226,7 +226,7 @@ pub const image_autocontrast_doc =
 ;
 
 pub fn image_autocontrast(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
     var cutoff: f32 = 0.0;
@@ -237,9 +237,9 @@ pub fn image_autocontrast(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.
         return null;
     }
 
-    // Validate cutoff range (now 0.0 to 0.5)
+    // Validate cutoff range (0.0 to 0.5 fraction)
     if (cutoff < 0 or cutoff >= 0.5) {
-        c.PyErr_SetString(c.PyExc_ValueError, "cutoff must be between 0 and 0.5");
+        py_utils.setValueError("cutoff must be between 0 and 0.5", .{});
         return null;
     }
 
@@ -248,7 +248,7 @@ pub fn image_autocontrast(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.
             inline else => |img| {
                 // Make a copy since autocontrast now works in-place
                 var out = img.dupe(allocator) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
                 // we already checked for the cutoff value
@@ -257,7 +257,7 @@ pub fn image_autocontrast(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.
             },
         }
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -289,12 +289,12 @@ pub const image_equalize_doc =
     \\equalized.save("equalized.jpg")
     \\
     \\# Compare with autocontrast
-    \\auto = img.autocontrast(cutoff=2.0)
+    \\auto = img.autocontrast(cutoff=0.02)
     \\```
 ;
 
 pub fn image_equalize(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Apply equalization
     if (self.py_image) |pimg| {
@@ -302,7 +302,7 @@ pub fn image_equalize(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) ?*c.
             inline else => |img| {
                 // Make a copy since equalize now works in-place
                 var out = img.dupe(allocator) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
                 out.equalize();
@@ -310,7 +310,7 @@ pub fn image_equalize(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) ?*c.
             },
         }
     }
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -353,7 +353,7 @@ pub const image_motion_blur_doc =
 ;
 
 pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
     const motion_blur = @import("../motion_blur.zig");
 
     // Parse the single argument (config object)
@@ -368,7 +368,7 @@ pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
     const type_name = type_obj.*.tp_name;
 
     if (!std.mem.eql(u8, std.mem.span(type_name), "zignal.MotionBlur")) {
-        c.PyErr_SetString(c.PyExc_TypeError, "config must be a MotionBlur object created with MotionBlur.linear(), MotionBlur.radial_zoom(), or MotionBlur.radial_spin()");
+        py_utils.setTypeError("MotionBlur object", config_obj);
         return null;
     }
 
@@ -405,7 +405,7 @@ pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
                 };
 
                 img.motionBlur(allocator, blur_config, &out) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
 
@@ -414,7 +414,7 @@ pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
         }
     }
 
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -433,14 +433,14 @@ pub const image_sobel_doc =
 
 pub fn image_sobel(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     _ = args;
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     if (self.py_image) |pimg| {
         var out = Image(u8).empty;
         switch (pimg.data) {
             inline else => |img| {
                 img.sobel(allocator, &out) catch {
-                    c.PyErr_SetString(c.PyExc_MemoryError, "Out of memory");
+                    py_utils.setMemoryError("image operation");
                     return null;
                 };
             },
@@ -448,7 +448,7 @@ pub fn image_sobel(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.
         return @ptrCast(moveImageToPython(out) orelse return null);
     }
 
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -491,7 +491,7 @@ pub const image_shen_castan_doc =
 ;
 
 pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments with defaults matching ShenCastan.zig
     var smooth: f64 = 0.9;
@@ -510,15 +510,15 @@ pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
 
     // Validate parameters
     if (smooth <= 0 or smooth >= 1) {
-        c.PyErr_SetString(c.PyExc_ValueError, "smooth must be between 0 and 1");
+        py_utils.setValueError("smooth must be between 0 and 1", .{});
         return null;
     }
     if (window_size < 3) {
-        c.PyErr_SetString(c.PyExc_ValueError, "window_size must be >= 3");
+        py_utils.setValueError("window_size must be >= 3", .{});
         return null;
     }
     if (@mod(window_size, 2) == 0) {
-        c.PyErr_SetString(c.PyExc_ValueError, "window_size must be odd");
+        py_utils.setValueError("window_size must be odd", .{});
         return null;
     }
     if (high_ratio <= 0 or high_ratio >= 1) {
@@ -564,9 +564,9 @@ pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
                     if (err == error.InvalidBParameter) {
                         c.PyErr_SetString(c.PyExc_ValueError, "smooth parameter must be between 0 and 1");
                     } else if (err == error.WindowSizeMustBeOdd) {
-                        c.PyErr_SetString(c.PyExc_ValueError, "window_size must be odd");
+                        py_utils.setValueError("window_size must be odd", .{});
                     } else if (err == error.WindowSizeTooSmall) {
-                        c.PyErr_SetString(c.PyExc_ValueError, "window_size must be >= 3");
+                        py_utils.setValueError("window_size must be >= 3", .{});
                     } else if (err == error.InvalidThreshold) {
                         c.PyErr_SetString(c.PyExc_ValueError, "Invalid threshold parameters (high_ratio or low_rel out of range)");
                     } else {
@@ -580,7 +580,7 @@ pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
         return @ptrCast(moveImageToPython(out) orelse return null);
     }
 
-    c.PyErr_SetString(c.PyExc_ValueError, "Image not initialized");
+    py_utils.setValueError("Image not initialized", .{});
     return null;
 }
 
@@ -613,7 +613,7 @@ pub const image_blend_doc =
 ;
 
 pub fn image_blend(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ImageObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments: overlay image and optional blend mode
     var overlay_obj: ?*c.PyObject = null;

--- a/bindings/python/src/py_utils.zig
+++ b/bindings/python/src/py_utils.zig
@@ -942,29 +942,31 @@ pub const TypeObjectConfig = struct {
 
 /// Build a PyTypeObject with the given configuration
 pub fn buildTypeObject(comptime config: TypeObjectConfig) c.PyTypeObject {
+    const str_fn: ?*const anyopaque = config.str orelse config.repr;
+
     return .{
         .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
         .tp_name = config.name.ptr,
         .tp_basicsize = @intCast(config.basicsize),
-        .tp_dealloc = @ptrCast(config.dealloc),
-        .tp_repr = @ptrCast(config.repr),
-        .tp_str = @ptrCast(config.str orelse config.repr),
+        .tp_dealloc = if (config.dealloc) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_repr = if (config.repr) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_str = if (str_fn) |func| @ptrCast(@alignCast(func)) else null,
         .tp_flags = config.flags,
         .tp_doc = if (config.doc) |d| d.ptr else null,
         .tp_methods = config.methods,
         .tp_getset = config.getset,
-        .tp_richcompare = @ptrCast(config.richcompare),
-        .tp_iter = @ptrCast(config.iter),
-        .tp_iternext = @ptrCast(config.iternext),
-        .tp_init = @ptrCast(config.init),
-        .tp_new = @ptrCast(config.new),
-        .tp_getattro = @ptrCast(config.getattro),
-        .tp_setattro = @ptrCast(config.setattro),
+        .tp_richcompare = if (config.richcompare) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_iter = if (config.iter) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_iternext = if (config.iternext) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_init = if (config.init) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_new = if (config.new) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_getattro = if (config.getattro) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_setattro = if (config.setattro) |func| @ptrCast(@alignCast(func)) else null,
         .tp_as_number = config.as_number,
         .tp_as_sequence = config.as_sequence,
         .tp_as_mapping = config.as_mapping,
-        .tp_hash = @ptrCast(config.hash),
-        .tp_call = @ptrCast(config.call),
+        .tp_hash = if (config.hash) |func| @ptrCast(@alignCast(func)) else null,
+        .tp_call = if (config.call) |func| @ptrCast(@alignCast(func)) else null,
     };
 }
 

--- a/bindings/python/src/transforms.zig
+++ b/bindings/python/src/transforms.zig
@@ -36,7 +36,7 @@ fn similarity_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 }
 
 fn similarity_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
-    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(SimilarityTransformObject, self_obj);
 
     var from_points_obj: ?*c.PyObject = null;
     var to_points_obj: ?*c.PyObject = null;
@@ -60,13 +60,13 @@ fn similarity_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 
     // Check we have same number of points
     if (from_points.len != to_points.len) {
-        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        py_utils.setValueError("from_points and to_points must have the same length", .{});
         return -1;
     }
 
     // Check we have at least 2 points
     if (from_points.len < 2) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 2 point correspondences for similarity transform");
+        py_utils.setValueError("Need at least 2 point correspondences for similarity transform", .{});
         return -1;
     }
 
@@ -89,7 +89,7 @@ fn similarity_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 }
 
 fn similarity_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(SimilarityTransformObject, self_obj);
 
     var point_obj: ?*c.PyObject = null;
     const kw = comptime py_utils.kw(&.{"points"});
@@ -128,13 +128,13 @@ fn similarity_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 
         return result_list;
     } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        py_utils.setTypeError("(x, y) tuple or list of tuples", point_obj);
         return null;
     }
 }
 
 fn similarity_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*SimilarityTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(SimilarityTransformObject, self_obj);
 
     var buffer: [512]u8 = undefined;
     const str = std.fmt.bufPrintZ(&buffer, "SimilarityTransform(matrix=[[{d:.6}, {d:.6}], [{d:.6}, {d:.6}]], bias=({d:.6}, {d:.6}))", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[1][0], self.matrix[1][1], self.bias[0], self.bias[1] }) catch return null;
@@ -198,7 +198,7 @@ fn affine_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 }
 
 fn affine_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
-    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(AffineTransformObject, self_obj);
 
     var from_points_obj: ?*c.PyObject = null;
     var to_points_obj: ?*c.PyObject = null;
@@ -222,19 +222,19 @@ fn affine_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
 
     // Check we have same number of points
     if (from_points.len != to_points.len) {
-        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        py_utils.setValueError("from_points and to_points must have the same length", .{});
         return -1;
     }
 
     // Check we have at least 3 points
     if (from_points.len < 3) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 3 point correspondences for affine transform");
+        py_utils.setValueError("Need at least 3 point correspondences for affine transform", .{});
         return -1;
     }
 
     // Create and fit the transform
     const transform = AffineTransform(f64).init(allocator, from_points, to_points) catch {
-        c.PyErr_SetString(c.PyExc_MemoryError, "Failed to compute affine transform");
+        py_utils.setMemoryError("affine transform");
         return -1;
     };
 
@@ -254,7 +254,7 @@ fn affine_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 }
 
 fn affine_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(AffineTransformObject, self_obj);
 
     var point_obj: ?*c.PyObject = null;
     const kw = comptime py_utils.kw(&.{"points"});
@@ -293,13 +293,13 @@ fn affine_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 
         return result_list;
     } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        py_utils.setTypeError("(x, y) tuple or list of tuples", point_obj);
         return null;
     }
 }
 
 fn affine_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*AffineTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(AffineTransformObject, self_obj);
 
     var buffer: [512]u8 = undefined;
     const str = std.fmt.bufPrintZ(&buffer, "AffineTransform(matrix=[[{d:.6}, {d:.6}], [{d:.6}, {d:.6}]], bias=({d:.6}, {d:.6}))", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[1][0], self.matrix[1][1], self.bias[0], self.bias[1] }) catch return null;
@@ -364,7 +364,7 @@ fn projective_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 }
 
 fn projective_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
-    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
     var from_points_obj: ?*c.PyObject = null;
     var to_points_obj: ?*c.PyObject = null;
@@ -388,13 +388,13 @@ fn projective_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
 
     // Check we have same number of points
     if (from_points.len != to_points.len) {
-        c.PyErr_SetString(c.PyExc_ValueError, "from_points and to_points must have the same length");
+        py_utils.setValueError("from_points and to_points must have the same length", .{});
         return -1;
     }
 
     // Check we have at least 4 points
     if (from_points.len < 4) {
-        c.PyErr_SetString(c.PyExc_ValueError, "Need at least 4 point correspondences for projective transform");
+        py_utils.setValueError("Need at least 4 point correspondences for projective transform", .{});
         return -1;
     }
 
@@ -416,7 +416,7 @@ fn projective_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 }
 
 fn projective_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
     var point_obj: ?*c.PyObject = null;
     const kw = comptime py_utils.kw(&.{"points"});
@@ -469,14 +469,14 @@ fn projective_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 
         return result_list;
     } else {
-        c.PyErr_SetString(c.PyExc_TypeError, "Expected (x, y) tuple or list of (x, y) tuples");
+        py_utils.setTypeError("(x, y) tuple or list of tuples", point_obj);
         return null;
     }
 }
 
 fn projective_inverse(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     _ = args;
-    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
     // Reconstruct the matrix from components
     const matrix = zignal.SMatrix(f64, 3, 3).init(.{
@@ -495,7 +495,7 @@ fn projective_inverse(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?
 
     // Create new ProjectiveTransform object
     const py_obj = c.PyType_GenericAlloc(@ptrCast(&ProjectiveTransformType), 0) orelse return null;
-    const result = @as(*ProjectiveTransformObject, @ptrCast(py_obj));
+    const result = py_utils.safeCast(ProjectiveTransformObject, py_obj);
 
     // Copy inverse matrix components
     for (0..3) |i| {
@@ -508,7 +508,7 @@ fn projective_inverse(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?
 }
 
 fn projective_repr(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    const self = @as(*ProjectiveTransformObject, @ptrCast(self_obj.?));
+    const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
     var buffer: [1024]u8 = undefined;
     const str = std.fmt.bufPrintZ(&buffer, "ProjectiveTransform(matrix=[[{d:.6}, {d:.6}, {d:.6}], [{d:.6}, {d:.6}, {d:.6}], [{d:.6}, {d:.6}, {d:.6}]])", .{ self.matrix[0][0], self.matrix[0][1], self.matrix[0][2], self.matrix[1][0], self.matrix[1][1], self.matrix[1][2], self.matrix[2][0], self.matrix[2][1], self.matrix[2][2] }) catch return null;

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -314,7 +314,7 @@ class TestImageSmoke:
 
         # RGB
         rgb = zignal.Image(5, 5, (100, 150, 200), dtype=zignal.Rgb)
-        enhanced_rgb = rgb.autocontrast(cutoff=2.0)
+        enhanced_rgb = rgb.autocontrast(cutoff=0.02)
         assert enhanced_rgb.rows == 5 and enhanced_rgb.cols == 5
 
         # RGBA


### PR DESCRIPTION
Uses generic helpers (`genericNew`, `genericDealloc`, `buildTypeObject`) and specialized error functions (`setTypeError`, `setMemoryError`) to reduce boilerplate across all Python binding modules.