### PR TITLE
feat(image): enable blending mode for image insertion

### DIFF
--- a/bindings/python/src/blending.zig
+++ b/bindings/python/src/blending.zig
@@ -14,6 +14,7 @@ pub const blending_doc =
     \\
     \\| Mode        | Description                                            | Best Use Case     |
     \\|-------------|--------------------------------------------------------|-------------------|
+    \\| NONE        | No blending; overlay replaces base pixel               | Direct copy       |
     \\| NORMAL      | Standard alpha blending with transparency              | Layering images   |
     \\| MULTIPLY    | Darkens by multiplying colors (white has no effect)    | Shadows, darkening|
     \\| SCREEN      | Lightens by inverting, multiplying, then inverting     | Highlights, glow  |
@@ -39,13 +40,15 @@ pub const blending_doc =
     \\```
     \\
     \\## Notes
-    \\- All blend modes respect alpha channel for proper compositing
+    \\- `NONE` performs a direct copy and is the default for APIs that accept blending
+    \\- All other blend modes respect alpha channel for proper compositing
     \\- Result color type matches the base color type
     \\- Overlay must be RGBA or convertible to RGBA
 ;
 
 // Per-value documentation for stub generation
 pub const blending_values = [_]stub_metadata.EnumValueDoc{
+    .{ .name = "NONE", .doc = "No blending; overlay replaces base pixel" },
     .{ .name = "NORMAL", .doc = "Standard alpha blending with transparency" },
     .{ .name = "MULTIPLY", .doc = "Darkens by multiplying colors" },
     .{ .name = "SCREEN", .doc = "Lightens by inverting, multiplying, inverting" },

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1064,7 +1064,7 @@ pub const image_methods_metadata = blk: {
             .meth = @ptrCast(&transforms.image_insert),
             .flags = c.METH_VARARGS | c.METH_KEYWORDS,
             .doc = transforms.image_insert_doc,
-            .params = "self, source: Image, rect: Rectangle | tuple[float, float, float, float], angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR",
+            .params = "self, source: Image, rect: Rectangle | tuple[float, float, float, float], angle: float = 0.0, method: Interpolation = Interpolation.BILINEAR, blend_mode: Blending = Blending.NONE",
             .returns = "None",
         },
     };

--- a/src/canvas/tests/drawing.zig
+++ b/src/canvas/tests/drawing.zig
@@ -244,7 +244,7 @@ test "drawImage copies opaque pixels" {
     src.at(1, 1).* = Rgba{ .r = 255, .g = 255, .b = 0, .a = 255 };
 
     const canvas = Canvas(Rgba).init(allocator, dest);
-    canvas.drawImage(src, .point(.{ 1, 1 }), null);
+    canvas.drawImage(src, .point(.{ 1, 1 }), null, .normal);
 
     try expectEqual(Rgba{ .r = 255, .g = 0, .b = 0, .a = 255 }, dest.at(1, 1).*);
     try expectEqual(Rgba{ .r = 0, .g = 255, .b = 0, .a = 255 }, dest.at(1, 2).*);
@@ -273,7 +273,7 @@ test "drawImage blends alpha" {
     src.at(0, 0).* = overlay;
 
     const canvas = Canvas(Rgba).init(allocator, dest);
-    canvas.drawImage(src, .point(.{ 0, 0 }), null);
+    canvas.drawImage(src, .point(.{ 0, 0 }), null, .normal);
 
     const expected = base.blend(overlay, .normal);
     try expectEqual(expected, dest.at(0, 0).*);
@@ -299,7 +299,7 @@ test "drawImage supports source rect and clipping" {
 
     const canvas = Canvas(Rgba).init(allocator, dest);
     const src_rect = Rectangle(usize).init(1, 0, 3, 2);
-    canvas.drawImage(src, .point(.{ 0, 0 }), src_rect);
+    canvas.drawImage(src, .point(.{ 0, 0 }), src_rect, .normal);
 
     try expectEqual(Rgba{ .r = 40, .g = 50, .b = 60, .a = 255 }, dest.at(0, 0).*);
     try expectEqual(Rgba{ .r = 70, .g = 80, .b = 90, .a = 255 }, dest.at(0, 1).*);
@@ -307,7 +307,7 @@ test "drawImage supports source rect and clipping" {
     try expectEqual(Rgba{ .r = 170, .g = 180, .b = 190, .a = 255 }, dest.at(1, 1).*);
 
     // Draw partially off-canvas to ensure clipping works
-    canvas.drawImage(src, .point(.{ -1, 0 }), null);
+    canvas.drawImage(src, .point(.{ -1, 0 }), null, .normal);
     try expectEqual(Rgba{ .r = 40, .g = 50, .b = 60, .a = 255 }, dest.at(0, 0).*);
 }
 

--- a/src/color/blending.zig
+++ b/src/color/blending.zig
@@ -11,6 +11,8 @@ const Rgba = @import("Rgba.zig").Rgba;
 
 /// Available blending modes for color composition
 pub const Blending = enum {
+    /// Performs no blending. The overlay fully replaces the base color.
+    none,
     /// Standard alpha blending. The overlay color is painted on top of the base with transparency.
     normal,
 
@@ -110,6 +112,7 @@ pub fn blendColors(base: Rgba, overlay: Rgba, mode: Blending) Rgba {
 
     // Blend based on mode - each function handles alpha compositing internally
     return switch (mode) {
+        .none => overlay,
         .normal => blendNormal(base, overlay),
         .multiply => blendMultiply(base, overlay),
         .screen => blendScreen(base, overlay),


### PR DESCRIPTION
Introduces `Blending.none` and refactors core pixel assignment logic using `Image.assignPixel`.

This change updates `Image.insert` and its Python binding to accept an optional `blend_mode` parameter. It also simplifies blending logic in `Canvas.setPixel` and `Canvas.drawImage`.