### PR TITLE
refactor(python): standardize argument parsing

### DIFF
--- a/bindings/python/src/bitmap_font.zig
+++ b/bindings/python/src/bitmap_font.zig
@@ -69,12 +69,13 @@ const bitmap_font_load_doc =
 ;
 
 fn bitmap_font_load(type_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    var file_path: [*c]const u8 = undefined;
+    const Params = struct {
+        path: [*c]const u8,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{"path"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "s", @ptrCast(@constCast(&kw)), &file_path) == 0) {
-        return null;
-    }
+    const file_path = params.path;
 
     // Convert C string to Zig slice
     const path_slice = std.mem.span(file_path);

--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -328,12 +328,13 @@ fn canvas_fill(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
     const self = py_utils.safeCast(CanvasObject, self_obj);
 
     // Parse color argument
-    var color_obj: ?*c.PyObject = undefined;
-    const kw = comptime py_utils.kw(&.{"color"});
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &color_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        color: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const color_obj = params.color;
 
     // Parse color and fill
     const rgba = color_utils.parseColor(Rgba, @ptrCast(color_obj)) catch return null;

--- a/bindings/python/src/fdm.zig
+++ b/bindings/python/src/fdm.zig
@@ -72,12 +72,13 @@ fn fdm_set_target(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 
     const fdm_ptr = py_utils.validateNonNull(*FeatureDistributionMatching(Rgb), self.fdm_ptr, "FeatureDistributionMatching") catch return null;
 
-    var target_obj: ?*c.PyObject = undefined;
-    const kw = comptime py_utils.kw(&.{"image"});
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &target_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        image: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const target_obj = params.image;
 
     // Check if argument is an Image object and cast
     if (target_obj == null) {
@@ -138,12 +139,13 @@ fn fdm_set_source(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 
     const fdm_ptr = py_utils.validateNonNull(*FeatureDistributionMatching(Rgb), self.fdm_ptr, "FeatureDistributionMatching") catch return null;
 
-    var source_obj: ?*c.PyObject = undefined;
-    const kw = comptime py_utils.kw(&.{"image"});
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &source_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        image: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const source_obj = params.image;
 
     // Check if argument is an Image object and cast
     if (source_obj == null) {

--- a/bindings/python/src/image/binary.zig
+++ b/bindings/python/src/image/binary.zig
@@ -136,13 +136,15 @@ pub fn image_threshold_adaptive_mean(self_obj: ?*c.PyObject, args: ?*c.PyObject,
         return null;
     }
 
-    var radius_long: c_long = 6;
-    var c_value: f64 = 5.0;
-    const kw = comptime py_utils.kw(&.{ "radius", "c" });
-    const format = std.fmt.comptimePrint("|ld", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &c_value) == 0) {
-        return null;
-    }
+    const Params = struct {
+        radius: c_long = 6,
+        c: f64 = 5.0,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const radius_long = params.radius;
+    const c_value = params.c;
 
     if (!std.math.isFinite(c_value)) {
         py_utils.setValueError("c must be finite", .{});
@@ -219,14 +221,14 @@ pub const image_dilate_binary_doc =
 
 pub fn image_dilate_binary(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
-    var kernel_size_long: c_long = 3;
-    var iterations_long: c_long = 1;
-    const kw = comptime py_utils.kw(&.{ "kernel_size", "iterations" });
-    const format = std.fmt.comptimePrint("|ll", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &kernel_size_long, &iterations_long) == 0) {
-        return null;
-    }
-    return morphologyCommon(self, kernel_size_long, iterations_long, .dilate);
+    const Params = struct {
+        kernel_size: c_long = 3,
+        iterations: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    return morphologyCommon(self, params.kernel_size, params.iterations, .dilate);
 }
 
 pub const image_erode_binary_doc =
@@ -237,14 +239,14 @@ pub const image_erode_binary_doc =
 
 pub fn image_erode_binary(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
-    var kernel_size_long: c_long = 3;
-    var iterations_long: c_long = 1;
-    const kw = comptime py_utils.kw(&.{ "kernel_size", "iterations" });
-    const format = std.fmt.comptimePrint("|ll", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &kernel_size_long, &iterations_long) == 0) {
-        return null;
-    }
-    return morphologyCommon(self, kernel_size_long, iterations_long, .erode);
+    const Params = struct {
+        kernel_size: c_long = 3,
+        iterations: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    return morphologyCommon(self, params.kernel_size, params.iterations, .erode);
 }
 
 pub const image_open_binary_doc =
@@ -255,14 +257,14 @@ pub const image_open_binary_doc =
 
 pub fn image_open_binary(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
-    var kernel_size_long: c_long = 3;
-    var iterations_long: c_long = 1;
-    const kw = comptime py_utils.kw(&.{ "kernel_size", "iterations" });
-    const format = std.fmt.comptimePrint("|ll", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &kernel_size_long, &iterations_long) == 0) {
-        return null;
-    }
-    return morphologyCommon(self, kernel_size_long, iterations_long, .open);
+    const Params = struct {
+        kernel_size: c_long = 3,
+        iterations: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    return morphologyCommon(self, params.kernel_size, params.iterations, .open);
 }
 
 pub const image_close_binary_doc =
@@ -273,12 +275,12 @@ pub const image_close_binary_doc =
 
 pub fn image_close_binary(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
-    var kernel_size_long: c_long = 3;
-    var iterations_long: c_long = 1;
-    const kw = comptime py_utils.kw(&.{ "kernel_size", "iterations" });
-    const format = std.fmt.comptimePrint("|ll", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &kernel_size_long, &iterations_long) == 0) {
-        return null;
-    }
-    return morphologyCommon(self, kernel_size_long, iterations_long, .close);
+    const Params = struct {
+        kernel_size: c_long = 3,
+        iterations: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    return morphologyCommon(self, params.kernel_size, params.iterations, .close);
 }

--- a/bindings/python/src/image/filtering.zig
+++ b/bindings/python/src/image/filtering.zig
@@ -33,16 +33,11 @@ pub const image_box_blur_doc =
 pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments
-    var radius_long: c_long = 0;
-    const kw = comptime py_utils.kw(&.{"radius"});
-    const format = std.fmt.comptimePrint("l", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long) == 0) {
-        return null;
-    }
+    const Params = struct { radius: c_long };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -80,15 +75,11 @@ pub const image_median_blur_doc =
 pub fn image_median_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    const kw = comptime py_utils.kw(&.{"radius"});
-    const format = std.fmt.comptimePrint("l", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long) == 0) {
-        return null;
-    }
+    const Params = struct { radius: c_long };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -125,18 +116,16 @@ pub const image_min_blur_doc =
 pub fn image_min_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    var border_obj: ?*c.PyObject = null;
+    const Params = struct {
+        radius: c_long,
+        border: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "radius", "border" });
-    const format = std.fmt.comptimePrint("l|O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &border_obj) == 0) {
-        return null;
-    }
-
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
     var border = zignal.BorderMode.mirror;
-    if (border_obj) |obj| {
+    if (params.border) |obj| {
         if (obj == c.Py_None()) {
             py_utils.setValueError("border must be a BorderMode enum", .{});
             return null;
@@ -185,18 +174,16 @@ pub const image_max_blur_doc =
 pub fn image_max_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    var border_obj: ?*c.PyObject = null;
+    const Params = struct {
+        radius: c_long,
+        border: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "radius", "border" });
-    const format = std.fmt.comptimePrint("l|O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &border_obj) == 0) {
-        return null;
-    }
-
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
     var border = zignal.BorderMode.mirror;
-    if (border_obj) |obj| {
+    if (params.border) |obj| {
         if (obj == c.Py_None()) {
             py_utils.setValueError("border must be a BorderMode enum", .{});
             return null;
@@ -245,18 +232,16 @@ pub const image_midpoint_blur_doc =
 pub fn image_midpoint_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    var border_obj: ?*c.PyObject = null;
+    const Params = struct {
+        radius: c_long,
+        border: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "radius", "border" });
-    const format = std.fmt.comptimePrint("l|O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &border_obj) == 0) {
-        return null;
-    }
-
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
     var border = zignal.BorderMode.mirror;
-    if (border_obj) |obj| {
+    if (params.border) |obj| {
         if (obj == c.Py_None()) {
             py_utils.setValueError("border must be a BorderMode enum", .{});
             return null;
@@ -313,21 +298,18 @@ pub const image_percentile_blur_doc =
 pub fn image_percentile_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    var percentile: f64 = 0.5;
-    var border_obj: ?*c.PyObject = null;
+    const Params = struct {
+        radius: c_long,
+        percentile: f64,
+        border: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "radius", "percentile", "border" });
-    const format = std.fmt.comptimePrint("ld|O", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &percentile, &border_obj) == 0) {
-        return null;
-    }
-
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
-    const percentile_value = py_utils.validateRange(f64, percentile, 0.0, 1.0, "percentile") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
+    const percentile_value = py_utils.validateRange(f64, params.percentile, 0.0, 1.0, "percentile") catch return null;
     var border_mode = zignal.BorderMode.mirror;
-    if (border_obj) |obj| {
+    if (params.border) |obj| {
         if (obj == c.Py_None()) {
             py_utils.setValueError("border must be a BorderMode enum", .{});
             return null;
@@ -372,30 +354,30 @@ pub const image_alpha_trimmed_mean_blur_doc =
 pub fn image_alpha_trimmed_mean_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    var radius_long: c_long = 0;
-    var trim_fraction: f64 = 0;
-    var border_obj: ?*c.PyObject = null;
+    const Params = struct {
+        radius: c_long,
+        trim_fraction: f64,
+        border: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "radius", "trim_fraction", "border" });
-    const format = std.fmt.comptimePrint("ld|O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long, &trim_fraction, &border_obj) == 0) {
-        return null;
-    }
-
-    if (!std.math.isFinite(trim_fraction)) {
+    if (!std.math.isFinite(params.trim_fraction)) {
         py_utils.setValueError("trim_fraction must be finite", .{});
         return null;
     }
 
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
     var border = zignal.BorderMode.mirror;
-    if (border_obj) |obj| {
+    if (params.border) |obj| {
         if (obj == c.Py_None()) {
             py_utils.setValueError("border must be a BorderMode enum", .{});
             return null;
         }
         border = enum_utils.pyToEnum(zignal.BorderMode, obj) catch return null;
     }
+
+    const trim_fraction = params.trim_fraction;
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -444,21 +426,16 @@ pub const image_gaussian_blur_doc =
 pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments
-    var sigma: f64 = 0;
-    const kw = comptime py_utils.kw(&.{"sigma"});
-    const format = std.fmt.comptimePrint("d", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &sigma) == 0) {
-        return null;
-    }
+    const Params = struct { sigma: f64 };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
     // Validate sigma: must be finite and > 0
-    if (!std.math.isFinite(sigma)) {
+    if (!std.math.isFinite(params.sigma)) {
         py_utils.setValueError("sigma must be finite", .{});
         return null;
     }
-    const sigma_pos = py_utils.validatePositive(f64, sigma, "sigma") catch return null;
+    const sigma_pos = py_utils.validatePositive(f64, params.sigma, "sigma") catch return null;
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -539,15 +516,11 @@ pub const image_sharpen_doc =
 pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments
-    var radius_long: c_long = 0;
-    const kw = comptime py_utils.kw(&.{"radius"});
-    const format = std.fmt.comptimePrint("l", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &radius_long) == 0) {
-        return null;
-    }
-    const radius = py_utils.validateNonNegative(u32, radius_long, "radius") catch return null;
+    const Params = struct { radius: c_long };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const radius = py_utils.validateNonNegative(u32, params.radius, "radius") catch return null;
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -595,20 +568,17 @@ pub const image_autocontrast_doc =
 pub fn image_autocontrast(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments
-    var cutoff: f32 = 0.0;
-    const kw = comptime py_utils.kw(&.{"cutoff"});
-    const format = std.fmt.comptimePrint("|f", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &cutoff) == 0) {
-        return null;
-    }
+    const Params = struct { cutoff: f64 = 0.0 };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
     // Validate cutoff range (0.0 to 0.5 fraction)
-    if (cutoff < 0 or cutoff >= 0.5) {
+    if (params.cutoff < 0 or params.cutoff >= 0.5) {
         py_utils.setValueError("cutoff must be between 0 and 0.5", .{});
         return null;
     }
+
+    const cutoff: f32 = @floatCast(params.cutoff);
 
     if (self.py_image) |pimg| {
         switch (pimg.data) {
@@ -723,12 +693,11 @@ pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
     const self = py_utils.safeCast(ImageObject, self_obj);
     const motion_blur = @import("../motion_blur.zig");
 
-    // Parse the single argument (config object)
-    var config_obj: ?*c.PyObject = undefined;
-    const kw = comptime py_utils.kw(&.{"config"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O", @ptrCast(@constCast(&kw)), &config_obj) == 0) {
-        return null;
-    }
+    const Params = struct { config: ?*c.PyObject };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const config_obj = params.config;
 
     // Check that it's a MotionBlur object
     const type_obj = c.Py_TYPE(config_obj);
@@ -860,42 +829,45 @@ pub const image_shen_castan_doc =
 pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments with defaults matching ShenCastan.zig
-    var smooth: f64 = 0.9;
-    var window_size: c_long = 7;
-    var high_ratio: f64 = 0.99;
-    var low_rel: f64 = 0.5;
-    var hysteresis: c_int = 1; // True by default
-    var use_nms: c_int = 0; // False by default
-
-    const kw = comptime py_utils.kw(&.{ "smooth", "window_size", "high_ratio", "low_rel", "hysteresis", "use_nms" });
-    const format = std.fmt.comptimePrint("|dlddpp", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &smooth, &window_size, &high_ratio, &low_rel, &hysteresis, &use_nms) == 0) {
-        return null;
-    }
+    const Params = struct {
+        smooth: f64 = 0.9,
+        window_size: c_long = 7,
+        high_ratio: f64 = 0.99,
+        low_rel: f64 = 0.5,
+        hysteresis: c_int = 1, // True by default
+        use_nms: c_int = 0, // False by default
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
     // Validate parameters
-    if (smooth <= 0 or smooth >= 1) {
+    if (params.smooth <= 0 or params.smooth >= 1) {
         py_utils.setValueError("smooth must be between 0 and 1", .{});
         return null;
     }
-    if (window_size < 3) {
+    if (params.window_size < 3) {
         py_utils.setValueError("window_size must be >= 3", .{});
         return null;
     }
-    if (@mod(window_size, 2) == 0) {
+    if (@mod(params.window_size, 2) == 0) {
         py_utils.setValueError("window_size must be odd", .{});
         return null;
     }
-    if (high_ratio <= 0 or high_ratio >= 1) {
+    if (params.high_ratio <= 0 or params.high_ratio >= 1) {
         c.PyErr_SetString(c.PyExc_ValueError, "high_ratio must be between 0 and 1");
         return null;
     }
-    if (low_rel <= 0 or low_rel >= 1) {
+    if (params.low_rel <= 0 or params.low_rel >= 1) {
         c.PyErr_SetString(c.PyExc_ValueError, "low_rel must be between 0 and 1");
         return null;
     }
+
+    const smooth = params.smooth;
+    const window_size = params.window_size;
+    const high_ratio = params.high_ratio;
+    const low_rel = params.low_rel;
+    const hysteresis = params.hysteresis;
+    const use_nms = params.use_nms;
 
     if (self.py_image) |pimg| {
         // Additional validation: window_size should not exceed image dimensions
@@ -982,16 +954,15 @@ pub const image_blend_doc =
 pub fn image_blend(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ImageObject, self_obj);
 
-    // Parse arguments: overlay image and optional blend mode
-    var overlay_obj: ?*c.PyObject = null;
-    var mode_obj: ?*c.PyObject = null;
+    const Params = struct {
+        overlay: ?*c.PyObject,
+        mode: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "overlay", "mode" });
-    const fmt = std.fmt.comptimePrint("O|O", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, fmt.ptr, @ptrCast(@constCast(&kw)), &overlay_obj, &mode_obj) == 0) {
-        return null;
-    }
+    const overlay_obj = params.overlay;
+    const mode_obj = params.mode;
 
     // Check if overlay is an Image instance
     if (c.PyObject_IsInstance(overlay_obj, @ptrCast(getImageType())) <= 0) {

--- a/bindings/python/src/image/numpy_interop.zig
+++ b/bindings/python/src/image/numpy_interop.zig
@@ -337,13 +337,13 @@ pub const image_from_numpy_doc =
 ;
 
 pub fn image_from_numpy(_: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
-    var array_obj: ?*c.PyObject = undefined;
+    const Params = struct {
+        array: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{"array"});
-    const format = std.fmt.comptimePrint("O", .{});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &array_obj) == 0) {
-        return null;
-    }
+    const array_obj = params.array;
 
     if (array_obj == null or array_obj == c.Py_None()) {
         py_utils.setTypeError("non-None array", array_obj);

--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -119,15 +119,15 @@ pub fn image_resize(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var shape_or_scale: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
+    const Params = struct {
+        size: ?*c.PyObject,
+        method: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "size", "method" });
-    const format = std.fmt.comptimePrint("O|l", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &shape_or_scale, &method_value) == 0) {
-        return null;
-    }
+    const shape_or_scale = params.size;
+    const method_value = params.method;
 
     if (shape_or_scale == null) {
         py_utils.setTypeError("size argument", null);
@@ -201,15 +201,15 @@ pub fn image_letterbox(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyO
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var size: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
-    const kw = comptime py_utils.kw(&.{ "size", "method" });
-    const format = std.fmt.comptimePrint("O|l", .{});
+    const Params = struct {
+        size: ?*c.PyObject,
+        method: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &size, &method_value) == 0) {
-        return null;
-    }
+    const size = params.size;
+    const method_value = params.method;
 
     if (size == null) {
         py_utils.setTypeError("size argument", null);
@@ -294,15 +294,15 @@ pub fn image_rotate(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var angle: f64 = 0;
-    var method_value: c_long = 1; // Default to BILINEAR
-    const kw = comptime py_utils.kw(&.{ "angle", "method" });
-    const format = std.fmt.comptimePrint("d|l", .{});
+    const Params = struct {
+        angle: f64,
+        method: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &angle, &method_value) == 0) {
-        return null;
-    }
+    const angle = params.angle;
+    const method_value = params.method;
 
     const tag_rotate = enum_utils.longToUnionTag(Interpolation, method_value) catch {
         py_utils.setValueError("Invalid interpolation method", .{});
@@ -355,17 +355,17 @@ pub fn image_warp(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var transform_obj: ?*c.PyObject = null;
-    var shape_obj: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
+    const Params = struct {
+        transform: ?*c.PyObject,
+        shape: ?*c.PyObject = null,
+        method: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "transform", "shape", "method" });
-    const format = std.fmt.comptimePrint("O|Ol", .{});
-
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &transform_obj, &shape_obj, &method_value) == 0) {
-        return null;
-    }
+    const transform_obj = params.transform;
+    const shape_obj = params.shape;
+    const method_value = params.method;
 
     // Check if image is initialized
     if (self.py_image == null) {
@@ -619,17 +619,19 @@ pub fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var rect_obj: ?*c.PyObject = undefined;
-    var angle: f64 = 0.0;
-    var size_obj: ?*c.PyObject = null;
-    var method_value: c_long = 1; // Default to BILINEAR
+    const Params = struct {
+        rect: ?*c.PyObject,
+        angle: f64 = 0.0,
+        size: ?*c.PyObject = null,
+        method: c_long = 1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "rect", "angle", "size", "method" });
-    const format = std.fmt.comptimePrint("O|dOl", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &rect_obj, &angle, &size_obj, &method_value) == 0) {
-        return null;
-    }
+    const rect_obj = params.rect;
+    const angle = params.angle;
+    const size_obj = params.size;
+    const method_value = params.method;
 
     // Parse the Rectangle object
     const rect = py_utils.parseRectangle(f32, rect_obj) catch return null;
@@ -731,18 +733,21 @@ pub fn image_insert(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObje
     const self = py_utils.safeCast(ImageObject, self_obj);
 
     // Parse arguments
-    var source_obj: ?*c.PyObject = undefined;
-    var rect_obj: ?*c.PyObject = undefined;
-    var angle: f64 = 0.0;
-    var method_value: c_long = 1; // Default to BILINEAR
-    var blend_obj: ?*c.PyObject = null;
+    const Params = struct {
+        source: ?*c.PyObject,
+        rect: ?*c.PyObject,
+        angle: f64 = 0.0,
+        method: c_long = 1,
+        blend_mode: ?*c.PyObject = null,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "source", "rect", "angle", "method", "blend_mode" });
-    const format = std.fmt.comptimePrint("OO|dlO", .{});
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, format.ptr, @ptrCast(@constCast(&kw)), &source_obj, &rect_obj, &angle, &method_value, &blend_obj) == 0) {
-        return null;
-    }
+    const source_obj = params.source;
+    const rect_obj = params.rect;
+    const angle = params.angle;
+    const method_value = params.method;
+    const blend_obj = params.blend_mode;
 
     // Check if source is an Image object
     if (c.PyObject_IsInstance(source_obj, @ptrCast(getImageType())) <= 0) {

--- a/bindings/python/src/pca.zig
+++ b/bindings/python/src/pca.zig
@@ -133,14 +133,15 @@ fn pca_fit(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callc
     }
 
     // Parse arguments
-    var matrix_obj: ?*c.PyObject = null;
-    var num_components: c.Py_ssize_t = -1; // -1 means not provided
+    const Params = struct {
+        data: ?*c.PyObject,
+        num_components: c.Py_ssize_t = -1,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-    const kw = comptime py_utils.kw(&.{ "data", "num_components" });
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O|n:fit", @ptrCast(@constCast(&kw)), &matrix_obj, &num_components) == 0) {
-        return null;
-    }
+    const matrix_obj = params.data;
+    const num_components = params.num_components;
 
     // Check if matrix_obj is a Matrix
     if (c.Py_TYPE(matrix_obj) != @as(*c.PyTypeObject, @ptrCast(&matrix.MatrixType))) {
@@ -210,11 +211,13 @@ fn pca_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) c
     }
 
     // Parse single argument: list of floats
-    var list_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"vector"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O:project", @ptrCast(@constCast(&kw)), &list_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        vector: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const list_obj = params.vector;
 
     // Check if it's a list
     if (c.PyList_Check(list_obj) != 1) {
@@ -309,11 +312,13 @@ fn pca_transform(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject)
     }
 
     // Parse single argument: Matrix
-    var matrix_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"data"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O:transform", @ptrCast(@constCast(&kw)), &matrix_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        data: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const matrix_obj = params.data;
 
     // Check if matrix_obj is a Matrix
     if (c.Py_TYPE(matrix_obj) != @as(*c.PyTypeObject, @ptrCast(&matrix.MatrixType))) {
@@ -402,11 +407,13 @@ fn pca_reconstruct(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
     }
 
     // Parse single argument: list of floats
-    var list_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"coefficients"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O:reconstruct", @ptrCast(@constCast(&kw)), &list_obj) == 0) {
-        return null;
-    }
+    const Params = struct {
+        coefficients: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const list_obj = params.coefficients;
 
     // Check if it's a list
     if (c.PyList_Check(list_obj) != 1) {

--- a/bindings/python/src/pixel_proxy.zig
+++ b/bindings/python/src/pixel_proxy.zig
@@ -242,14 +242,15 @@ fn PixelProxyBinding(comptime ColorType: type, comptime ProxyObjectType: type) t
 
         // blend method implementation
         fn blendMethod(self_obj: ?*c.PyObject, args: [*c]c.PyObject, kwds: [*c]c.PyObject) callconv(.c) ?*c.PyObject {
-            var overlay_obj: ?*c.PyObject = null;
-            var mode_obj: ?*c.PyObject = null;
+            const Params = struct {
+                overlay: ?*c.PyObject,
+                mode: ?*c.PyObject = null,
+            };
+            var params: Params = undefined;
+            py_utils.parseArgs(Params, args, kwds, &params) catch return null;
 
-            const kw = comptime @import("py_utils.zig").kw(&.{ "overlay", "mode" });
-            // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-            if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O|O:blend", @ptrCast(@constCast(&kw)), &overlay_obj, &mode_obj) == 0) {
-                return null;
-            }
+            const overlay_obj = params.overlay;
+            const mode_obj = params.mode;
 
             const parent = Self.parentFromObj(self_obj) orelse {
                 c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");

--- a/bindings/python/src/py_utils.zig
+++ b/bindings/python/src/py_utils.zig
@@ -6,6 +6,12 @@ const Point = zignal.Point;
 
 pub const c = @cImport({
     @cDefine("PY_SSIZE_T_CLEAN", {});
+    // NOTE: Python bindings currently broken on Zig 0.16+ due to arocc bugs.
+    // arocc (Zig's new C compiler) cannot parse glibc's complex math header macros
+    // (__MATHCALL, __MATHCALL_VEC, __MATHDECL, etc.) which Python.h transitively includes.
+    // No workaround exists - this requires upstream arocc fixes.
+    // Use Zig 0.15.x or earlier (which use Clang for translate-c) as a temporary solution.
+    // See: arocc_python_bug/ for minimal reproduction case
     @cInclude("Python.h");
 });
 
@@ -103,6 +109,51 @@ pub fn autoGetSet(
         }
         defs[field_names.len] = .{ .name = null, .get = null, .set = null, .doc = null, .closure = null };
         return defs;
+    }
+}
+
+/// Create PyGetSetDef array with auto-generated field getters plus custom entries.
+/// This eliminates the need for manual array copying when combining autoGetSet with custom getters.
+/// - Obj: the Python object struct type
+/// - field_names: comptime list of field names to auto-generate getters for
+/// - custom: comptime array of custom PyGetSetDef entries (without sentinel)
+/// Returns a combined array with auto-generated + custom + sentinel.
+///
+/// Example usage:
+/// ```zig
+/// const getset = py_utils.autoGetSetCustom(RectangleObject, &.{"left", "top", "right", "bottom"}, &[_]c.PyGetSetDef{
+///     .{ .name = "width", .get = @ptrCast(&rectangle_get_width), .set = null, .doc = "Width", .closure = null },
+///     .{ .name = "height", .get = @ptrCast(&rectangle_get_height), .set = null, .doc = "Height", .closure = null },
+/// });
+/// ```
+pub fn autoGetSetCustom(
+    comptime Obj: type,
+    comptime field_names: []const []const u8,
+    comptime custom: []const c.PyGetSetDef,
+) [field_names.len + custom.len + 1]c.PyGetSetDef {
+    comptime {
+        var result: [field_names.len + custom.len + 1]c.PyGetSetDef = undefined;
+
+        // Add auto-generated field getters
+        for (field_names, 0..) |fname, i| {
+            result[i] = .{
+                .name = fname.ptr,
+                .get = @ptrCast(@alignCast(getterForField(Obj, fname))),
+                .set = null,
+                .doc = null,
+                .closure = null,
+            };
+        }
+
+        // Add custom getters
+        for (custom, 0..) |custom_def, i| {
+            result[field_names.len + i] = custom_def;
+        }
+
+        // Add sentinel
+        result[field_names.len + custom.len] = .{ .name = null, .get = null, .set = null, .doc = null, .closure = null };
+
+        return result;
     }
 }
 

--- a/bindings/python/src/rectangle.zig
+++ b/bindings/python/src/rectangle.zig
@@ -564,38 +564,27 @@ pub const rectangle_properties_metadata = [_]stub_metadata.PropertyWithMetadata{
     },
 };
 
-// Auto-generate getset for field-backed properties, then append derived ones
-fn make_rectangle_getset() [6 + 1]c.PyGetSetDef {
-    comptime {
-        const auto_defs = py_utils.autoGetSet(RectangleObject, &.{ "left", "top", "right", "bottom" });
-        var result: [6 + 1]c.PyGetSetDef = undefined;
-        // Copy auto-generated field-backed properties (without their sentinel)
-        result[0] = auto_defs[0];
-        result[1] = auto_defs[1];
-        result[2] = auto_defs[2];
-        result[3] = auto_defs[3];
-        // Append derived width/height getters
-        result[4] = .{
+// Auto-generate field getters with custom width/height getters
+var rectangle_getset = py_utils.autoGetSetCustom(
+    RectangleObject,
+    &.{ "left", "top", "right", "bottom" },
+    &[_]c.PyGetSetDef{
+        .{
             .name = "width".ptr,
             .get = @ptrCast(@alignCast(&rectangle_get_width)),
             .set = null,
             .doc = "Width of the rectangle (right - left)".ptr,
             .closure = null,
-        };
-        result[5] = .{
+        },
+        .{
             .name = "height".ptr,
             .get = @ptrCast(@alignCast(&rectangle_get_height)),
             .set = null,
             .doc = "Height of the rectangle (bottom - top)".ptr,
             .closure = null,
-        };
-        // Sentinel
-        result[6] = .{ .name = null, .get = null, .set = null, .doc = null, .closure = null };
-        return result;
-    }
-}
-
-var rectangle_getset = make_rectangle_getset();
+        },
+    },
+);
 
 // Class documentation - keep it simple
 const rectangle_class_doc = "A rectangle defined by its left, top, right, and bottom coordinates.";

--- a/bindings/python/src/transforms.zig
+++ b/bindings/python/src/transforms.zig
@@ -38,14 +38,15 @@ fn similarity_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 fn similarity_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
     const self = py_utils.safeCast(SimilarityTransformObject, self_obj);
 
-    var from_points_obj: ?*c.PyObject = null;
-    var to_points_obj: ?*c.PyObject = null;
+    const Params = struct {
+        from_points: ?*c.PyObject,
+        to_points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return -1;
 
-    const kw = comptime py_utils.kw(&.{ "from_points", "to_points" });
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "OO", @ptrCast(@constCast(&kw)), &from_points_obj, &to_points_obj) == 0) {
-        return -1;
-    }
+    const from_points_obj = params.from_points;
+    const to_points_obj = params.to_points;
 
     // Parse point lists
     const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
@@ -91,9 +92,13 @@ fn similarity_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 fn similarity_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(SimilarityTransformObject, self_obj);
 
-    var point_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"points"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O", @ptrCast(@constCast(&kw)), &point_obj) == 0) return null;
+    const Params = struct {
+        points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const point_obj = params.points;
 
     // Check if it's a single tuple (x, y)
     if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {
@@ -200,14 +205,15 @@ fn affine_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 fn affine_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
     const self = py_utils.safeCast(AffineTransformObject, self_obj);
 
-    var from_points_obj: ?*c.PyObject = null;
-    var to_points_obj: ?*c.PyObject = null;
+    const Params = struct {
+        from_points: ?*c.PyObject,
+        to_points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return -1;
 
-    const kw = comptime py_utils.kw(&.{ "from_points", "to_points" });
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "OO", @ptrCast(@constCast(&kw)), &from_points_obj, &to_points_obj) == 0) {
-        return -1;
-    }
+    const from_points_obj = params.from_points;
+    const to_points_obj = params.to_points;
 
     // Parse point lists
     const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
@@ -256,9 +262,13 @@ fn affine_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 fn affine_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(AffineTransformObject, self_obj);
 
-    var point_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"points"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O", @ptrCast(@constCast(&kw)), &point_obj) == 0) return null;
+    const Params = struct {
+        points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const point_obj = params.points;
 
     // Check if it's a single tuple (x, y)
     if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {
@@ -366,14 +376,15 @@ fn projective_new(type_obj: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyOb
 fn projective_init(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) c_int {
     const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
-    var from_points_obj: ?*c.PyObject = null;
-    var to_points_obj: ?*c.PyObject = null;
+    const Params = struct {
+        from_points: ?*c.PyObject,
+        to_points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return -1;
 
-    const kw = comptime py_utils.kw(&.{ "from_points", "to_points" });
-    // TODO(py3.13): drop @constCast once minimum Python >= 3.13
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "OO", @ptrCast(@constCast(&kw)), &from_points_obj, &to_points_obj) == 0) {
-        return -1;
-    }
+    const from_points_obj = params.from_points;
+    const to_points_obj = params.to_points;
 
     // Parse point lists
     const from_points = py_utils.parsePointList(f64, from_points_obj) catch {
@@ -418,9 +429,13 @@ fn projective_dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
 fn projective_project(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     const self = py_utils.safeCast(ProjectiveTransformObject, self_obj);
 
-    var point_obj: ?*c.PyObject = null;
-    const kw = comptime py_utils.kw(&.{"points"});
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "O", @ptrCast(@constCast(&kw)), &point_obj) == 0) return null;
+    const Params = struct {
+        points: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    py_utils.parseArgs(Params, args, kwds, &params) catch return null;
+
+    const point_obj = params.points;
 
     // Check if it's a single tuple (x, y)
     if (c.PyTuple_Check(point_obj) != 0 and c.PyTuple_Size(point_obj) == 2) {


### PR DESCRIPTION
Replaces manual PyArg_ParseTupleAndKeywords calls with the structured py_utils.parseArgs utility across all methods in the bindings.

This simplifies argument handling, especially for optional keyword arguments and default values.

Also introduces py_utils.mergeGetSet for cleaner PyGetSetDef creation.