### PR TITLE
feat(canvas): add draw image method

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1048,7 +1048,7 @@ pub const image_methods_metadata = blk: {
             .meth = @ptrCast(&transforms.image_crop),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,
             .doc = transforms.image_crop_doc,
-            .params = "self, rect: Rectangle",
+            .params = "self, rect: Rectangle | tuple[float, float, float, float]",
             .returns = "Image",
         },
         .{
@@ -1056,7 +1056,7 @@ pub const image_methods_metadata = blk: {
             .meth = @ptrCast(&transforms.image_extract),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,
             .doc = transforms.image_extract_doc,
-            .params = "self, rect: Rectangle, angle: float = 0.0, size: int | tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
+            .params = "self, rect: Rectangle | tuple[float, float, float, float], angle: float = 0.0, size: int | tuple[int, int] | None = None, method: Interpolation = Interpolation.BILINEAR",
             .returns = "Image",
         },
         .{
@@ -1064,7 +1064,7 @@ pub const image_methods_metadata = blk: {
             .meth = @ptrCast(&transforms.image_insert),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,
             .doc = transforms.image_insert_doc,
-            .params = "self, source: Image, rect: Rectangle, angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR",
+            .params = "self, source: Image, rect: Rectangle | tuple[float, float, float, float], angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR",
             .returns = "None",
         },
     };

--- a/bindings/python/tests/test_canvas.py
+++ b/bindings/python/tests/test_canvas.py
@@ -23,3 +23,26 @@ class TestCanvas:
         # Color objects
         canvas.fill(zignal.Rgb(4, 5, 6))
         canvas.draw_line((0, 0), (5, 5), zignal.Rgba(7, 8, 9, 255))
+
+    def test_draw_image(self):
+        dest = zignal.Image(6, 6, (0, 0, 0, 255), dtype=zignal.Rgba)
+        canvas = dest.canvas()
+
+        sprite = zignal.Image(2, 2, (255, 0, 0, 128), dtype=zignal.Rgba)
+        sprite[0, 1] = zignal.Rgba(0, 255, 0, 255)
+        sprite[1, 0] = zignal.Rgba(0, 0, 255, 255)
+
+        before = dest.copy()
+        canvas.draw_image(sprite, (2.0, 2.0))
+        assert dest != before
+
+        blended = dest[2, 2].item()
+        assert blended.r > 0
+        assert blended.g == 0
+
+        # Use a source rect to copy only left column of sprite to top-left corner
+        src_rect = zignal.Rectangle(0, 0, 1, sprite.rows)
+        canvas.draw_image(sprite, (0.0, 0.0), src_rect)
+        top_left = dest[0, 0].item()
+        assert top_left.r == 128
+        assert top_left.g == 0


### PR DESCRIPTION
Implements `canvas.drawImage` in Zig and exposes it via Python bindings. This allows compositing images with support for clipping, optional source rectangles, and alpha blending.