### PR TITLE
ci: update macOS runners in CI matrix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:


### PR DESCRIPTION
Replaces macos-13 and macos-14 with macos-latest and macos-15-intel.