### PR TITLE
perf(convolution): skip convolution for uniform channels

### DIFF
--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -211,8 +211,8 @@ pub fn convolve(comptime T: type, self: Image(T), allocator: Allocator, kernel: 
                         kernel_sum += weight;
                     }
                     const plane_size = self.rows * self.cols;
-                    const scale = 256;
                     const Pixel = PixelIO(u8, 1);
+                    const scale = Pixel.scale;
 
                     // Separate channels using helper
                     const channels = try channel_ops.splitChannels(T, self, allocator);


### PR DESCRIPTION
Avoids running the convolution loop when a channel is uniform and the kernel is not normalized. The resulting scaled uniform value is calculated and the output plane is filled using memset.

Refactors separable convolution temporary buffer initialization.