### PR TITLE
fix(matrix): guard query ops and deinit on poisoned chains

### DIFF
--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -150,6 +150,9 @@ pub fn Matrix(comptime T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
+            // Poisoned matrices from failed chains have items.len == 0 and an
+            // undefined pointer; freeing that would be UB. Skip empty slices.
+            if (self.items.len == 0) return;
             self.allocator.free(self.items);
         }
 
@@ -957,6 +960,7 @@ pub fn Matrix(comptime T: type) type {
 
         /// Sums all the elements in a matrix.
         pub fn sum(self: Self) T {
+            assert(self.err == null);
             var accum: T = 0;
             for (self.items) |val| {
                 accum += val;
@@ -967,6 +971,7 @@ pub fn Matrix(comptime T: type) type {
         /// Computes the Frobenius norm of the matrix.
         pub fn frobeniusNorm(self: Self) T {
             ensureFloat("frobeniusNorm");
+            assert(self.err == null);
             var squared_sum: T = 0;
             for (self.items) |val| {
                 squared_sum += val * val;
@@ -976,11 +981,13 @@ pub fn Matrix(comptime T: type) type {
 
         /// Mean (average) of all elements
         pub fn mean(self: Self) T {
+            assert(self.err == null);
             return self.sum() / @as(T, @floatFromInt(self.items.len));
         }
 
         /// Variance: E[(X - μ)²]
         pub fn variance(self: Self) T {
+            assert(self.err == null);
             const mu = self.mean();
             var sum_sq_diff: T = 0;
             for (self.items) |val| {
@@ -993,11 +1000,13 @@ pub fn Matrix(comptime T: type) type {
         /// Standard deviation: sqrt(variance)
         pub fn stdDev(self: Self) T {
             ensureFloat("stdDev");
+            assert(self.err == null);
             return @sqrt(self.variance());
         }
 
         /// Minimum element
         pub fn min(self: Self) T {
+            assert(self.err == null);
             var min_val = self.items[0];
             for (self.items[1..]) |val| {
                 if (val < min_val) {
@@ -1009,6 +1018,7 @@ pub fn Matrix(comptime T: type) type {
 
         /// Maximum element
         pub fn max(self: Self) T {
+            assert(self.err == null);
             var max_val = self.items[0];
             for (self.items[1..]) |val| {
                 if (val > max_val) {
@@ -1021,6 +1031,7 @@ pub fn Matrix(comptime T: type) type {
         /// Entrywise L1 norm: sum of absolute values of all elements
         pub fn l1Norm(self: Self) T {
             ensureFloat("l1Norm");
+            assert(self.err == null);
             var sum_abs: T = 0;
             for (self.items) |val| {
                 sum_abs += @abs(val);
@@ -1031,6 +1042,7 @@ pub fn Matrix(comptime T: type) type {
         /// Max norm (L-infinity): maximum absolute value
         pub fn maxNorm(self: Self) T {
             ensureFloat("maxNorm");
+            assert(self.err == null);
             var max_abs: T = 0;
             for (self.items) |val| {
                 const abs_val = @abs(val);
@@ -1044,6 +1056,7 @@ pub fn Matrix(comptime T: type) type {
         /// Minimum absolute value among all elements.
         pub fn minNorm(self: Self) T {
             ensureFloat("minNorm");
+            assert(self.err == null);
             if (self.items.len == 0) return 0;
             var min_abs = @abs(self.items[0]);
             for (self.items[1..]) |val| {
@@ -1058,6 +1071,7 @@ pub fn Matrix(comptime T: type) type {
         /// Counts non-zero elements.
         pub fn sparseNorm(self: Self) T {
             ensureFloat("sparseNorm");
+            assert(self.err == null);
             var count: T = 0;
             for (self.items) |val| {
                 if (val != 0) count += 1;
@@ -1068,6 +1082,7 @@ pub fn Matrix(comptime T: type) type {
         /// Entrywise ℓᵖ norm with optional runtime exponent.
         pub fn elementNorm(self: Self, p: T) MatrixError!T {
             ensureFloat("elementNorm");
+            if (self.err) |e| return e;
             if (std.math.isInf(p)) {
                 if (p > 0) {
                     return self.maxNorm();
@@ -1100,6 +1115,7 @@ pub fn Matrix(comptime T: type) type {
 
         fn leadingSingularValue(self: Self, allocator: std.mem.Allocator) !T {
             ensureFloat("leadingSingularValue");
+            if (self.err) |e| return e;
             if (self.rows == 0 or self.cols == 0) return 0;
 
             if (self.rows < self.cols) {
@@ -1119,6 +1135,7 @@ pub fn Matrix(comptime T: type) type {
 
         fn sumSingularP(self: Self, allocator: std.mem.Allocator, exponent: T) !T {
             ensureFloat("schattenNorm");
+            if (self.err) |e| return e;
             if (self.rows == 0 or self.cols == 0) return 0;
 
             if (self.rows >= self.cols) {
@@ -1143,6 +1160,7 @@ pub fn Matrix(comptime T: type) type {
         /// Schatten p-norm of the matrix.
         pub fn schattenNorm(self: Self, allocator: std.mem.Allocator, p: T) !T {
             ensureFloat("schattenNorm");
+            if (self.err) |e| return e;
             if (std.math.isInf(p)) {
                 if (p > 0) {
                     return self.leadingSingularValue(allocator);
@@ -1175,6 +1193,7 @@ pub fn Matrix(comptime T: type) type {
         /// Induced operator norms with p ∈ {1, 2, ∞}.
         pub fn inducedNorm(self: Self, allocator: std.mem.Allocator, p: T) !T {
             ensureFloat("inducedNorm");
+            if (self.err) |e| return e;
             if (p == 1) {
                 var max_sum: T = 0;
                 for (0..self.cols) |c| {
@@ -1207,6 +1226,7 @@ pub fn Matrix(comptime T: type) type {
 
         /// Trace: sum of diagonal elements (square matrices only)
         pub fn trace(self: Self) T {
+            assert(self.err == null);
             assert(self.rows == self.cols);
             var sum_diag: T = 0;
             for (0..self.rows) |i| {

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -150,9 +150,9 @@ pub fn Matrix(comptime T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            // Poisoned matrices from failed chains have items.len == 0 and an
-            // undefined pointer; freeing that would be UB. Skip empty slices.
-            if (self.items.len == 0) return;
+            // Poisoned matrices from failed chains have an undefined pointer;
+            // freeing that would be UB. Valid 0x0 matrices are safe to free.
+            if (self.err != null) return;
             self.allocator.free(self.items);
         }
 
@@ -982,12 +982,14 @@ pub fn Matrix(comptime T: type) type {
         /// Mean (average) of all elements
         pub fn mean(self: Self) T {
             assert(self.err == null);
+            assert(self.items.len > 0);
             return self.sum() / @as(T, @floatFromInt(self.items.len));
         }
 
         /// Variance: E[(X - μ)²]
         pub fn variance(self: Self) T {
             assert(self.err == null);
+            assert(self.items.len > 0);
             const mu = self.mean();
             var sum_sq_diff: T = 0;
             for (self.items) |val| {
@@ -1007,6 +1009,7 @@ pub fn Matrix(comptime T: type) type {
         /// Minimum element
         pub fn min(self: Self) T {
             assert(self.err == null);
+            assert(self.items.len > 0);
             var min_val = self.items[0];
             for (self.items[1..]) |val| {
                 if (val < min_val) {
@@ -1019,6 +1022,7 @@ pub fn Matrix(comptime T: type) type {
         /// Maximum element
         pub fn max(self: Self) T {
             assert(self.err == null);
+            assert(self.items.len > 0);
             var max_val = self.items[0];
             for (self.items[1..]) |val| {
                 if (val > max_val) {

--- a/src/matrix/test_ops_advanced.zig
+++ b/src/matrix/test_ops_advanced.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const expectEqual = std.testing.expectEqual;
-const Matrix = @import("Matrix.zig").Matrix;
+const matrix_module = @import("Matrix.zig");
+const Matrix = matrix_module.Matrix;
+const MatrixError = matrix_module.MatrixError;
 
 test "Matrix apply method" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
@@ -115,6 +117,34 @@ test "Matrix norms" {
 
     // Test trace (diagonal sum): 3 + 2 = 5
     try expectEqual(@as(f64, 5.0), mat.trace());
+}
+
+test "Matrix poisoned chain: deinit safe and !T queries surface err" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const a: Matrix(f64) = try .init(alloc, 2, 3);
+    @memset(a.items, 1.0);
+    const b: Matrix(f64) = try .init(alloc, 4, 5);
+    @memset(b.items, 1.0);
+
+    // add() with mismatched dims produces a poisoned matrix without unwrapping.
+    var poisoned = a.add(b);
+    try std.testing.expectEqual(@as(MatrixError, error.DimensionMismatch), poisoned.err.?);
+
+    // deinit on a poisoned matrix must not free the undefined pointer.
+    poisoned.deinit();
+
+    // eval() on a fresh poisoned matrix surfaces the deferred error.
+    var poisoned2 = a.add(b);
+    try std.testing.expectError(error.DimensionMismatch, poisoned2.eval());
+    poisoned2.deinit();
+
+    // Already-`!T` query ops surface the deferred error rather than asserting.
+    var poisoned3 = a.add(b);
+    try std.testing.expectError(error.DimensionMismatch, poisoned3.elementNorm(2.0));
+    poisoned3.deinit();
 }
 
 test "Matrix offset and pow" {


### PR DESCRIPTION
Matrix(T) chainable ops stash failures in `err` and short-circuit until .eval() unwraps them. Query ops returning T (sum, mean, min, frobeniusNorm, trace, ...) skipped that check, so calling them on a poisoned matrix from a failed chain hit `items[0]` on a zero-length undefined slice (panic in safe builds, UB in release) or silently returned 0 / NaN. deinit also freed the undefined pointer.

Add std.debug.assert(self.err == null) to value-returning query ops (precondition: caller must have evaluated the chain), propagate the deferred error via `if (self.err) |e| return e;` on the already-!T norm ops, and skip the free in deinit when items.len == 0.