### PR TITLE
refactor(py): generalize python type object definitions

### DIFF
--- a/bindings/python/src/canvas.zig
+++ b/bindings/python/src/canvas.zig
@@ -1220,19 +1220,14 @@ pub const canvas_special_methods_metadata = [_]stub_metadata.MethodInfo{
     },
 };
 
-pub var CanvasType = c.PyTypeObject{
-    .ob_base = .{
-        .ob_base = .{},
-        .ob_size = 0,
-    },
-    .tp_name = "zignal.Canvas",
-    .tp_basicsize = @sizeOf(CanvasObject),
-    .tp_dealloc = canvas_dealloc,
-    .tp_repr = canvas_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = canvas_class_doc,
-    .tp_methods = @ptrCast(&canvas_methods),
-    .tp_getset = @ptrCast(&canvas_getset),
-    .tp_init = canvas_init,
-    .tp_new = canvas_new,
-};
+pub var CanvasType = py_utils.buildTypeObject(.{
+    .name = "zignal.Canvas",
+    .basicsize = @sizeOf(CanvasObject),
+    .doc = canvas_class_doc,
+    .methods = @ptrCast(&canvas_methods),
+    .getset = @ptrCast(&canvas_getset),
+    .new = canvas_new,
+    .init = canvas_init,
+    .dealloc = canvas_dealloc,
+    .repr = canvas_repr,
+});

--- a/bindings/python/src/grayscale_format.zig
+++ b/bindings/python/src/grayscale_format.zig
@@ -12,13 +12,11 @@ fn grayscale_repr(self: [*c]c.PyObject) callconv(.c) [*c]c.PyObject {
     return c.PyUnicode_FromString("Grayscale");
 }
 
-pub var GrayscaleType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.Grayscale",
-    .tp_basicsize = @sizeOf(GrayscaleTypeObject),
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Grayscale image format (single channel, u8)",
-    .tp_new = null, // not instantiable; used as a sentinel
-    .tp_repr = grayscale_repr,
-    .tp_str = grayscale_repr,
-};
+pub var GrayscaleType = py_utils.buildTypeObject(.{
+    .name = "zignal.Grayscale",
+    .basicsize = @sizeOf(GrayscaleTypeObject),
+    .doc = "Grayscale image format (single channel, u8)",
+    .new = null, // not instantiable; used as a sentinel
+    .repr = grayscale_repr,
+    .str = grayscale_repr,
+});

--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -1393,22 +1393,17 @@ pub fn moveImageToPython(owned_img: anytype) ?*ImageObject {
     return result;
 }
 
-pub var ImageType = c.PyTypeObject{
-    .ob_base = .{
-        .ob_base = .{},
-        .ob_size = 0,
-    },
-    .tp_name = "zignal.Image",
-    .tp_basicsize = @sizeOf(ImageObject),
-    .tp_dealloc = image_dealloc,
-    .tp_repr = image_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = image_class_doc,
-    .tp_methods = @ptrCast(&image_methods),
-    .tp_getset = @ptrCast(&image_getset),
-    .tp_as_mapping = @ptrCast(&image_as_mapping),
-    .tp_iter = image_iter,
-    .tp_init = image_init,
-    .tp_new = image_new,
-    .tp_richcompare = @ptrCast(&image_richcompare),
-};
+pub var ImageType = py_utils.buildTypeObject(.{
+    .name = "zignal.Image",
+    .basicsize = @sizeOf(ImageObject),
+    .doc = image_class_doc,
+    .methods = @ptrCast(&image_methods),
+    .getset = @ptrCast(&image_getset),
+    .as_mapping = @ptrCast(&image_as_mapping),
+    .new = image_new,
+    .init = image_init,
+    .dealloc = image_dealloc,
+    .repr = image_repr,
+    .iter = image_iter,
+    .richcompare = @ptrCast(&image_richcompare),
+});

--- a/bindings/python/src/optimization.zig
+++ b/bindings/python/src/optimization.zig
@@ -141,18 +141,16 @@ var assignment_getset = [_]c.PyGetSetDef{
     .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
 };
 
-pub var AssignmentType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.Assignment",
-    .tp_basicsize = @sizeOf(AssignmentObject),
-    .tp_dealloc = assignment_dealloc,
-    .tp_repr = assignment_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = assignment_doc,
-    .tp_getset = &assignment_getset,
-    .tp_init = assignment_init,
-    .tp_new = assignment_new,
-};
+pub var AssignmentType = py_utils.buildTypeObject(.{
+    .name = "zignal.Assignment",
+    .basicsize = @sizeOf(AssignmentObject),
+    .doc = assignment_doc,
+    .getset = &assignment_getset,
+    .new = assignment_new,
+    .init = assignment_init,
+    .dealloc = assignment_dealloc,
+    .repr = assignment_repr,
+});
 
 // ============================================================================
 // MODULE FUNCTIONS

--- a/bindings/python/src/pixel_iterator.zig
+++ b/bindings/python/src/pixel_iterator.zig
@@ -107,16 +107,14 @@ fn pixel_iterator_next(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     return result;
 }
 
-pub var PixelIteratorType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.PixelIterator",
-    .tp_basicsize = @sizeOf(PixelIteratorObject),
-    .tp_dealloc = pixel_iterator_dealloc,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = pixel_iterator_doc,
-    .tp_iter = pixel_iterator_iter,
-    .tp_iternext = pixel_iterator_next,
-};
+pub var PixelIteratorType = py_utils.buildTypeObject(.{
+    .name = "zignal.PixelIterator",
+    .basicsize = @sizeOf(PixelIteratorObject),
+    .doc = pixel_iterator_doc,
+    .dealloc = pixel_iterator_dealloc,
+    .iter = pixel_iterator_iter,
+    .iternext = pixel_iterator_next,
+});
 
 /// Create a new iterator bound to the given Image PyObject
 pub fn new(image_obj: ?*c.PyObject) ?*c.PyObject {

--- a/bindings/python/src/pixel_proxy.zig
+++ b/bindings/python/src/pixel_proxy.zig
@@ -404,31 +404,27 @@ var rgba_proxy_getset = RgbaProxyBinding.generateGetSet();
 var rgb_proxy_methods = RgbProxyBinding.generateMethods();
 var rgba_proxy_methods = RgbaProxyBinding.generateMethods();
 
-pub var RgbPixelProxyType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.RgbPixelProxy",
-    .tp_basicsize = @sizeOf(RgbPixelProxy),
-    .tp_dealloc = RgbProxyBinding.dealloc,
-    .tp_repr = RgbProxyBinding.repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Proxy object for RGB pixel access",
-    .tp_methods = @ptrCast(&rgb_proxy_methods),
-    .tp_getset = @ptrCast(&rgb_proxy_getset),
-    .tp_richcompare = RgbProxyBinding.richcompare,
-};
+pub var RgbPixelProxyType = py_utils.buildTypeObject(.{
+    .name = "zignal.RgbPixelProxy",
+    .basicsize = @sizeOf(RgbPixelProxy),
+    .doc = "Proxy object for RGB pixel access",
+    .methods = @ptrCast(&rgb_proxy_methods),
+    .getset = @ptrCast(&rgb_proxy_getset),
+    .dealloc = RgbProxyBinding.dealloc,
+    .repr = RgbProxyBinding.repr,
+    .richcompare = RgbProxyBinding.richcompare,
+});
 
-pub var RgbaPixelProxyType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.RgbaPixelProxy",
-    .tp_basicsize = @sizeOf(RgbaPixelProxy),
-    .tp_dealloc = RgbaProxyBinding.dealloc,
-    .tp_repr = RgbaProxyBinding.repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Proxy object for RGBA pixel access",
-    .tp_methods = @ptrCast(&rgba_proxy_methods),
-    .tp_getset = @ptrCast(&rgba_proxy_getset),
-    .tp_richcompare = RgbaProxyBinding.richcompare,
-};
+pub var RgbaPixelProxyType = py_utils.buildTypeObject(.{
+    .name = "zignal.RgbaPixelProxy",
+    .basicsize = @sizeOf(RgbaPixelProxy),
+    .doc = "Proxy object for RGBA pixel access",
+    .methods = @ptrCast(&rgba_proxy_methods),
+    .getset = @ptrCast(&rgba_proxy_getset),
+    .dealloc = RgbaProxyBinding.dealloc,
+    .repr = RgbaProxyBinding.repr,
+    .richcompare = RgbaProxyBinding.richcompare,
+});
 
 pub fn makeRgbProxy(parent: ?*c.PyObject, row: c.Py_ssize_t, col: c.Py_ssize_t) ?*c.PyObject {
     const proxy_obj = c.PyType_GenericAlloc(@ptrCast(&RgbPixelProxyType), 0);

--- a/bindings/python/src/transforms.zig
+++ b/bindings/python/src/transforms.zig
@@ -163,19 +163,17 @@ var similarity_getset = [_]c.PyGetSetDef{
     .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
 };
 
-pub var SimilarityTransformType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.SimilarityTransform",
-    .tp_basicsize = @sizeOf(SimilarityTransformObject),
-    .tp_dealloc = similarity_dealloc,
-    .tp_repr = similarity_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Similarity transform (rotation + uniform scale + translation)",
-    .tp_methods = &similarity_methods,
-    .tp_getset = &similarity_getset,
-    .tp_init = similarity_init,
-    .tp_new = similarity_new,
-};
+pub var SimilarityTransformType = py_utils.buildTypeObject(.{
+    .name = "zignal.SimilarityTransform",
+    .basicsize = @sizeOf(SimilarityTransformObject),
+    .doc = "Similarity transform (rotation + uniform scale + translation)",
+    .methods = @ptrCast(&similarity_methods),
+    .getset = @ptrCast(&similarity_getset),
+    .new = similarity_new,
+    .init = similarity_init,
+    .dealloc = similarity_dealloc,
+    .repr = similarity_repr,
+});
 
 // ============================================================================
 // AFFINE TRANSFORM
@@ -333,19 +331,17 @@ var affine_getset = [_]c.PyGetSetDef{
     .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
 };
 
-pub var AffineTransformType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.AffineTransform",
-    .tp_basicsize = @sizeOf(AffineTransformObject),
-    .tp_dealloc = affine_dealloc,
-    .tp_repr = affine_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Affine transform (general 2D linear transform)",
-    .tp_methods = &affine_methods,
-    .tp_getset = &affine_getset,
-    .tp_init = affine_init,
-    .tp_new = affine_new,
-};
+pub var AffineTransformType = py_utils.buildTypeObject(.{
+    .name = "zignal.AffineTransform",
+    .basicsize = @sizeOf(AffineTransformObject),
+    .doc = "Affine transform (general 2D linear transform)",
+    .methods = @ptrCast(&affine_methods),
+    .getset = @ptrCast(&affine_getset),
+    .new = affine_new,
+    .init = affine_init,
+    .dealloc = affine_dealloc,
+    .repr = affine_repr,
+});
 
 // ============================================================================
 // PROJECTIVE TRANSFORM
@@ -545,19 +541,17 @@ var projective_getset = [_]c.PyGetSetDef{
     .{ .name = null, .get = null, .set = null, .doc = null, .closure = null },
 };
 
-pub var ProjectiveTransformType = c.PyTypeObject{
-    .ob_base = .{ .ob_base = .{}, .ob_size = 0 },
-    .tp_name = "zignal.ProjectiveTransform",
-    .tp_basicsize = @sizeOf(ProjectiveTransformObject),
-    .tp_dealloc = projective_dealloc,
-    .tp_repr = projective_repr,
-    .tp_flags = c.Py_TPFLAGS_DEFAULT,
-    .tp_doc = "Projective transform (homography/perspective transform)",
-    .tp_methods = &projective_methods,
-    .tp_getset = &projective_getset,
-    .tp_init = projective_init,
-    .tp_new = projective_new,
-};
+pub var ProjectiveTransformType = py_utils.buildTypeObject(.{
+    .name = "zignal.ProjectiveTransform",
+    .basicsize = @sizeOf(ProjectiveTransformObject),
+    .doc = "Projective transform (homography/perspective transform)",
+    .methods = @ptrCast(&projective_methods),
+    .getset = @ptrCast(&projective_getset),
+    .new = projective_new,
+    .init = projective_init,
+    .dealloc = projective_dealloc,
+    .repr = projective_repr,
+});
 
 // ============================================================================
 // STUB GENERATION METADATA


### PR DESCRIPTION
Replace manual initialization of PyTypeObject structs with the `py_utils.buildTypeObject` utility across all binding files.

Refactor color type bindings and enum registration to use comptime generation and table-driven loops, drastically reducing boilerplate.