### PR TITLE
simplify float to integer conversions

### DIFF
--- a/bindings/python/src/color_factory.zig
+++ b/bindings/python/src/color_factory.zig
@@ -363,7 +363,7 @@ pub fn ColorBinding(comptime ZigColorType: type) type {
                         c.PyErr_SetString(c.PyExc_ValueError, "Alpha float value for integer colors must be between 0.0 and 1.0");
                         return null;
                     }
-                    alpha = @intFromFloat(@round(val * 255.0));
+                    alpha = @round(val * 255.0);
                 } else if (c.PyLong_Check(@as(*c.PyObject, @ptrCast(alpha_obj.?))) != 0) {
                     const val = c.PyLong_AsLong(@ptrCast(alpha_obj.?));
                     if (val < 0 or val > 255) {

--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -592,8 +592,8 @@ pub fn image_extract(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     if (!validateF32(angle, "Angle")) return null;
 
     // Determine output size
-    var out_rows: u32 = @intFromFloat(@round(rect.height()));
-    var out_cols: u32 = @intFromFloat(@round(rect.width()));
+    var out_rows: u32 = @round(rect.height());
+    var out_cols: u32 = @round(rect.width());
 
     if (size_obj != null and size_obj != c.Py_None()) {
         // Accept either an integer (square) or a tuple (rows, cols)

--- a/bindings/python/src/python.zig
+++ b/bindings/python/src/python.zig
@@ -669,10 +669,10 @@ fn parseRectangleTuple(comptime T: type, tuple_obj: ?*c.PyObject) !zignal.Rectan
     }
     return switch (@typeInfo(T)) {
         .int => .init(
-            @intFromFloat(left),
-            @intFromFloat(top),
-            @intFromFloat(right),
-            @intFromFloat(bottom),
+            @trunc(left),
+            @trunc(top),
+            @trunc(right),
+            @trunc(bottom),
         ),
         .float => .init(
             @floatCast(left),
@@ -710,10 +710,10 @@ fn parseRectangle(comptime T: type, rect_obj: ?*c.PyObject) !zignal.Rectangle(T)
     const info = @typeInfo(T);
     return switch (info) {
         .int => .init(
-            @intFromFloat(rect.left),
-            @intFromFloat(rect.top),
-            @intFromFloat(rect.right),
-            @intFromFloat(rect.bottom),
+            @trunc(rect.left),
+            @trunc(rect.top),
+            @trunc(rect.right),
+            @trunc(rect.bottom),
         ),
         .float => .init(
             @floatCast(rect.left),

--- a/examples/src/blur_box_vs_gaussian.zig
+++ b/examples/src/blur_box_vs_gaussian.zig
@@ -45,7 +45,7 @@ fn boxesForGaussian(sigma: f32, passes: usize, buffer: []usize) ![]usize {
     var wl = @floor(w_ideal);
 
     // Make wl odd
-    const wl_int_even_check: i64 = @intFromFloat(wl);
+    const wl_int_even_check: i64 = @trunc(wl);
     if (@mod(wl_int_even_check, @as(i64, 2)) == 0) {
         wl -= 1.0;
     }
@@ -62,12 +62,12 @@ fn boxesForGaussian(sigma: f32, passes: usize, buffer: []usize) ![]usize {
         m = 0;
     }
 
-    var m_int: isize = @intFromFloat(m);
+    var m_int: isize = @trunc(m);
     if (m_int < 0) m_int = 0;
     if (m_int > passes) m_int = @intCast(passes);
 
-    const wl_int = @max(@as(isize, 1), @as(isize, @intFromFloat(wl)));
-    const wu_int = @max(@as(isize, 1), @as(isize, @intFromFloat(wu)));
+    const wl_int: isize = @max(1, @as(isize, @trunc(wl)));
+    const wu_int: isize = @max(1, @as(isize, @trunc(wu)));
 
     // First m passes use wl, remaining passes use wu
     for (0..passes) |i| {

--- a/examples/src/make_logo.zig
+++ b/examples/src/make_logo.zig
@@ -178,7 +178,7 @@ fn drawDecorativeElements(canvas: *Canvas(Rgb)) void {
 }
 
 fn drawPixelPattern(canvas: *Canvas(Rgb), start_x: f32, start_y: f32, size: f32, pixel_size: f32, base_color: Rgb, pattern_seed: u64) void {
-    const pixels_per_side = @as(usize, @intFromFloat(size / pixel_size));
+    const pixels_per_side: usize = @trunc(size / pixel_size);
 
     for (0..pixels_per_side) |i| {
         for (0..pixels_per_side) |j| {
@@ -256,7 +256,7 @@ fn drawPixelPattern(canvas: *Canvas(Rgb), start_x: f32, start_y: f32, size: f32,
 
             // Convert back to RGB then to RGBA with alpha
             const adjusted_rgb = adjusted_oklab.to(.rgb).as(u8);
-            const alpha = @as(u8, @intFromFloat(@min(255, intensity * 255)));
+            const alpha: u8 = @trunc(@min(255, intensity * 255));
             const color_with_alpha = adjusted_rgb.withAlpha(alpha);
 
             const rect: zignal.Rectangle(f32) = .init(x, y, x + pixel_size - 1, y + pixel_size - 1);

--- a/examples/src/perlin_noise.zig
+++ b/examples/src/perlin_noise.zig
@@ -57,7 +57,7 @@ pub export fn generate(rgba_ptr: [*]Rgba, rows: u32, cols: u32) void {
         const y: f32 = @as(f32, @floatFromInt(r)) / @as(f32, @floatFromInt(image.rows));
         for (0..image.cols) |c| {
             const x: f32 = @as(f32, @floatFromInt(c)) / @as(f32, @floatFromInt(image.cols));
-            const val: u8 = @intFromFloat(
+            const val: u8 = @trunc(
                 @max(0, @min(255, @round(
                     255 * (opts.amplitude / 2 * (perlin(f32, x, y, 0, opts) + opts.amplitude)),
                 ))),

--- a/examples/src/whitebalance.zig
+++ b/examples/src/whitebalance.zig
@@ -36,7 +36,7 @@ fn estimateIlluminant(image: Image(Rgba), color: Rgb, fraction: f64) RgbGains {
     var sum_g: f64 = 0;
     var sum_b: f64 = 0;
     // Compute the average color per channel
-    const sep: usize = @intFromFloat(@as(f32, @floatFromInt(image.rows)) * fraction);
+    const sep: usize = @trunc(@as(f32, @floatFromInt(image.rows)) * fraction);
     const size: f64 = @floatFromInt(image.cols * image.rows);
 
     // Process original pixels up to separation point
@@ -144,9 +144,9 @@ fn whitebalanceSimd(pixels: []Rgba, w: RgbGains) void {
             const g_clamped = @max(0.0, @min(1.0, g_new));
             const b_clamped = @max(0.0, @min(1.0, b_new));
 
-            pixels[i + j].r = @intFromFloat(@round(r_clamped * 255.0));
-            pixels[i + j].g = @intFromFloat(@round(g_clamped * 255.0));
-            pixels[i + j].b = @intFromFloat(@round(b_clamped * 255.0));
+            pixels[i + j].r = @round(r_clamped * 255.0);
+            pixels[i + j].g = @round(g_clamped * 255.0);
+            pixels[i + j].b = @round(b_clamped * 255.0);
         }
     }
 

--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -63,7 +63,7 @@ pub fn Canvas(comptime T: type) type {
         /// Clamps a floating-point coordinate to image bounds and converts to u32 .
         /// Returns the clamped coordinate as a u32  index.
         inline fn clampToImageBounds(coord: f32, max_size: u32) u32 {
-            return @intFromFloat(clamp(coord, 0, @as(f32, @floatFromInt(max_size))));
+            return @trunc(clamp(coord, 0, @as(f32, @floatFromInt(max_size))));
         }
 
         /// Clamps a rectangle to image bounds and returns integer pixel coordinates.
@@ -173,9 +173,9 @@ pub fn Canvas(comptime T: type) type {
             if (y < 0 or y >= frows) return;
             if (x2 < 0 or x1 >= fcols) return;
 
-            const row: u32 = @intFromFloat(y);
-            const start: u32 = @intFromFloat(@max(0, @floor(x1)));
-            const end: u32 = @intFromFloat(@min(fcols - 1, @ceil(x2)));
+            const row: u32 = @trunc(y);
+            const start: u32 = @trunc(@max(0, @floor(x1)));
+            const end: u32 = @trunc(@min(fcols - 1, @ceil(x2)));
 
             if (start > end) return;
 
@@ -238,10 +238,10 @@ pub fn Canvas(comptime T: type) type {
         /// Produces pixel-perfect lines with hard edges and no antialiasing.
         /// Optimal for grid-aligned graphics and when performance is critical.
         fn drawLineBresenham(self: Self, p1: Point(2, f32), p2: Point(2, f32), color: anytype) void {
-            var x1: i32 = @intFromFloat(p1.x());
-            var y1: i32 = @intFromFloat(p1.y());
-            const x2: i32 = @intFromFloat(p2.x());
-            const y2: i32 = @intFromFloat(p2.y());
+            var x1: i32 = @trunc(p1.x());
+            var y1: i32 = @trunc(p1.y());
+            const x2: i32 = @trunc(p2.x());
+            const y2: i32 = @trunc(p2.y());
 
             const pixel_color = convertColor(T, color);
 
@@ -471,8 +471,8 @@ pub fn Canvas(comptime T: type) type {
                     const x_start = x1 - half_width;
                     const x_end = x1 + half_width;
                     if (needs_alpha_blend) {
-                        const px_start = @as(u32, @intFromFloat(@max(0, @floor(x_start))));
-                        const px_end = @as(u32, @intFromFloat(@min(fcols - 1, @ceil(x_end))));
+                        const px_start: u32 = @trunc(@max(0, @floor(x_start)));
+                        const px_end: u32 = @trunc(@min(fcols - 1, @ceil(x_end)));
                         if (px_start > px_end) continue;
                         var px = px_start;
                         while (px <= px_end) : (px += 1) {
@@ -578,8 +578,8 @@ pub fn Canvas(comptime T: type) type {
         pub fn setPixel(self: Self, point: Point(2, f32), color: anytype) void {
             const ColorType = @TypeOf(color);
             comptime assert(isColor(ColorType));
-            const row: i32 = @intFromFloat(@floor(point.y()));
-            const col: i32 = @intFromFloat(@floor(point.x()));
+            const row: i32 = @floor(point.y());
+            const col: i32 = @floor(point.x());
             if (self.atOrNull(row, col)) |pixel| {
                 const mode: Blending = if (comptime ColorType == Rgba)
                     if (color.a != 255) .normal else .none
@@ -604,8 +604,8 @@ pub fn Canvas(comptime T: type) type {
 
             if (src_rect.isEmpty()) return;
 
-            const origin_x = @as(i32, @intFromFloat(@round(position.x())));
-            const origin_y = @as(i32, @intFromFloat(@round(position.y())));
+            const origin_x: i32 = @round(position.x());
+            const origin_y: i32 = @round(position.y());
 
             // Simple blit loop with type-based blending
             for (src_rect.t..src_rect.b) |src_r| {
@@ -807,10 +807,10 @@ pub fn Canvas(comptime T: type) type {
                 const solid_color = convertColor(T, color);
 
                 // Calculate bounding box
-                const left: u32 = @intFromFloat(@round(@max(0, center.x() - outer_radius - 1)));
-                const top: u32 = @intFromFloat(@round(@max(0, center.y() - outer_radius - 1)));
-                const right: u32 = @intFromFloat(@round(@min(fcols, center.x() + outer_radius + 1)));
-                const bottom: u32 = @intFromFloat(@round(@min(frows, center.y() + outer_radius + 1)));
+                const left: u32 = @round(@max(0, center.x() - outer_radius - 1));
+                const top: u32 = @round(@max(0, center.y() - outer_radius - 1));
+                const right: u32 = @round(@min(fcols, center.x() + outer_radius + 1));
+                const bottom: u32 = @round(@min(frows, center.y() + outer_radius + 1));
 
                 for (top..bottom) |r| {
                     const y = @as(f32, @floatFromInt(r)) - center.y();
@@ -838,10 +838,10 @@ pub fn Canvas(comptime T: type) type {
             const outer_radius = radius + line_width / 2.0;
 
             // Calculate bounding box
-            const left: u32 = @intFromFloat(@round(@max(0, center.x() - outer_radius - 1)));
-            const top: u32 = @intFromFloat(@round(@max(0, center.y() - outer_radius - 1)));
-            const right: u32 = @intFromFloat(@round(@min(fcols, center.x() + outer_radius + 1)));
-            const bottom: u32 = @intFromFloat(@round(@min(frows, center.y() + outer_radius + 1)));
+            const left: u32 = @round(@max(0, center.x() - outer_radius - 1));
+            const top: u32 = @round(@max(0, center.y() - outer_radius - 1));
+            const right: u32 = @round(@min(fcols, center.x() + outer_radius + 1));
+            const bottom: u32 = @round(@min(frows, center.y() + outer_radius + 1));
 
             const c2 = convertColor(Rgba, color);
 
@@ -925,10 +925,10 @@ pub fn Canvas(comptime T: type) type {
                 const outer_radius = radius + line_width / 2.0;
 
                 // Calculate bounding box
-                const left: u32 = @intFromFloat(@round(@max(0, center.x() - outer_radius - 1)));
-                const top: u32 = @intFromFloat(@round(@max(0, center.y() - outer_radius - 1)));
-                const right: u32 = @intFromFloat(@round(@min(fcols, center.x() + outer_radius + 1)));
-                const bottom: u32 = @intFromFloat(@round(@min(frows, center.y() + outer_radius + 1)));
+                const left: u32 = @round(@max(0, center.x() - outer_radius - 1));
+                const top: u32 = @round(@max(0, center.y() - outer_radius - 1));
+                const right: u32 = @round(@min(fcols, center.x() + outer_radius + 1));
+                const bottom: u32 = @round(@min(frows, center.y() + outer_radius + 1));
 
                 if (left >= right or top >= bottom) return;
 
@@ -957,7 +957,7 @@ pub fn Canvas(comptime T: type) type {
             const arc_length = @abs(angle_span) * radius;
 
             // Determine number of segments based on arc length
-            const segments = @max(@as(u32, 8), @as(u32, @intFromFloat(@ceil(arc_length / 5.0))));
+            const segments: u32 = @max(8, @as(u32, @ceil(arc_length / 5.0)));
             const angle_step = angle_span / @as(f32, @floatFromInt(segments));
 
             // Stack allocation for reasonable arc sizes
@@ -1202,10 +1202,10 @@ pub fn Canvas(comptime T: type) type {
         fn fillCircleSoft(self: Self, center: Point(2, f32), radius: f32, color: anytype) void {
             const frows: f32 = @floatFromInt(self.image.rows);
             const fcols: f32 = @floatFromInt(self.image.cols);
-            const left: u32 = @intFromFloat(clamp(@round(center.x() - radius), 0, fcols));
-            const top: u32 = @intFromFloat(clamp(@round(center.y() - radius), 0, frows));
-            const right: u32 = @intFromFloat(clamp(@round(center.x() + radius), 0, fcols));
-            const bottom: u32 = @intFromFloat(clamp(@round(center.y() + radius), 0, frows));
+            const left: u32 = @trunc(clamp(@round(center.x() - radius), 0, fcols));
+            const top: u32 = @trunc(clamp(@round(center.y() - radius), 0, frows));
+            const right: u32 = @trunc(clamp(@round(center.x() + radius), 0, fcols));
+            const bottom: u32 = @trunc(clamp(@round(center.y() + radius), 0, frows));
 
             if (left >= right or top >= bottom) return;
 
@@ -1355,10 +1355,10 @@ pub fn Canvas(comptime T: type) type {
             const frows: f32 = @floatFromInt(self.image.rows);
             const fcols: f32 = @floatFromInt(self.image.cols);
             const bounds: Rectangle(u32) = .{
-                .l = @intFromFloat(@round(@max(0, center.x() - radius - 1))),
-                .t = @intFromFloat(@round(@max(0, center.y() - radius - 1))),
-                .r = @intFromFloat(@round(@min(fcols, center.x() + radius + 1))),
-                .b = @intFromFloat(@round(@min(frows, center.y() + radius + 1))),
+                .l = @round(@max(0, center.x() - radius - 1)),
+                .t = @round(@max(0, center.y() - radius - 1)),
+                .r = @round(@min(fcols, center.x() + radius + 1)),
+                .b = @round(@min(frows, center.y() + radius + 1)),
             };
             if (bounds.isEmpty()) return;
 
@@ -1494,7 +1494,7 @@ pub fn Canvas(comptime T: type) type {
                 const p2 = polygon[(i + 2) % polygon.len];
                 const control_points = calculateSmoothControlPoints(p0, p1, p2, tension);
                 const estimated_length = estimateCubicBezierLength(p0, control_points.cp1, control_points.cp2, p1);
-                const segments = @max(spline_min_segments_count, @min(spline_max_segments_count, @as(u32, @intFromFloat(estimated_length / pixels_per_segment))));
+                const segments: u32 = @max(spline_min_segments_count, @min(spline_max_segments_count, @as(u32, @trunc(estimated_length / pixels_per_segment))));
                 total_points += segments;
             }
 
@@ -1519,7 +1519,7 @@ pub fn Canvas(comptime T: type) type {
                 const control_points = calculateSmoothControlPoints(p0, p1, p2, tension);
 
                 const estimated_length = estimateCubicBezierLength(p0, control_points.cp1, control_points.cp2, p1);
-                const segments = @max(spline_min_segments_count, @min(spline_max_segments_count, @as(u32, @intFromFloat(estimated_length / pixels_per_segment))));
+                const segments: u32 = @max(spline_min_segments_count, @min(spline_max_segments_count, @as(u32, @trunc(estimated_length / pixels_per_segment))));
 
                 // Tessellate directly into our buffer
                 const segment_buffer = points_buffer[write_idx .. write_idx + segments];
@@ -1605,7 +1605,7 @@ pub fn Canvas(comptime T: type) type {
             evalArgs: anytype,
             buffer: []Point(2, f32),
         ) u32 {
-            const segments = @max(min_segments, @min(max_segments, @as(u32, @intFromFloat(estimated_length / pixels_per_segment))));
+            const segments: u32 = @max(min_segments, @min(max_segments, @as(u32, @trunc(estimated_length / pixels_per_segment))));
             const actual_segments = @min(segments, buffer.len);
 
             for (0..actual_segments) |i| {
@@ -1784,10 +1784,10 @@ pub fn Canvas(comptime T: type) type {
                                             const y_end_f = @ceil(base_y + scale);
 
                                             // Clip to the valid rectangle
-                                            const x_start = @as(u32, @intFromFloat(@max(x_start_f, clip_rect.l)));
-                                            const y_start = @as(u32, @intFromFloat(@max(y_start_f, clip_rect.t)));
-                                            const x_end = @as(u32, @intFromFloat(@min(x_end_f, clip_rect.r)));
-                                            const y_end = @as(u32, @intFromFloat(@min(y_end_f, clip_rect.b)));
+                                            const x_start: u32 = @trunc(@max(x_start_f, clip_rect.l));
+                                            const y_start: u32 = @trunc(@max(y_start_f, clip_rect.t));
+                                            const x_end: u32 = @trunc(@min(x_end_f, clip_rect.r));
+                                            const y_end: u32 = @trunc(@min(y_end_f, clip_rect.b));
 
                                             // Fill the pixel block
                                             if (x_start < x_end and y_start < y_end) {
@@ -1815,7 +1815,7 @@ pub fn Canvas(comptime T: type) type {
                                         const dest_x = x + dx + @as(f32, @floatFromInt(glyph_info.x_offset)) * scale;
                                         const dest_y = y + dy + @as(f32, @floatFromInt(glyph_info.y_offset)) * scale;
 
-                                        if (self.atOrNull(@intFromFloat(dest_y), @intFromFloat(dest_x))) |_| {
+                                        if (self.atOrNull(@trunc(dest_y), @trunc(dest_x))) |_| {
                                             // Calculate which part of the source we're sampling
                                             const src_x = dx / scale;
                                             const src_y = dy / scale;
@@ -1839,8 +1839,8 @@ pub fn Canvas(comptime T: type) type {
                                             while (row_f <= row_end_f) : (row_f += 1) {
                                                 var col_f = col_start_f;
                                                 while (col_f <= col_end_f) : (col_f += 1) {
-                                                    const row_idx = @as(u32, @intFromFloat(row_f));
-                                                    const col_idx = @as(u32, @intFromFloat(col_f));
+                                                    const row_idx: u32 = @trunc(row_f);
+                                                    const col_idx: u32 = @trunc(col_f);
 
                                                     if (getGlyphBit(char_data, row_idx, col_idx, glyph_bytes_per_row) != 0) {
                                                         // Calculate how much this pixel contributes

--- a/src/canvas/tests/arcs.zig
+++ b/src/canvas/tests/arcs.zig
@@ -47,8 +47,8 @@ test "arc drawing - basic angles" {
     while (dy < check_radius * 2) : (dy += 1) {
         var dx: usize = 0;
         while (dx < check_radius * 2) : (dx += 1) {
-            const x = @as(usize, @intFromFloat(@round(expected_x))) + dx - check_radius;
-            const y = @as(usize, @intFromFloat(@round(expected_y))) + dy - check_radius;
+            const x: usize = @as(usize, @round(expected_x)) + dx - check_radius;
+            const y: usize = @as(usize, @round(expected_y)) + dy - check_radius;
             if (x < width and y < height) {
                 const pixel = img.at(y, x);
                 if (pixel.r == 0 and pixel.g == 0 and pixel.b == 0) {
@@ -88,7 +88,7 @@ test "arc drawing - full circle optimization" {
     }
 
     // Should have approximately 2πr pixels for a circle outline
-    const expected = @as(usize, @intFromFloat(2 * std.math.pi * radius));
+    const expected: usize = @trunc(2 * std.math.pi * radius);
     try expect(black_count > expected * 3 / 4); // Allow some tolerance
     try expect(black_count < expected * 5 / 4);
 }
@@ -161,20 +161,20 @@ test "fillArc - pie slices" {
     }
 
     // Quarter circle area should be approximately πr²/4
-    const expected_area = @as(usize, @intFromFloat(std.math.pi * radius * radius / 4));
+    const expected_area: usize = @trunc(std.math.pi * radius * radius / 4);
     try expect(black_count > expected_area * 3 / 4); // Allow tolerance
     try expect(black_count < expected_area * 5 / 4);
 
     // Verify the filled area is in the correct quadrant
     // Points in the first quadrant (x > center.x, y > center.y) should be filled
-    const sample_x = @as(usize, @intFromFloat(center.x() + radius / 2));
-    const sample_y = @as(usize, @intFromFloat(center.y() + radius / 2));
+    const sample_x: usize = @trunc(center.x() + radius / 2);
+    const sample_y: usize = @trunc(center.y() + radius / 2);
     const sample_pixel = img.at(sample_y, sample_x);
     try expect(sample_pixel.r == 0 and sample_pixel.g == 0 and sample_pixel.b == 0);
 
     // Points in the opposite quadrant should not be filled
-    const opposite_x = @as(usize, @intFromFloat(center.x() - radius / 2));
-    const opposite_y = @as(usize, @intFromFloat(center.y() - radius / 2));
+    const opposite_x: usize = @trunc(center.x() - radius / 2);
+    const opposite_y: usize = @trunc(center.y() - radius / 2);
     const opposite_pixel = img.at(opposite_y, opposite_x);
     try expect(opposite_pixel.r == 255 and opposite_pixel.g == 255 and opposite_pixel.b == 255);
 }

--- a/src/canvas/tests/drawing.zig
+++ b/src/canvas/tests/drawing.zig
@@ -48,10 +48,10 @@ test "line endpoints are connected" {
         // Check 3x3 area around endpoints
         for (0..3) |dy| {
             for (0..3) |dx| {
-                const y1 = @as(i32, @intFromFloat(tc.p1.y())) + @as(i32, @intCast(dy)) - 1;
-                const x1 = @as(i32, @intFromFloat(tc.p1.x())) + @as(i32, @intCast(dx)) - 1;
-                const y2 = @as(i32, @intFromFloat(tc.p2.y())) + @as(i32, @intCast(dy)) - 1;
-                const x2 = @as(i32, @intFromFloat(tc.p2.x())) + @as(i32, @intCast(dx)) - 1;
+                const y1: i32 = @as(i32, @trunc(tc.p1.y())) + @as(i32, @intCast(dy)) - 1;
+                const x1: i32 = @as(i32, @trunc(tc.p1.x())) + @as(i32, @intCast(dx)) - 1;
+                const y2: i32 = @as(i32, @trunc(tc.p2.y())) + @as(i32, @intCast(dy)) - 1;
+                const x2: i32 = @as(i32, @trunc(tc.p2.x())) + @as(i32, @intCast(dx)) - 1;
 
                 if (y1 >= 0 and y1 < height and x1 >= 0 and x1 < width) {
                     const idx1 = @as(usize, @intCast(y1)) * width + @as(usize, @intCast(x1));
@@ -169,10 +169,10 @@ test "filled circle has correct radius" {
         }
 
         // Most pixels inside radius should be filled
-        const inside_total = @as(usize, @intFromFloat(std.math.pi * (radius - 1) * (radius - 1)));
+        const inside_total: usize = @trunc(std.math.pi * (radius - 1) * (radius - 1));
         // Allow 15% tolerance for small circles due to discretization
         const tolerance_factor: f32 = if (radius <= 10) 0.85 else 0.9;
-        const expected_count = @as(usize, @intFromFloat(@as(f32, @floatFromInt(inside_total)) * tolerance_factor));
+        const expected_count: usize = @trunc(@as(f32, @floatFromInt(inside_total)) * tolerance_factor);
         try expect(inside_count >= expected_count);
     }
 }
@@ -212,7 +212,7 @@ test "circle outline has correct thickness" {
                 const y = center.y() + r * @sin(angle);
 
                 if (x >= 0 and x < width and y >= 0 and y < height) {
-                    const idx = @as(usize, @intFromFloat(y)) * width + @as(usize, @intFromFloat(x));
+                    const idx: usize = @as(usize, @trunc(y)) * width + @as(usize, @trunc(x));
                     if (img.data[idx].r == 0) {
                         black_pixels += 1;
                     }
@@ -382,8 +382,8 @@ test "polygon fill respects convexity" {
     };
 
     for (test_points) |tp| {
-        const x = @as(usize, @intFromFloat(tp.p.x()));
-        const y = @as(usize, @intFromFloat(tp.p.y()));
+        const x: usize = @trunc(tp.p.x());
+        const y: usize = @trunc(tp.p.y());
         if (x < width and y < height) {
             const idx = y * width + x;
             const is_black = img.data[idx].r == 0;
@@ -462,10 +462,10 @@ test "bezier curve smoothness" {
     // Check 3x3 area around endpoints
     for (0..3) |dy| {
         for (0..3) |dx| {
-            const y0 = @as(i32, @intFromFloat(p0.y())) + @as(i32, @intCast(dy)) - 1;
-            const x0 = @as(i32, @intFromFloat(p0.x())) + @as(i32, @intCast(dx)) - 1;
-            const y3 = @as(i32, @intFromFloat(p3.y())) + @as(i32, @intCast(dy)) - 1;
-            const x3 = @as(i32, @intFromFloat(p3.x())) + @as(i32, @intCast(dx)) - 1;
+            const y0: i32 = @as(i32, @trunc(p0.y())) + @as(i32, @intCast(dy)) - 1;
+            const x0: i32 = @as(i32, @trunc(p0.x())) + @as(i32, @intCast(dx)) - 1;
+            const y3: i32 = @as(i32, @trunc(p3.y())) + @as(i32, @intCast(dy)) - 1;
+            const x3: i32 = @as(i32, @trunc(p3.x())) + @as(i32, @intCast(dx)) - 1;
 
             if (y0 >= 0 and y0 < height and x0 >= 0 and x0 < width) {
                 const idx0 = @as(usize, @intCast(y0)) * width + @as(usize, @intCast(x0));

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -171,7 +171,7 @@ fn processImage(
             }
 
             const angle_rad = std.math.degreesToRadians(angle_deg);
-            try img.motionBlur(gpa, .{ .linear = .{ .angle = angle_rad, .distance = @intFromFloat(dist) } }, out);
+            try img.motionBlur(gpa, .{ .linear = .{ .angle = angle_rad, .distance = @trunc(dist) } }, out);
         },
         .motion_zoom, .motion_spin => {
             const cx = options.center_x orelse 0.5;

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -107,7 +107,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     // However, users usually want to know the *raw* max difference, but we only have stats of the *processed* image.
     // For now, reporting the max pixel value in the diff image is consistent with what is shown.
 
-    std.log.info("Max difference found: {d}", .{@as(u32, @intFromFloat(result.stats.max()))});
+    std.log.info("Max difference found: {d}", .{@as(u32, @trunc(result.stats.max()))});
     std.log.info("Pixels differing > {d}: {d}", .{ threshold, result.diff_count });
 
     if (parsed.options.output) |output_path| {

--- a/src/cli/display.zig
+++ b/src/cli/display.zig
@@ -155,8 +155,8 @@ pub fn createHorizontalComposite(
     );
 
     // Calculate dimensions for each sub-image
-    const w = @as(u32, @intFromFloat(@round(@as(f32, @floatFromInt(ref_img.cols)) * scale_factor)));
-    const h = @as(u32, @intFromFloat(@round(@as(f32, @floatFromInt(ref_img.rows)) * scale_factor)));
+    const w: u32 = @round(@as(f32, @floatFromInt(ref_img.cols)) * scale_factor);
+    const h: u32 = @round(@as(f32, @floatFromInt(ref_img.rows)) * scale_factor);
 
     // Safety check for zero dimensions
     const final_w = if (w == 0) 1 else w;

--- a/src/cli/tile.zig
+++ b/src/cli/tile.zig
@@ -93,8 +93,8 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         },
         .square => {
             const sqrt = std.math.sqrt(@as(f32, @floatFromInt(img_count)));
-            cols = @intFromFloat(@ceil(sqrt));
-            rows = @intFromFloat(@ceil(@as(f32, @floatFromInt(img_count)) / @as(f32, @floatFromInt(cols))));
+            cols = @ceil(sqrt);
+            rows = @ceil(@as(f32, @floatFromInt(img_count)) / @as(f32, @floatFromInt(cols)));
         },
         .grid => {
             if (parsed.options.rows == null or parsed.options.cols == null) {
@@ -157,10 +157,10 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
             cell_h = @intCast(reference_img.?.rows);
         } else if (cell_w != 0 and cell_h == 0) {
             // Scale height proportionally
-            cell_h = @intFromFloat(@round((@as(f32, @floatFromInt(cell_w)) / ref_w_f) * ref_h_f));
+            cell_h = @round((@as(f32, @floatFromInt(cell_w)) / ref_w_f) * ref_h_f);
         } else if (cell_w == 0 and cell_h != 0) {
             // Scale width proportionally
-            cell_w = @intFromFloat(@round((@as(f32, @floatFromInt(cell_h)) / ref_h_f) * ref_w_f));
+            cell_w = @round((@as(f32, @floatFromInt(cell_h)) / ref_h_f) * ref_w_f);
         }
     }
 

--- a/src/color.zig
+++ b/src/color.zig
@@ -105,7 +105,7 @@ pub fn convertColor(comptime DestType: type, source: anytype) DestType {
     if (@typeInfo(SrcType) == .float and DestType == u8) {
         // Use f64 for precision with smaller floats, but SrcType if it's larger.
         const P = if (@typeInfo(SrcType).float.bits < 64) f64 else SrcType;
-        return @intFromFloat(@round(clamp(@as(P, source), 0.0, 1.0) * @as(P, 255.0)));
+        return @round(clamp(@as(P, source), 0.0, 1.0) * @as(P, 255.0));
     }
     if (@typeInfo(SrcType) == .float and @typeInfo(DestType) == .float) return @floatCast(source);
 
@@ -304,9 +304,9 @@ pub fn Rgb(comptime T: type) type {
 
         /// Converts RGB to 24-bit hexadecimal representation (0xRRGGBB format).
         pub fn hex(self: Rgb(T)) u24 {
-            const r: u8 = if (T == u8) self.r else @intFromFloat(@round(clamp(self.r, 0, 1) * 255));
-            const g: u8 = if (T == u8) self.g else @intFromFloat(@round(clamp(self.g, 0, 1) * 255));
-            const b: u8 = if (T == u8) self.b else @intFromFloat(@round(clamp(self.b, 0, 1) * 255));
+            const r: u8 = if (T == u8) self.r else @round(clamp(self.r, 0, 1) * 255);
+            const g: u8 = if (T == u8) self.g else @round(clamp(self.g, 0, 1) * 255);
+            const b: u8 = if (T == u8) self.b else @round(clamp(self.b, 0, 1) * 255);
             return (@as(u24, r) << 16) | (@as(u24, g) << 8) | @as(u24, b);
         }
 
@@ -364,9 +364,9 @@ pub fn Rgb(comptime T: type) type {
                 },
                 else => switch (U) {
                     u8 => .{
-                        .r = @intFromFloat(@round(255 * clamp(self.r, 0, 1))),
-                        .g = @intFromFloat(@round(255 * clamp(self.g, 0, 1))),
-                        .b = @intFromFloat(@round(255 * clamp(self.b, 0, 1))),
+                        .r = @round(255 * clamp(self.r, 0, 1)),
+                        .g = @round(255 * clamp(self.g, 0, 1)),
+                        .b = @round(255 * clamp(self.b, 0, 1)),
                     },
                     else => .{
                         .r = @floatCast(self.r),
@@ -420,10 +420,10 @@ pub fn Rgba(comptime T: type) type {
 
         /// Converts RGBA to 32-bit hexadecimal representation (0xRRGGBBAA format).
         pub fn hex(self: Rgba(T)) u32 {
-            const r: u8 = if (T == u8) self.r else @intFromFloat(@round(clamp(self.r, 0, 1) * 255));
-            const g: u8 = if (T == u8) self.g else @intFromFloat(@round(clamp(self.g, 0, 1) * 255));
-            const b: u8 = if (T == u8) self.b else @intFromFloat(@round(clamp(self.b, 0, 1) * 255));
-            const a: u8 = if (T == u8) self.a else @intFromFloat(@round(clamp(self.a, 0, 1) * 255));
+            const r: u8 = if (T == u8) self.r else @round(clamp(self.r, 0, 1) * 255);
+            const g: u8 = if (T == u8) self.g else @round(clamp(self.g, 0, 1) * 255);
+            const b: u8 = if (T == u8) self.b else @round(clamp(self.b, 0, 1) * 255);
+            const a: u8 = if (T == u8) self.a else @round(clamp(self.a, 0, 1) * 255);
             return (@as(u32, r) << 24) | (@as(u32, g) << 16) | (@as(u32, b) << 8) | @as(u32, a);
         }
 
@@ -437,7 +437,7 @@ pub fn Rgba(comptime T: type) type {
         pub fn fade(self: Rgba(T), alpha: f32) Rgba(T) {
             const scale = clamp(alpha, 0, 1);
             if (T == u8) {
-                const new_a: u8 = @intFromFloat(@as(f32, @floatFromInt(self.a)) * scale);
+                const new_a: u8 = @trunc(@as(f32, @floatFromInt(self.a)) * scale);
                 return .{ .r = self.r, .g = self.g, .b = self.b, .a = new_a };
             } else {
                 const s: T = @as(T, scale);
@@ -484,10 +484,10 @@ pub fn Rgba(comptime T: type) type {
                 },
                 else => switch (U) {
                     u8 => .{
-                        .r = @intFromFloat(@round(255 * clamp(self.r, 0, 1))),
-                        .g = @intFromFloat(@round(255 * clamp(self.g, 0, 1))),
-                        .b = @intFromFloat(@round(255 * clamp(self.b, 0, 1))),
-                        .a = @intFromFloat(@round(255 * clamp(self.a, 0, 1))),
+                        .r = @round(255 * clamp(self.r, 0, 1)),
+                        .g = @round(255 * clamp(self.g, 0, 1)),
+                        .b = @round(255 * clamp(self.b, 0, 1)),
+                        .a = @round(255 * clamp(self.a, 0, 1)),
                     },
                     else => .{
                         .r = @floatCast(self.r),
@@ -541,7 +541,7 @@ pub fn Gray(comptime T: type) type {
                     else => .{ .y = @as(U, @floatFromInt(self.y)) / 255 },
                 },
                 else => switch (U) {
-                    u8 => .{ .y = @intFromFloat(@round(255 * clamp(self.y, 0, 1))) },
+                    u8 => .{ .y = @round(255 * clamp(self.y, 0, 1)) },
                     else => .{ .y = @floatCast(self.y) },
                 },
             };
@@ -952,9 +952,9 @@ pub fn Ycbcr(comptime T: type) type {
                 },
                 else => switch (U) {
                     u8 => .{
-                        .y = @intFromFloat(@round(255 * clamp(self.y, 0, 1))),
-                        .cb = @intFromFloat(@round(255 * clamp(self.cb + 0.5, 0, 1))),
-                        .cr = @intFromFloat(@round(255 * clamp(self.cr + 0.5, 0, 1))),
+                        .y = @round(255 * clamp(self.y, 0, 1)),
+                        .cb = @round(255 * clamp(self.cb + 0.5, 0, 1)),
+                        .cr = @round(255 * clamp(self.cr + 0.5, 0, 1)),
                     },
                     else => .{
                         .y = @floatCast(self.y),
@@ -1021,9 +1021,9 @@ fn rgbToGray(comptime T: type, rgb: Rgb(T)) Gray(T) {
         const b: i32 = rgb.b;
         const scale = 1 << 16;
         const offset = 1 << 15;
-        const yr: i32 = @intFromFloat(@round(luma_r * scale));
-        const yg: i32 = @intFromFloat(@round(luma_g * scale));
-        const yb: i32 = @intFromFloat(@round(luma_b * scale));
+        const yr: i32 = @round(luma_r * scale);
+        const yg: i32 = @round(luma_g * scale);
+        const yb: i32 = @round(luma_b * scale);
         return .{ .y = @intCast(clamp((yr * r + yg * g + yb * b + offset) >> 16, 0, 255)) };
     } else {
         comptime assert(@typeInfo(T) == .float);
@@ -1105,7 +1105,7 @@ fn hslToRgb(comptime T: type, hsl: Hsl(T)) Rgb(T) {
     const l = @max(0, @min(1, hsl.l / 100));
 
     const hue_sector: T = h / 60.0;
-    const sector: usize = @intFromFloat(hue_sector);
+    const sector: usize = @trunc(hue_sector);
     const fractional: T = hue_sector - @as(T, @floatFromInt(sector));
 
     const hue_factors = [_][3]T{
@@ -1175,7 +1175,7 @@ fn hsvToRgb(comptime T: type, hsv: Hsv(T)) Rgb(T) {
     }
 
     const sector = hue * 6;
-    const index: i32 = @intFromFloat(sector);
+    const index: i32 = @trunc(sector);
     const fractional = sector - @as(T, @floatFromInt(index));
     const p = val * (1 - sat);
     const q = val * (1 - (sat * fractional));

--- a/src/fdm.zig
+++ b/src/fdm.zig
@@ -186,14 +186,14 @@ pub fn FeatureDistributionMatching(comptime T: type) type {
                     for (source_img.data) |*pixel| {
                         const val = @as(f64, @floatFromInt(pixel.*)) / 255.0;
                         const result = clamp(val * scale + offset, 0, 1);
-                        pixel.* = @as(u8, @intFromFloat(@round(255.0 * result)));
+                        pixel.* = @round(255.0 * result);
                     }
                 } else {
                     for (source_img.data) |*pixel| {
                         // Color image, target is grayscale: convert to gray then match
                         const val = @as(f64, @floatFromInt(convertColor(u8, pixel.*))) / 255.0;
                         const result = clamp(val * scale + offset, 0, 1);
-                        const res_u8 = @as(u8, @intFromFloat(@round(255.0 * result)));
+                        const res_u8: u8 = @round(255.0 * result);
                         pixel.* = .{ .r = res_u8, .g = res_u8, .b = res_u8 };
                     }
                 }
@@ -266,9 +266,9 @@ pub fn FeatureDistributionMatching(comptime T: type) type {
                     res[1] = r * w.at(0, 1).* + g * w.at(1, 1).* + b * w.at(2, 1).* + bias[1];
                     res[2] = r * w.at(0, 2).* + g * w.at(1, 2).* + b * w.at(2, 2).* + bias[2];
 
-                    pixel.r = @intFromFloat(@round(255.0 * clamp(res[0], 0, 1)));
-                    pixel.g = @intFromFloat(@round(255.0 * clamp(res[1], 0, 1)));
-                    pixel.b = @intFromFloat(@round(255.0 * clamp(res[2], 0, 1)));
+                    pixel.r = @round(255.0 * clamp(res[0], 0, 1));
+                    pixel.g = @round(255.0 * clamp(res[1], 0, 1));
+                    pixel.b = @round(255.0 * clamp(res[2], 0, 1));
                 }
             }
         }

--- a/src/features/Fast.zig
+++ b/src/features/Fast.zig
@@ -169,8 +169,8 @@ fn suppressNonMaximal(self: Fast, keypoints: []const KeyPoint, allocator: Alloca
 
     // Create a grid for spatial binning (faster than O(n²) comparison)
     const grid_size = 20; // pixels per grid cell
-    const max_row = @as(usize, @intFromFloat(keypoints[0].y));
-    const max_col = @as(usize, @intFromFloat(keypoints[0].x));
+    const max_row: usize = @trunc(keypoints[0].y);
+    const max_col: usize = @trunc(keypoints[0].x);
     var min_row = max_row;
     var min_col = max_col;
     var grid_rows: usize = 0;
@@ -178,8 +178,8 @@ fn suppressNonMaximal(self: Fast, keypoints: []const KeyPoint, allocator: Alloca
 
     // Find bounds
     for (keypoints) |kp| {
-        const r = @as(usize, @intFromFloat(kp.y));
-        const c = @as(usize, @intFromFloat(kp.x));
+        const r: usize = @trunc(kp.y);
+        const c: usize = @trunc(kp.x);
         min_row = @min(min_row, r);
         min_col = @min(min_col, c);
         grid_rows = @max(grid_rows, r);
@@ -205,8 +205,8 @@ fn suppressNonMaximal(self: Fast, keypoints: []const KeyPoint, allocator: Alloca
 
     // Bin keypoints into grid
     for (keypoints) |kp| {
-        const r = (@as(usize, @intFromFloat(kp.y)) - min_row) / grid_size;
-        const c = (@as(usize, @intFromFloat(kp.x)) - min_col) / grid_size;
+        const r: usize = (@as(usize, @trunc(kp.y)) - min_row) / grid_size;
+        const c: usize = (@as(usize, @trunc(kp.x)) - min_col) / grid_size;
         const idx = r * grid_cols + c;
         try grid[idx].append(allocator, kp);
     }

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -417,7 +417,7 @@ fn computeFeaturesPerLevel(self: Orb, allocator: Allocator) ![]usize {
 
         // Calculate desired features for this level
         const desired_float = n_features_f * (1.0 - factor) / (1.0 - factor_to_n) * scale_factor_level;
-        const desired_clamped = @min(@as(usize, @intFromFloat(@round(desired_float))), remaining);
+        const desired_clamped: usize = @min(@as(usize, @round(desired_float)), remaining);
 
         // Ensure at least some features per level (except possibly last level)
         // Reduced minimum to allow more flexible distribution, but never exceed remaining budget
@@ -483,8 +483,8 @@ fn computeOrientation(self: Orb, image: Image(u8), kp: KeyPoint) f32 {
     const half_patch = self.patch_size / 2;
     const radius = @as(f32, @floatFromInt(half_patch));
     const radius_sq = radius * radius;
-    const x = @as(isize, @intFromFloat(kp.x));
-    const y = @as(isize, @intFromFloat(kp.y));
+    const x: isize = @trunc(kp.x);
+    const y: isize = @trunc(kp.y);
 
     var m00: f32 = 0; // Zeroth moment
     var m10: f32 = 0; // First moment in x
@@ -564,8 +564,8 @@ fn computeHarrisResponse(image: Image(u8), kp: KeyPoint) f32 {
     const half_window = window_size / 2;
     const k = 0.04; // Harris detector constant
 
-    const x = @as(isize, @intFromFloat(kp.x));
-    const y = @as(isize, @intFromFloat(kp.y));
+    const x: isize = @trunc(kp.x);
+    const y: isize = @trunc(kp.y);
 
     var Ixx: f32 = 0;
     var Iyy: f32 = 0;
@@ -611,8 +611,8 @@ fn computeHarrisResponse(image: Image(u8), kp: KeyPoint) f32 {
 
 /// Sample a pixel with bounds checking
 fn samplePixel(image: Image(u8), x: f32, y: f32) u8 {
-    const ix = @as(isize, @intFromFloat(@round(x)));
-    const iy = @as(isize, @intFromFloat(@round(y)));
+    const ix: isize = @round(x);
+    const iy: isize = @round(y);
 
     if (ix < 0 or ix >= image.cols or iy < 0 or iy >= image.rows) {
         return 0;
@@ -627,7 +627,7 @@ fn computeAdaptiveThreshold(self: Orb, level: usize) u8 {
     const attenuation = 1.0 / level_scale;
     const base_threshold = @as(f32, @floatFromInt(self.fast_threshold));
     const scaled_threshold = std.math.clamp(base_threshold * attenuation, @as(f32, 5.0), @as(f32, 255.0));
-    return @as(u8, @intFromFloat(@round(scaled_threshold)));
+    return @round(scaled_threshold);
 }
 
 // Tests

--- a/src/font/pcf.zig
+++ b/src/font/pcf.zig
@@ -70,10 +70,10 @@ const FormatFlags = struct {
     // Helper to decode format flags from u32
     pub fn decode(format: u32) FormatFlags {
         return FormatFlags{
-            .glyph_pad = @as(u2, @truncate(format & glyph_pad_mask)),
+            .glyph_pad = @truncate(format & glyph_pad_mask),
             .byte_order_msb = (format & byte_order_mask) != 0,
             .bit_order_msb = (format & bit_order_mask) != 0,
-            .scan_unit = @as(u2, @truncate((format & scan_unit_mask) >> scan_unit_shift)),
+            .scan_unit = @truncate((format & scan_unit_mask) >> scan_unit_shift),
             .compressed_metrics = (format & compressed_metrics_mask) != 0,
             .accel_w_inkbounds = (format & accel_w_inkbounds_mask) != 0,
             .ink_bounds = (format & ink_bounds_mask) != 0,
@@ -861,7 +861,7 @@ fn convertToBitmapFont(
             return PcfError.InvalidBitmapData;
         }
         const format_flags = FormatFlags.decode(bitmap_info.format);
-        const pad_bits = @as(u2, @truncate(bitmap_info.format & 0x3));
+        const pad_bits: u2 = @truncate(bitmap_info.format & 0x3);
         const glyph_pad = @as(GlyphPadding, @enumFromInt(pad_bits));
 
         try convertGlyphBitmap(

--- a/src/image.zig
+++ b/src/image.zig
@@ -548,8 +548,8 @@ pub fn Image(comptime T: type) type {
         pub fn scale(self: Self, allocator: Allocator, factor: f32, method: Interpolation) !Self {
             if (factor <= 0) return error.InvalidScaleFactor;
 
-            const new_rows: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(self.rows)) * factor));
-            const new_cols: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(self.cols)) * factor));
+            const new_rows: u32 = @round(@as(f32, @floatFromInt(self.rows)) * factor);
+            const new_cols: u32 = @round(@as(f32, @floatFromInt(self.cols)) * factor);
 
             if (new_rows == 0 or new_cols == 0) return error.InvalidDimensions;
 
@@ -1018,7 +1018,7 @@ pub fn Image(comptime T: type) type {
             if (sigma < 0) return error.InvalidSigma;
 
             // Calculate kernel size (3 sigma on each side)
-            const radius = @as(usize, @intFromFloat(@ceil(3.0 * sigma)));
+            const radius: usize = @ceil(3.0 * sigma);
             const kernel_size = 2 * radius + 1;
 
             // Generate 1D Gaussian kernel

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -159,16 +159,16 @@ pub fn resizePlaneBilinearU8(
     // Process each output pixel
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y_i = @as(isize, @intFromFloat(@floor(src_y_f)));
-        const fy = @as(i32, @intFromFloat((src_y_f - @floor(src_y_f)) * sf));
+        const src_y_i: isize = @floor(src_y_f);
+        const fy: i32 = @trunc((src_y_f - @floor(src_y_f)) * sf);
 
         const y0 = resolveIndex(src_y_i, @intCast(src_rows), .mirror).?;
         const y1 = resolveIndex(src_y_i + 1, @intCast(src_rows), .mirror).?;
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x_i = @as(isize, @intFromFloat(@floor(src_x_f)));
-            const fx = @as(i32, @intFromFloat((src_x_f - @floor(src_x_f)) * sf));
+            const src_x_i: isize = @floor(src_x_f);
+            const fx: i32 = @trunc((src_x_f - @floor(src_x_f)) * sf);
 
             const x0 = resolveIndex(src_x_i, @intCast(src_cols), .mirror).?;
             const x1 = resolveIndex(src_x_i + 1, @intCast(src_cols), .mirror).?;
@@ -203,11 +203,11 @@ pub fn resizePlaneNearestU8(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @max(0, @min(src_rows - 1, @as(u32, @intFromFloat(@round(src_y_f)))));
+        const src_y = @max(0, @min(src_rows - 1, @as(u32, @round(src_y_f))));
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @max(0, @min(src_cols - 1, @as(u32, @intFromFloat(@round(src_x_f)))));
+            const src_x = @max(0, @min(src_cols - 1, @as(u32, @round(src_x_f))));
             dst[r * dst_cols + c] = src[@as(usize, src_y) * src_cols + src_x];
         }
     }
@@ -248,13 +248,13 @@ pub fn resizePlaneBicubicU8(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @as(isize, @intFromFloat(@floor(src_y_f)));
-        const fy = @as(i32, @intFromFloat((src_y_f - @floor(src_y_f)) * SCALE));
+        const src_y: isize = @floor(src_y_f);
+        const fy: i32 = @trunc((src_y_f - @floor(src_y_f)) * SCALE);
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @as(isize, @intFromFloat(@floor(src_x_f)));
-            const fx = @as(i32, @intFromFloat((src_x_f - @floor(src_x_f)) * SCALE));
+            const src_x: isize = @floor(src_x_f);
+            const fx: i32 = @trunc((src_x_f - @floor(src_x_f)) * SCALE);
 
             var sum: i32 = 0;
             var weight_sum: i32 = 0;
@@ -323,13 +323,13 @@ pub fn resizePlaneCatmullRomU8(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @as(isize, @intFromFloat(@floor(src_y_f)));
-        const fy = @as(i32, @intFromFloat((src_y_f - @floor(src_y_f)) * SCALE));
+        const src_y: isize = @floor(src_y_f);
+        const fy: i32 = @trunc((src_y_f - @floor(src_y_f)) * SCALE);
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @as(isize, @intFromFloat(@floor(src_x_f)));
-            const fx = @as(i32, @intFromFloat((src_x_f - @floor(src_x_f)) * SCALE));
+            const src_x: isize = @floor(src_x_f);
+            const fx: i32 = @trunc((src_x_f - @floor(src_x_f)) * SCALE);
 
             var sum: i32 = 0;
             var weight_sum: i32 = 0;
@@ -399,13 +399,13 @@ pub fn resizePlaneMitchellU8(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @as(isize, @intFromFloat(@floor(src_y_f)));
-        const fy = @as(i32, @intFromFloat((src_y_f - @floor(src_y_f)) * s));
+        const src_y: isize = @floor(src_y_f);
+        const fy: i32 = @trunc((src_y_f - @floor(src_y_f)) * s);
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @as(isize, @intFromFloat(@floor(src_x_f)));
-            const fx = @as(i32, @intFromFloat((src_x_f - @floor(src_x_f)) * s));
+            const src_x: isize = @floor(src_x_f);
+            const fx: i32 = @trunc((src_x_f - @floor(src_x_f)) * s);
 
             var sum: i32 = 0;
             var weight_sum: i32 = 0;
@@ -459,12 +459,12 @@ pub fn resizePlaneLanczosU8(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @as(isize, @intFromFloat(@floor(src_y_f)));
+        const src_y: isize = @floor(src_y_f);
         const fy = src_y_f - @floor(src_y_f);
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @as(isize, @intFromFloat(@floor(src_x_f)));
+            const src_x: isize = @floor(src_x_f);
             const fx = src_x_f - @floor(src_x_f);
 
             var sum: f32 = 0;
@@ -510,11 +510,11 @@ pub fn resizePlaneF32(
 
             for (0..dst_rows) |r| {
                 const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-                const src_y = @max(0, @min(src_rows - 1, @as(u32, @intFromFloat(@round(src_y_f)))));
+                const src_y = @max(0, @min(src_rows - 1, @as(u32, @round(src_y_f))));
 
                 for (0..dst_cols) |c| {
                     const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-                    const src_x = @max(0, @min(src_cols - 1, @as(u32, @intFromFloat(@round(src_x_f)))));
+                    const src_x = @max(0, @min(src_cols - 1, @as(u32, @round(src_x_f))));
                     dst[r * dst_cols + c] = src[@as(usize, src_y) * src_cols + src_x];
                 }
             }
@@ -525,13 +525,13 @@ pub fn resizePlaneF32(
 
             for (0..dst_rows) |r| {
                 const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-                const src_y = @as(u32, @intFromFloat(@floor(src_y_f)));
+                const src_y: u32 = @floor(src_y_f);
                 const src_y_next = resolveIndex(@intCast(src_y + 1), @intCast(src_rows), .mirror).?;
                 const fy = src_y_f - @floor(src_y_f);
 
                 for (0..dst_cols) |c| {
                     const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-                    const src_x = @as(u32, @intFromFloat(@floor(src_x_f)));
+                    const src_x: u32 = @floor(src_x_f);
                     const src_x_next = resolveIndex(@intCast(src_x + 1), @intCast(src_cols), .mirror).?;
                     const fx = src_x_f - @floor(src_x_f);
 
@@ -579,12 +579,12 @@ fn resizePlaneBicubicF32(
 
     for (0..dst_rows) |r| {
         const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @as(isize, @intFromFloat(@floor(src_y_f)));
+        const src_y: isize = @floor(src_y_f);
         const fy = src_y_f - @floor(src_y_f);
 
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @as(isize, @intFromFloat(@floor(src_x_f)));
+            const src_x: isize = @floor(src_x_f);
             const fx = src_x_f - @floor(src_x_f);
 
             var sum: f32 = 0;

--- a/src/image/colormaps.zig
+++ b/src/image/colormaps.zig
@@ -41,7 +41,7 @@ pub const Colormap = union(enum) {
 /// Logic ported from dlib.
 pub fn jet(value: f64, min_val: f64, max_val: f64) Rgb {
     const t = meta.normalize(f64, value, min_val, max_val);
-    const index: usize = @intFromFloat(@round(t * 255.0));
+    const index: usize = @round(t * 255.0);
     const color = jet_lut[index];
     return .{ .r = color[0], .g = color[1], .b = color[2] };
 }
@@ -50,7 +50,7 @@ pub fn jet(value: f64, min_val: f64, max_val: f64) Rgb {
 /// Logic ported from dlib.
 pub fn heat(value: f64, min_val: f64, max_val: f64) Rgb {
     const t = meta.normalize(f64, value, min_val, max_val);
-    const index: usize = @intFromFloat(@round(t * 255.0));
+    const index: usize = @round(t * 255.0);
     const color = heat_lut[index];
     return .{ .r = color[0], .g = color[1], .b = color[2] };
 }
@@ -59,7 +59,7 @@ pub fn heat(value: f64, min_val: f64, max_val: f64) Rgb {
 /// Uses a 256-entry lookup table generated at comptime.
 pub fn turbo(value: f64, min_val: f64, max_val: f64) Rgb {
     const t = meta.normalize(f64, value, min_val, max_val);
-    const index: usize = @intFromFloat(@round(t * 255.0));
+    const index: usize = @round(t * 255.0);
     const color = turbo_lut[index];
     return .{ .r = color[0], .g = color[1], .b = color[2] };
 }
@@ -68,7 +68,7 @@ pub fn turbo(value: f64, min_val: f64, max_val: f64) Rgb {
 /// Uses a 256-entry lookup table.
 pub fn viridis(value: f64, min_val: f64, max_val: f64) Rgb {
     const t = meta.normalize(f64, value, min_val, max_val);
-    const index: usize = @intFromFloat(@round(t * 255.0));
+    const index: usize = @round(t * 255.0);
     const color = viridis_lut[index];
     return .{ .r = color[0], .g = color[1], .b = color[2] };
 }
@@ -88,21 +88,21 @@ fn jetEval(t: f64) [3]u8 {
     if (gray <= 1) {
         r = 0;
         g = 0;
-        b = @intFromFloat(@round((gray + 1) * s * 255.0));
+        b = @round((gray + 1) * s * 255.0);
     } else if (gray <= 3) {
         r = 0;
-        g = @intFromFloat(@round((gray - 1) * s * 255.0));
+        g = @round((gray - 1) * s * 255.0);
         b = 255;
     } else if (gray <= 5) {
-        r = @intFromFloat(@round((gray - 3) * s * 255.0));
+        r = @round((gray - 3) * s * 255.0);
         g = 255;
-        b = @intFromFloat(@round((5 - gray) * s * 255.0));
+        b = @round((5 - gray) * s * 255.0);
     } else if (gray <= 7) {
         r = 255;
-        g = @intFromFloat(@round((7 - gray) * s * 255.0));
+        g = @round((7 - gray) * s * 255.0);
         b = 0;
     } else {
-        r = @intFromFloat(@round((9 - gray) * s * 255.0));
+        r = @round((9 - gray) * s * 255.0);
         g = 0;
         b = 0;
     }
@@ -119,15 +119,15 @@ const jet_lut = blk: {
 };
 
 fn heatEval(t: f64) [3]u8 {
-    const r = @as(u8, @intFromFloat(@round(@min(t / 0.4, 1.0) * 255.0)));
+    const r: u8 = @round(@min(t / 0.4, 1.0) * 255.0);
     var g: u8 = 0;
     var b: u8 = 0;
 
     if (t > 0.4) {
-        g = @intFromFloat(@round(@min((t - 0.4) / 0.4, 1.0) * 255.0));
+        g = @round(@min((t - 0.4) / 0.4, 1.0) * 255.0);
     }
     if (t > 0.8) {
-        b = @intFromFloat(@round(@min((t - 0.8) / 0.2, 1.0) * 255.0));
+        b = @round(@min((t - 0.8) / 0.2, 1.0) * 255.0);
     }
     return .{ r, g, b };
 }
@@ -160,9 +160,9 @@ fn turboEval(t: f64) [3]u8 {
     const b_val = @reduce(.Add, v * b_coeffs);
 
     return .{
-        @intFromFloat(@round(math.clamp(r_val, 0.0, 1.0) * 255.0)),
-        @intFromFloat(@round(math.clamp(g_val, 0.0, 1.0) * 255.0)),
-        @intFromFloat(@round(math.clamp(b_val, 0.0, 1.0) * 255.0)),
+        @round(math.clamp(r_val, 0.0, 1.0) * 255.0),
+        @round(math.clamp(g_val, 0.0, 1.0) * 255.0),
+        @round(math.clamp(b_val, 0.0, 1.0) * 255.0),
     };
 }
 

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -92,7 +92,7 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                 inline for (0..kernel_width) |kx| {
                     const val = as(f32, kernel[kr][kx]);
                     result[idx] = if (T == u8)
-                        @intFromFloat(@round(val * 256.0))
+                        @round(val * 256.0)
                     else
                         val;
                     idx += 1;
@@ -292,7 +292,7 @@ pub fn convolve(comptime T: type, self: Image(T), allocator: Allocator, kernel: 
 fn scaleKernelToInt(allocator: Allocator, kernel: []const f32, scale: comptime_int) ![]i32 {
     const result = try allocator.alloc(i32, kernel.len);
     for (kernel, 0..) |k, i| {
-        result[i] = @intFromFloat(@round(k * scale));
+        result[i] = @round(k * scale);
     }
     return result;
 }

--- a/src/image/edges.zig
+++ b/src/image/edges.zig
@@ -70,7 +70,7 @@ pub fn Edges(comptime T: type) type {
                         // Scale by 1/4 to match typical Sobel output range
                         // Max theoretical magnitude is ~1442, so /4 maps to ~360 max
                         const scaled = magnitude / 4.0;
-                        out.at(r, c).* = @intFromFloat(@max(0, @min(255, scaled)));
+                        out.at(r, c).* = @trunc(@max(0, @min(255, scaled)));
                     }
                 }
             }
@@ -149,7 +149,7 @@ pub fn Edges(comptime T: type) type {
                     var g = gradients.at(rr, cc).*;
                     if (g < 0) g = 0;
                     if (g > 255) g = 255;
-                    const bin: usize = @intFromFloat(@round(g));
+                    const bin: usize = @round(g);
                     hist[bin] += 1;
                     total += 1;
                 }
@@ -163,7 +163,7 @@ pub fn Edges(comptime T: type) type {
                 }
                 return;
             }
-            const target: usize = @intFromFloat(@floor(@as(f32, @floatFromInt(total)) * opts.high_ratio));
+            const target: usize = @floor(@as(f32, @floatFromInt(total)) * opts.high_ratio);
             var cum: usize = 0;
             var idx: usize = 0;
             while (idx < 256 and cum < target) : (idx += 1) {
@@ -673,7 +673,7 @@ fn nonMaxSuppressEdges(
 /// Uses separable convolution for efficiency.
 fn blurGaussian(src: Image(f32), sigma: f32, dst: Image(f32), allocator: Allocator) !void {
     // Calculate kernel size (3 sigma on each side)
-    const radius = @as(usize, @intFromFloat(@ceil(3.0 * sigma)));
+    const radius: usize = @ceil(3.0 * sigma);
     const kernel_size = 2 * radius + 1;
 
     // Generate 1D Gaussian kernel

--- a/src/image/enhancement.zig
+++ b/src/image/enhancement.zig
@@ -35,7 +35,7 @@ pub fn Enhancement(comptime T: type) type {
                             const val = image.at(r, c).*;
                             const clamped = @max(min_val, @min(max_val, val));
                             const normalized = @as(f32, @floatFromInt(clamped - min_val)) / @as(f32, @floatFromInt(range));
-                            image.at(r, c).* = @trunc(normalized * 255.0);
+                            image.at(r, c).* = @round(normalized * 255.0);
                         }
                     }
                 },
@@ -59,7 +59,7 @@ pub fn Enhancement(comptime T: type) type {
                                         const clamped = @max(min, @min(max, val));
                                         const range = if (max > min) max - min else 1;
                                         const normalized = @as(f32, @floatFromInt(clamped - min)) / @as(f32, @floatFromInt(range));
-                                        return @trunc(normalized * 255.0);
+                                        return @round(normalized * 255.0);
                                     }
                                 }.apply;
 

--- a/src/image/enhancement.zig
+++ b/src/image/enhancement.zig
@@ -17,7 +17,7 @@ pub fn Enhancement(comptime T: type) type {
             }
 
             const total_pixels = image.rows * image.cols;
-            const cutoff_pixels = @as(usize, @intFromFloat(@as(f32, @floatFromInt(total_pixels)) * cutoff));
+            const cutoff_pixels: usize = @trunc(@as(f32, @floatFromInt(total_pixels)) * cutoff);
 
             switch (@typeInfo(T)) {
                 .int => {
@@ -35,7 +35,7 @@ pub fn Enhancement(comptime T: type) type {
                             const val = image.at(r, c).*;
                             const clamped = @max(min_val, @min(max_val, val));
                             const normalized = @as(f32, @floatFromInt(clamped - min_val)) / @as(f32, @floatFromInt(range));
-                            image.at(r, c).* = @intFromFloat(normalized * 255.0);
+                            image.at(r, c).* = @trunc(normalized * 255.0);
                         }
                     }
                 },
@@ -59,7 +59,7 @@ pub fn Enhancement(comptime T: type) type {
                                         const clamped = @max(min, @min(max, val));
                                         const range = if (max > min) max - min else 1;
                                         const normalized = @as(f32, @floatFromInt(clamped - min)) / @as(f32, @floatFromInt(range));
-                                        return @intFromFloat(normalized * 255.0);
+                                        return @trunc(normalized * 255.0);
                                     }
                                 }.apply;
 

--- a/src/image/histogram.zig
+++ b/src/image/histogram.zig
@@ -41,7 +41,7 @@ pub fn Histogram(comptime T: type) type {
             /// Calculate the mean value from the histogram
             pub fn mean(self: Self) u8 {
                 const mean_val = stats.mean(&self.values);
-                return @intFromFloat(@round(mean_val));
+                return @round(mean_val);
             }
 
             /// Calculate the median value from the histogram
@@ -193,9 +193,9 @@ pub fn Histogram(comptime T: type) type {
             /// Calculate the mean value for each channel
             pub fn mean(self: Self) Rgb {
                 return .{
-                    .r = @intFromFloat(@round(stats.mean(&self.r))),
-                    .g = @intFromFloat(@round(stats.mean(&self.g))),
-                    .b = @intFromFloat(@round(stats.mean(&self.b))),
+                    .r = @round(stats.mean(&self.r)),
+                    .g = @round(stats.mean(&self.g)),
+                    .b = @round(stats.mean(&self.b)),
                 };
             }
 
@@ -336,10 +336,10 @@ pub fn Histogram(comptime T: type) type {
             /// Calculate the mean value for each channel
             pub fn mean(self: Self) Rgba {
                 return .{
-                    .r = @intFromFloat(@round(stats.mean(&self.r))),
-                    .g = @intFromFloat(@round(stats.mean(&self.g))),
-                    .b = @intFromFloat(@round(stats.mean(&self.b))),
-                    .a = @intFromFloat(@round(stats.mean(&self.a))),
+                    .r = @round(stats.mean(&self.r)),
+                    .g = @round(stats.mean(&self.g)),
+                    .b = @round(stats.mean(&self.b)),
+                    .a = @round(stats.mean(&self.a)),
                 };
             }
 
@@ -595,7 +595,8 @@ const stats = struct {
         const total_minus_one = total - 1;
         const rank_f = p * @as(f64, @floatFromInt(total_minus_one));
         const rank_floor = std.math.floor(rank_f + 1e-12);
-        const rank = std.math.clamp(@as(usize, @intFromFloat(rank_floor)), 0, total_minus_one);
+        const rank_trunc: usize = @trunc(rank_floor);
+        const rank = std.math.clamp(rank_trunc, 0, total_minus_one);
 
         var cumulative: usize = 0;
 

--- a/src/image/hough.zig
+++ b/src/image/hough.zig
@@ -51,8 +51,8 @@ pub const HoughTransform = struct {
 
         for (0..size) |t| {
             const theta = @as(f64, @floatFromInt(t)) * math.pi / @as(f64, @floatFromInt(even_size));
-            cos_table[t] = @intFromFloat(scale * @cos(theta) / sqrt_2);
-            sin_table[t] = @intFromFloat(scale * @sin(theta) / sqrt_2);
+            cos_table[t] = @trunc(scale * @cos(theta) / sqrt_2);
+            sin_table[t] = @trunc(scale * @sin(theta) / sqrt_2);
         }
 
         return .{
@@ -82,7 +82,7 @@ pub const HoughTransform = struct {
         const size_minus_one: i32 = @intCast(self.size - 1);
         const box_t: i32 = @intCast(box.t);
         const box_l: i32 = @intCast(box.l);
-        const offset = @as(i32, @intFromFloat(((1 << 16) * @as(f64, @floatFromInt(self.even_size)) / 4.0) + 0.5));
+        const offset: i32 = @trunc(((1 << 16) * @as(f64, @floatFromInt(self.even_size)) / 4.0) + 0.5);
 
         // Use a local slice for faster access and to avoid bounds checks in the hot loop
         const cos_table = self.cos_table;

--- a/src/image/hough.zig
+++ b/src/image/hough.zig
@@ -82,7 +82,7 @@ pub const HoughTransform = struct {
         const size_minus_one: i32 = @intCast(self.size - 1);
         const box_t: i32 = @intCast(box.t);
         const box_l: i32 = @intCast(box.l);
-        const offset: i32 = @trunc(((1 << 16) * @as(f64, @floatFromInt(self.even_size)) / 4.0) + 0.5);
+        const offset: i32 = @round(((1 << 16) * @as(f64, @floatFromInt(self.even_size)) / 4.0));
 
         // Use a local slice for faster access and to avoid bounds checks in the hot loop
         const cos_table = self.cos_table;

--- a/src/image/integral.zig
+++ b/src/image/integral.zig
@@ -313,7 +313,7 @@ pub fn Integral(comptime T: type) type {
                                 @field(dst.at(r, c).*, f.name) = switch (@typeInfo(f.type)) {
                                     .int => blk: {
                                         const sharpened_val = 2 * as(f32, original) - blurred;
-                                        break :blk @intFromFloat(@max(std.math.minInt(f.type), @min(std.math.maxInt(f.type), @round(sharpened_val))));
+                                        break :blk @trunc(@max(std.math.minInt(f.type), @min(std.math.maxInt(f.type), @round(sharpened_val))));
                                     },
                                     .float => as(f.type, 2 * as(f32, original) - blurred),
                                     else => @compileError("Can't compute sharpen with struct fields of type " ++ @typeName(f.type) ++ "."),

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -292,7 +292,7 @@ fn lanczos3KernelLut(x: f32) f32 {
 
     const step = 1024.0 / 3.0;
     const pos = ax * step;
-    const idx: usize = @intFromFloat(pos);
+    const idx: usize = @trunc(pos);
     const frac = pos - @as(f32, @floatFromInt(idx));
 
     return lanczos3_lut[idx] * (1.0 - frac) + lanczos3_lut[idx + 1] * frac;
@@ -323,15 +323,15 @@ fn mitchellKernel(x: f32, m_b: f32, m_c: f32) f32 {
 // ============================================================================
 
 fn interpolateNearestNeighbor(comptime T: type, self: Image(T), x: f32, y: f32, border: BorderMode) ?T {
-    const col = resolveIndex(@intFromFloat(@round(x)), @intCast(self.cols), border) orelse return null;
-    const row = resolveIndex(@intFromFloat(@round(y)), @intCast(self.rows), border) orelse return null;
+    const col = resolveIndex(@round(x), @intCast(self.cols), border) orelse return null;
+    const row = resolveIndex(@round(y), @intCast(self.rows), border) orelse return null;
 
     return self.at(row, col).*;
 }
 
 fn interpolateBilinear(comptime T: type, self: Image(T), x: f32, y: f32, border: BorderMode) ?T {
-    const left: isize = @intFromFloat(@floor(x));
-    const top: isize = @intFromFloat(@floor(y));
+    const left: isize = @floor(x);
+    const top: isize = @floor(y);
     const right = left + 1;
     const bottom = top + 1;
 
@@ -366,8 +366,8 @@ fn interpolateBilinear(comptime T: type, self: Image(T), x: f32, y: f32, border:
     const tb_frac: f32 = y - as(f32, top);
 
     const scale = 256;
-    const fx: i32 = @intFromFloat(@round(lr_frac * scale));
-    const fy: i32 = @intFromFloat(@round(tb_frac * scale));
+    const fx: i32 = @round(lr_frac * scale);
+    const fy: i32 = @round(tb_frac * scale);
 
     const lerpInt = struct {
         fn lerp(comptime P: type, p_tl: P, p_tr: P, p_bl: P, p_br: P, p_fx: i32, p_fy: i32) P {
@@ -452,8 +452,8 @@ fn interpolateWithKernel(
     kernel_params: anytype,
     border: BorderMode,
 ) ?T {
-    const ix: isize = @intFromFloat(@floor(x));
-    const iy: isize = @intFromFloat(@floor(y));
+    const ix: isize = @floor(x);
+    const iy: isize = @floor(y);
     const fx = x - as(f32, ix);
     const fy = y - as(f32, iy);
 

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -143,9 +143,9 @@ pub fn MotionBlurOps(comptime T: type) type {
                                         sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
                                     {
                                         // Bilinear interpolation
-                                        const x0 = @as(usize, @intFromFloat(@floor(sample_x)));
+                                        const x0: usize = @floor(sample_x);
                                         const x1 = @min(x0 + 1, image.cols - 1);
-                                        const y0 = @as(usize, @intFromFloat(@floor(sample_y)));
+                                        const y0: usize = @floor(sample_y);
                                         const y1 = @min(y0 + 1, image.rows - 1);
 
                                         const fx = sample_x - @as(f32, @floatFromInt(x0));
@@ -168,7 +168,7 @@ pub fn MotionBlurOps(comptime T: type) type {
 
                                 const result = if (count > 0) sum / count else as(f32, image.at(r, c).*);
                                 out.at(r, c).* = switch (@typeInfo(T)) {
-                                    .int => @intFromFloat(@max(std.math.minInt(T), @min(std.math.maxInt(T), @round(result)))),
+                                    .int => @trunc(@max(std.math.minInt(T), @min(std.math.maxInt(T), @round(result)))),
                                     .float => as(T, result),
                                     else => unreachable,
                                 };
@@ -201,9 +201,9 @@ pub fn MotionBlurOps(comptime T: type) type {
                                             sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
                                         {
                                             // Bilinear interpolation
-                                            const x0 = @as(usize, @intFromFloat(@floor(sample_x)));
+                                            const x0: usize = @floor(sample_x);
                                             const x1 = @min(x0 + 1, image.cols - 1);
-                                            const y0 = @as(usize, @intFromFloat(@floor(sample_y)));
+                                            const y0: usize = @floor(sample_y);
                                             const y1 = @min(y0 + 1, image.rows - 1);
 
                                             const fx = sample_x - @as(f32, @floatFromInt(x0));
@@ -226,7 +226,7 @@ pub fn MotionBlurOps(comptime T: type) type {
 
                                     const channel_result = if (count > 0) sum / count else as(f32, @field(image.at(r, c).*, field.name));
                                     @field(result_pixel, field.name) = switch (@typeInfo(field.type)) {
-                                        .int => @intFromFloat(@max(std.math.minInt(field.type), @min(std.math.maxInt(field.type), @round(channel_result)))),
+                                        .int => @trunc(@max(std.math.minInt(field.type), @min(std.math.maxInt(field.type), @round(channel_result)))),
                                         .float => as(field.type, channel_result),
                                         else => @compileError("Unsupported field type"),
                                     };
@@ -275,7 +275,7 @@ pub fn MotionBlurOps(comptime T: type) type {
             // Calculate number of samples based on strength
             const base_samples = 8;
             const max_additional_samples = 24;
-            const num_samples = base_samples + @as(usize, @intFromFloat(clamped_strength * @as(f32, @floatFromInt(max_additional_samples))));
+            const num_samples: usize = base_samples + @as(usize, @trunc(clamped_strength * @as(f32, @floatFromInt(max_additional_samples))));
 
             switch (@typeInfo(T)) {
                 .int, .float => {
@@ -326,9 +326,9 @@ pub fn MotionBlurOps(comptime T: type) type {
                                     sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
                                 {
                                     // Bilinear interpolation
-                                    const x0 = @as(usize, @intFromFloat(@floor(sample_x)));
+                                    const x0: usize = @floor(sample_x);
                                     const x1 = @min(x0 + 1, image.cols - 1);
-                                    const y0 = @as(usize, @intFromFloat(@floor(sample_y)));
+                                    const y0: usize = @floor(sample_y);
                                     const y1 = @min(y0 + 1, image.rows - 1);
 
                                     const fx_interp = sample_x - @as(f32, @floatFromInt(x0));
@@ -350,7 +350,7 @@ pub fn MotionBlurOps(comptime T: type) type {
 
                             const result = if (count > 0) sum / @as(f32, @floatFromInt(count)) else as(f32, image.at(r, c).*);
                             out.at(r, c).* = switch (@typeInfo(T)) {
-                                .int => @intFromFloat(@max(std.math.minInt(T), @min(std.math.maxInt(T), @round(result)))),
+                                .int => @trunc(@max(std.math.minInt(T), @min(std.math.maxInt(T), @round(result)))),
                                 .float => as(T, result),
                                 else => unreachable,
                             };
@@ -409,9 +409,9 @@ pub fn MotionBlurOps(comptime T: type) type {
                                         sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
                                     {
                                         // Bilinear interpolation
-                                        const x0 = @as(usize, @intFromFloat(@floor(sample_x)));
+                                        const x0: usize = @floor(sample_x);
                                         const x1 = @min(x0 + 1, image.cols - 1);
-                                        const y0 = @as(usize, @intFromFloat(@floor(sample_y)));
+                                        const y0: usize = @floor(sample_y);
                                         const y1 = @min(y0 + 1, image.rows - 1);
 
                                         const fx_interp = sample_x - @as(f32, @floatFromInt(x0));
@@ -433,7 +433,7 @@ pub fn MotionBlurOps(comptime T: type) type {
 
                                 const channel_result = if (count > 0) sum / @as(f32, @floatFromInt(count)) else as(f32, @field(image.at(r, c).*, field.name));
                                 @field(result_pixel, field.name) = switch (@typeInfo(field.type)) {
-                                    .int => @intFromFloat(@max(std.math.minInt(field.type), @min(std.math.maxInt(field.type), @round(channel_result)))),
+                                    .int => @trunc(@max(std.math.minInt(field.type), @min(std.math.maxInt(field.type), @round(channel_result)))),
                                     .float => as(field.type, channel_result),
                                     else => @compileError("Unsupported field type"),
                                 };

--- a/src/image/order_statistic_blur.zig
+++ b/src/image/order_statistic_blur.zig
@@ -369,7 +369,7 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
             fn compute(self: *const @This(), hist: *const Histogram(u8), window_area: usize) Error!u8 {
                 const total_f = @as(f64, @floatFromInt(window_area));
                 const trimmed_total = @floor(self.trim_fraction * total_f);
-                const trimmed_each = @as(usize, @intFromFloat(trimmed_total));
+                const trimmed_each: usize = @trunc(trimmed_total);
                 const trim_each = @min(trimmed_each, window_area / 2);
 
                 var total_sum: u64 = 0;

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -56,8 +56,8 @@ pub fn ImagePyramid(comptime T: type) type {
             for (1..n_levels) |i| {
                 // Calculate dimensions for this level
                 const scale = std.math.pow(f32, scale_factor, @as(f32, @floatFromInt(i)));
-                const new_rows = @max(1, @as(u32, @intFromFloat(@as(f32, @floatFromInt(source.rows)) / scale)));
-                const new_cols = @max(1, @as(u32, @intFromFloat(@as(f32, @floatFromInt(source.cols)) / scale)));
+                const new_rows: u32 = @max(1, @as(u32, @trunc(@as(f32, @floatFromInt(source.rows)) / scale)));
+                const new_cols: u32 = @max(1, @as(u32, @trunc(@as(f32, @floatFromInt(source.cols)) / scale)));
 
                 // Skip if image becomes too small
                 if (new_rows < 8 or new_cols < 8) {

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -357,11 +357,10 @@ test "insert and extract inverse relationship" {
 
         var total_error: u32 = 0;
         var pixel_count: u32 = 0;
-
-        const start_r = @as(usize, @intFromFloat(cy - check_size / 2));
-        const end_r = @as(usize, @intFromFloat(cy + check_size / 2));
-        const start_c = @as(usize, @intFromFloat(cx - check_size / 2));
-        const end_c = @as(usize, @intFromFloat(cx + check_size / 2));
+        const start_r: usize = @trunc(cy - check_size / 2);
+        const end_r: usize = @trunc(cy + check_size / 2);
+        const start_c: usize = @trunc(cx - check_size / 2);
+        const end_c: usize = @trunc(cx + check_size / 2);
 
         for (start_r..end_r) |r| {
             for (start_c..end_c) |c| {

--- a/src/image/transforms.zig
+++ b/src/image/transforms.zig
@@ -84,8 +84,8 @@ pub fn Transform(comptime T: type) type {
             const aspect_scale = @min(rows_scale, cols_scale);
 
             // Calculate dimensions of the scaled image (ensure at least 1 pixel)
-            const scaled_rows: u32 = @intFromFloat(@round(aspect_scale * @as(f32, @floatFromInt(self.rows))));
-            const scaled_cols: u32 = @intFromFloat(@round(aspect_scale * @as(f32, @floatFromInt(self.cols))));
+            const scaled_rows: u32 = @round(aspect_scale * @as(f32, @floatFromInt(self.rows)));
+            const scaled_cols: u32 = @round(aspect_scale * @as(f32, @floatFromInt(self.cols)));
 
             // Calculate offset to center the image
             const offset_row = (out.rows -| scaled_rows) / 2;
@@ -153,8 +153,8 @@ pub fn Transform(comptime T: type) type {
             const new_w = w * cos_abs + h * sin_abs;
             const new_h = h * cos_abs + w * sin_abs;
             return .{
-                .cols = @intFromFloat(@ceil(new_w)),
-                .rows = @intFromFloat(@ceil(new_h)),
+                .cols = @ceil(new_w),
+                .rows = @ceil(new_h),
             };
         }
 
@@ -244,10 +244,10 @@ pub fn Transform(comptime T: type) type {
         /// - `allocator`: The allocator to use for the cropped image's data.
         /// - `rectangle`: The `Rectangle(f32)` defining the region to crop. Coordinates will be rounded.
         pub fn crop(self: Self, allocator: Allocator, rectangle: Rectangle(f32)) !Self {
-            const chip_top: i32 = @intFromFloat(@round(rectangle.t));
-            const chip_left: i32 = @intFromFloat(@round(rectangle.l));
-            const chip_rows: u32 = @intFromFloat(@round(rectangle.height()));
-            const chip_cols: u32 = @intFromFloat(@round(rectangle.width()));
+            const chip_top: i32 = @round(rectangle.t);
+            const chip_left: i32 = @round(rectangle.l);
+            const chip_rows: u32 = @round(rectangle.height());
+            const chip_cols: u32 = @round(rectangle.width());
 
             const chip = try Self.init(allocator, chip_rows, chip_cols);
             copyRect(self, chip_top, chip_left, chip, .zero);
@@ -283,8 +283,8 @@ pub fn Transform(comptime T: type) type {
                 @abs(height - frows) < epsilon)
             {
                 // Use the same logic as crop
-                const rect_top: i32 = @intFromFloat(@round(rect.t));
-                const rect_left: i32 = @intFromFloat(@round(rect.l));
+                const rect_top: i32 = @round(rect.t);
+                const rect_left: i32 = @round(rect.l);
                 copyRect(self, rect_top, rect_left, out, border);
                 return;
             }
@@ -355,8 +355,8 @@ pub fn Transform(comptime T: type) type {
                 @abs(rect_width - fcols) < epsilon and
                 @abs(rect_height - frows) < epsilon)
             {
-                const dst_top: i32 = @intFromFloat(@round(rect.t));
-                const dst_left: i32 = @intFromFloat(@round(rect.l));
+                const dst_top: i32 = @round(rect.t);
+                const dst_left: i32 = @round(rect.l);
                 for (0..source.rows) |r| {
                     const y: i32 = dst_top + @as(i32, @intCast(r));
                     for (0..source.cols) |c| {
@@ -387,10 +387,10 @@ pub fn Transform(comptime T: type) type {
             const bound_hw = half_width * abs_cos + half_height * abs_sin;
             const bound_hh = half_width * abs_sin + half_height * abs_cos;
 
-            const min_r = if (cy - bound_hh < 0) 0 else @as(u32, @intFromFloat(@floor(cy - bound_hh)));
-            const max_r = @min(@as(u32, self.rows), @as(u32, @intFromFloat(@ceil(cy + bound_hh))) + 1);
-            const min_c = if (cx - bound_hw < 0) 0 else @as(u32, @intFromFloat(@floor(cx - bound_hw)));
-            const max_c = @min(@as(u32, self.cols), @as(u32, @intFromFloat(@ceil(cx + bound_hw))) + 1);
+            const min_r: u32 = if (cy - bound_hh < 0) 0 else @as(u32, @floor(cy - bound_hh));
+            const max_r: u32 = @min(self.rows, @as(u32, @ceil(cy + bound_hh)) + 1);
+            const min_c: u32 = if (cx - bound_hw < 0) 0 else @as(u32, @floor(cx - bound_hw));
+            const max_c: u32 = @min(self.cols, @as(u32, @ceil(cx + bound_hw)) + 1);
 
             // Only iterate over potentially affected pixels
             for (min_r..max_r) |r| {

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -547,7 +547,7 @@ fn magnitudeBits(value: i32, mag: u5) u32 {
 
 // LLM DCT constants in 13-bit fixed point (CONST_BITS = 13)
 inline fn FIX(comptime x: f32) i32 {
-    return @as(i32, @intFromFloat(x * (1 << 13) + 0.5));
+    return @trunc(x * (1 << 13) + 0.5);
 }
 
 const FIX_0_298631336: i32 = FIX(0.298631336);
@@ -693,7 +693,7 @@ fn buildQuantRecipLLM(divisors_out: *[64]u32, qtbl: *const [64]u8) void {
         const q = @as(f64, @floatFromInt(qtbl[idx]));
         const scale = 8.0; // Overall factor of 8 from the DCT
         const recip_f = (@as(f64, @floatFromInt(1 << RECIP_SHIFT))) / (q * scale);
-        const recip_u: u32 = @intFromFloat(@round(@max(0.0, @min(4_294_967_295.0, recip_f))));
+        const recip_u: u32 = @round(@max(0.0, @min(4_294_967_295.0, recip_f)));
         divisors_out[idx] = recip_u;
     }
 }
@@ -1719,9 +1719,9 @@ fn yCbCrToRgbBlock(_: *JpegState, y_block: *[64]i32, cb_block: *const [64]i32, c
         g_vec = std.math.clamp(g_vec, vec_0, vec_255);
         b_vec = std.math.clamp(b_vec, vec_0, vec_255);
 
-        const r_u8: @Vector(8, u8) = @intFromFloat(r_vec);
-        const g_u8: @Vector(8, u8) = @intFromFloat(g_vec);
-        const b_u8: @Vector(8, u8) = @intFromFloat(b_vec);
+        const r_u8: @Vector(8, u8) = @trunc(r_vec);
+        const g_u8: @Vector(8, u8) = @trunc(g_vec);
+        const b_u8: @Vector(8, u8) = @trunc(b_vec);
 
         var r_array: [8]u8 = undefined;
         var g_array: [8]u8 = undefined;
@@ -2283,7 +2283,7 @@ pub const JpegError = error{
 // IDCT implementation based on stb_image
 fn f2f(comptime x: f32) i32 {
     // 4096 = 1 << 12
-    return @intFromFloat(x * 4096 + 0.5);
+    return @trunc(x * 4096 + 0.5);
 }
 
 fn idct1D(s0: i32, s1: i32, s2: i32, s3: i32, s4: i32, s5: i32, s6: i32, s7: i32) struct { i32, i32, i32, i32, i32, i32, i32, i32 } {
@@ -2484,8 +2484,8 @@ fn upsampleChroma420(input: []const [64]i32, output: *[256]i32, h_blocks: u4, v_
             const src_y_f = (@as(f32, @floatFromInt(dst_y)) + 0.5) * scale_y - 0.5;
 
             // Get integer and fractional parts
-            const x0: usize = @intFromFloat(std.math.clamp(@floor(src_x_f), 0, 7));
-            const y0: usize = @intFromFloat(std.math.clamp(@floor(src_y_f), 0, 7));
+            const x0: usize = @trunc(std.math.clamp(@floor(src_x_f), 0, 7));
+            const y0: usize = @trunc(std.math.clamp(@floor(src_y_f), 0, 7));
             const x1: usize = @min(7, x0 + 1);
             const y1: usize = @min(7, y0 + 1);
 
@@ -2504,7 +2504,7 @@ fn upsampleChroma420(input: []const [64]i32, output: *[256]i32, h_blocks: u4, v_
             const result = std.math.lerp(interp_x0, interp_x1, fy);
 
             const dst_idx = dst_y * dst_width + dst_x;
-            output[dst_idx] = @intFromFloat(@round(result));
+            output[dst_idx] = @round(result);
         }
     }
 }
@@ -2806,7 +2806,7 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
 
                         // Horizontal interpolation for chroma
                         const chroma_x_f: f32 = (@as(f32, @floatFromInt(h * 8 + px)) + 0.5) * 0.5 - 0.5;
-                        const cx0: usize = @intFromFloat(std.math.clamp(@floor(chroma_x_f), 0, 7));
+                        const cx0: usize = @trunc(std.math.clamp(@floor(chroma_x_f), 0, 7));
                         const cx1: usize = @min(7, cx0 + 1);
                         const fx: f32 = chroma_x_f - @as(f32, @floatFromInt(cx0));
 
@@ -2815,11 +2815,11 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
 
                         const cb0: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][1][chroma_idx]);
                         const cb1: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][1][chroma_idx_next]);
-                        const Cb: i32 = @intFromFloat(@round(std.math.lerp(cb0, cb1, fx)));
+                        const Cb: i32 = @round(std.math.lerp(cb0, cb1, fx));
 
                         const cr0: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][2][chroma_idx]);
                         const cr1: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][2][chroma_idx_next]);
-                        const Cr: i32 = @intFromFloat(@round(std.math.lerp(cr0, cr1, fx)));
+                        const Cr: i32 = @round(std.math.lerp(cr0, cr1, fx));
 
                         const ycbcr: Ycbcr = .{
                             .y = @intCast(std.math.clamp(Y, 0, 255)),
@@ -2861,7 +2861,7 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
 
                         // Horizontal interpolation for 4:1 chroma
                         const chroma_x_f: f32 = (@as(f32, @floatFromInt(h * 8 + px)) + 0.5) * 0.25 - 0.5;
-                        const cx0: usize = @intFromFloat(std.math.clamp(@floor(chroma_x_f), 0, 7));
+                        const cx0: usize = @trunc(std.math.clamp(@floor(chroma_x_f), 0, 7));
                         const cx1: usize = @min(7, cx0 + 1);
                         const fx: f32 = chroma_x_f - @as(f32, @floatFromInt(cx0));
 
@@ -2870,11 +2870,11 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
 
                         const cb0: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][1][chroma_idx]);
                         const cb1: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][1][chroma_idx_next]);
-                        const Cb: i32 = @intFromFloat(@round(std.math.lerp(cb0, cb1, fx)));
+                        const Cb: i32 = @round(std.math.lerp(cb0, cb1, fx));
 
                         const cr0: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][2][chroma_idx]);
                         const cr1: f32 = @floatFromInt(state.block_storage.?[chroma_block_index][2][chroma_idx_next]);
-                        const Cr: i32 = @intFromFloat(@round(std.math.lerp(cr0, cr1, fx)));
+                        const Cr: i32 = @round(std.math.lerp(cr0, cr1, fx));
 
                         const ycbcr: Ycbcr = .{
                             .y = @intCast(std.math.clamp(Y, 0, 255)),
@@ -2923,8 +2923,8 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
                         const chroma_y_f: f32 = (@as(f32, @floatFromInt(v * 8 + py)) + 0.5) * 0.5 - 0.5;
                         const chroma_x_f: f32 = (@as(f32, @floatFromInt(h * 8 + px)) + 0.5) * 0.5 - 0.5;
 
-                        const cy0: usize = @intFromFloat(std.math.clamp(@floor(chroma_y_f), 0, 7));
-                        const cx0: usize = @intFromFloat(std.math.clamp(@floor(chroma_x_f), 0, 7));
+                        const cy0: usize = @trunc(std.math.clamp(@floor(chroma_y_f), 0, 7));
+                        const cx0: usize = @trunc(std.math.clamp(@floor(chroma_x_f), 0, 7));
                         const cy1: usize = @min(7, cy0 + 1);
                         const cx1: usize = @min(7, cx0 + 1);
 
@@ -2946,11 +2946,11 @@ fn ycbcrToRgbAllBlocks(state: *JpegState) !void {
                         // Bilinear interpolation
                         const cb_interp_x0 = std.math.lerp(cb00, cb10, fx);
                         const cb_interp_x1 = std.math.lerp(cb01, cb11, fx);
-                        const Cb: i32 = @intFromFloat(@round(std.math.lerp(cb_interp_x0, cb_interp_x1, fy)));
+                        const Cb: i32 = @round(std.math.lerp(cb_interp_x0, cb_interp_x1, fy));
 
                         const cr_interp_x0 = std.math.lerp(cr00, cr10, fx);
                         const cr_interp_x1 = std.math.lerp(cr01, cr11, fx);
-                        const Cr: i32 = @intFromFloat(@round(std.math.lerp(cr_interp_x0, cr_interp_x1, fy)));
+                        const Cr: i32 = @round(std.math.lerp(cr_interp_x0, cr_interp_x1, fy));
 
                         const ycbcr: Ycbcr = .{
                             .y = @intCast(std.math.clamp(Y, 0, 255)),

--- a/src/jpeg.zig
+++ b/src/jpeg.zig
@@ -547,7 +547,7 @@ fn magnitudeBits(value: i32, mag: u5) u32 {
 
 // LLM DCT constants in 13-bit fixed point (CONST_BITS = 13)
 inline fn FIX(comptime x: f32) i32 {
-    return @trunc(x * (1 << 13) + 0.5);
+    return @round(x * (1 << 13));
 }
 
 const FIX_0_298631336: i32 = FIX(0.298631336);
@@ -1719,9 +1719,9 @@ fn yCbCrToRgbBlock(_: *JpegState, y_block: *[64]i32, cb_block: *const [64]i32, c
         g_vec = std.math.clamp(g_vec, vec_0, vec_255);
         b_vec = std.math.clamp(b_vec, vec_0, vec_255);
 
-        const r_u8: @Vector(8, u8) = @trunc(r_vec);
-        const g_u8: @Vector(8, u8) = @trunc(g_vec);
-        const b_u8: @Vector(8, u8) = @trunc(b_vec);
+        const r_u8: @Vector(8, u8) = @round(r_vec);
+        const g_u8: @Vector(8, u8) = @round(g_vec);
+        const b_u8: @Vector(8, u8) = @round(b_vec);
 
         var r_array: [8]u8 = undefined;
         var g_array: [8]u8 = undefined;
@@ -2283,7 +2283,7 @@ pub const JpegError = error{
 // IDCT implementation based on stb_image
 fn f2f(comptime x: f32) i32 {
     // 4096 = 1 << 12
-    return @trunc(x * 4096 + 0.5);
+    return @round(x * 4096);
 }
 
 fn idct1D(s0: i32, s1: i32, s2: i32, s3: i32, s4: i32, s5: i32, s6: i32, s7: i32) struct { i32, i32, i32, i32, i32, i32, i32, i32 } {

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -20,7 +20,7 @@ pub fn as(comptime T: type, from: anytype) T {
         .float, .comptime_float => {
             return switch (@typeInfo(T)) {
                 .float => @floatCast(from),
-                .int => @intFromFloat(@round(from)),
+                .int => @round(from),
                 else => @compileError(@typeName(@TypeOf(from)) ++ " can't be converted to " ++ @typeName(T)),
             };
         },
@@ -107,7 +107,7 @@ pub fn clamp(comptime T: type, value: anytype) T {
                     else
                         @as(f64, @floatFromInt(std.math.minInt(T)));
                     const max = @as(f64, @floatFromInt(std.math.maxInt(T)));
-                    return @intFromFloat(std.math.clamp(@round(as(f64, value)), min, max));
+                    return @trunc(std.math.clamp(@round(as(f64, value)), min, max));
                 },
                 else => @compileError("clamp only supports numeric inputs, got: " ++ @typeName(ValueType)),
             }
@@ -194,7 +194,7 @@ pub fn safeCast(comptime T: type, value: anytype) !T {
                     if (rounded < min_limit or rounded > max_limit) return error.Overflow;
                     // Special check for negative zero or small negative floats casting to unsigned
                     if (int_info.signedness == .unsigned and rounded < 0) return error.Overflow;
-                    return @intFromFloat(rounded);
+                    return @trunc(rounded);
                 },
                 else => @compileError("safeCast only supports numeric inputs"),
             }

--- a/src/optimization.zig
+++ b/src/optimization.zig
@@ -106,7 +106,7 @@ pub fn solveAssignmentProblem(
         for (0..n_cols) |j| {
             const base_val = cost_matrix.at(i, j).*;
             const abs_val = @abs(as(f64, base_val));
-            padding_value += @intFromFloat(@ceil(abs_val * @as(f64, @floatFromInt(scale_factor))));
+            padding_value += @ceil(abs_val * @as(f64, @floatFromInt(scale_factor)));
         }
     }
 
@@ -118,7 +118,7 @@ pub fn solveAssignmentProblem(
                 work[i * n + j] = switch (@typeInfo(T)) {
                     .float => blk: {
                         const val = base_val * @as(T, @floatFromInt(multiplier));
-                        break :blk @intFromFloat(@round(val * @as(T, @floatFromInt(scale_factor))));
+                        break :blk @round(val * @as(T, @floatFromInt(scale_factor)));
                     },
                     .int => @as(i64, base_val) * multiplier,
                     else => @compileError("Unsupported type for cost matrix"),

--- a/src/perlin.zig
+++ b/src/perlin.zig
@@ -60,9 +60,9 @@ pub fn perlin(T: type, x: T, y: T, z: T, opts: PerlinOptions(T)) T {
 fn noise(T: type, x: T, y: T, z: T) T {
     assert(@typeInfo(T) == .float);
     // Find unit cube that contains the point.
-    const x_i: u8 = @intCast(@as(isize, @intFromFloat(@floor(x))) & 255);
-    const y_i: u8 = @intCast(@as(isize, @intFromFloat(@floor(y))) & 255);
-    const z_i: u8 = @intCast(@as(isize, @intFromFloat(@floor(z))) & 255);
+    const x_i: u8 = @intCast(@as(isize, @floor(x)) & 255);
+    const y_i: u8 = @intCast(@as(isize, @floor(y)) & 255);
+    const z_i: u8 = @intCast(@as(isize, @floor(z)) & 255);
 
     // Find relative x, y, z of the point in the cube.
     const x_r = x - @floor(x);

--- a/src/png.zig
+++ b/src/png.zig
@@ -1318,7 +1318,7 @@ fn encodeRaw(gpa: Allocator, image_data: []const u8, width: u32, height: u32, co
     } else if (options.gamma) |g| {
         // gAMA chunk - must come before PLTE and IDAT
         // Store gamma * 100000 as big-endian u32
-        const gamma_int: u32 = @intFromFloat(g * 100000.0);
+        const gamma_int: u32 = @trunc(g * 100000.0);
         var gama_data: [4]u8 = undefined;
         std.mem.writeInt(u32, &gama_data, gamma_int, .big);
         try writer.writeChunk("gAMA".*, &gama_data);
@@ -2697,7 +2697,7 @@ test "PNG encode with color management chunks" {
             found_gama = true;
             try std.testing.expectEqual(@as(u32, 4), chunk_length);
             const gamma_int = std.mem.readInt(u32, gamma_png[offset + 8 .. offset + 12][0..4], .big);
-            const expected_gamma_int: u32 = @intFromFloat((1.0 / 2.2) * 100000.0);
+            const expected_gamma_int: u32 = @trunc((1.0 / 2.2) * 100000.0);
             try std.testing.expectApproxEqAbs(@as(f32, @floatFromInt(gamma_int)), @as(f32, @floatFromInt(expected_gamma_int)), 1.0);
             break;
         }

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -171,8 +171,8 @@ pub fn fromImageProfiled(
     var height = image.rows;
     const scale = terminal.aspectScale(options.width, options.height, image.rows, image.cols);
     if (@abs(scale - 1.0) > 1e-5) {
-        width = @intFromFloat(@as(f32, @floatFromInt(width)) * scale);
-        height = @intFromFloat(@as(f32, @floatFromInt(height)) * scale);
+        width = @trunc(@as(f32, @floatFromInt(width)) * scale);
+        height = @trunc(@as(f32, @floatFromInt(height)) * scale);
     }
 
     // Prepare palette based on mode
@@ -255,12 +255,12 @@ pub fn fromImageProfiled(
 
                         // Fallback to clamped nearest-neighbor sample to avoid leaving pixels uninitialized.
                         const clamped_col: isize = clamp(
-                            @as(isize, @intFromFloat(@round(src_x))),
+                            @as(isize, @round(src_x)),
                             0,
                             @as(isize, @intCast(image.cols - 1)),
                         );
                         const clamped_row: isize = clamp(
-                            @as(isize, @intFromFloat(@round(src_y))),
+                            @as(isize, @round(src_y)),
                             0,
                             @as(isize, @intCast(image.rows - 1)),
                         );


### PR DESCRIPTION
This commit simplifies float-to-integer conversions across the codebase by removing deprecated `@intFromFloat` calls and using `@trunc`, `@round`, `@floor`, or `@ceil` directly where appropriate.