### PR TITLE
refactor(matrix): split Matrix(T) chain into Chain(T)

### DIFF
--- a/bindings/python/src/matrix.zig
+++ b/bindings/python/src/matrix.zig
@@ -610,9 +610,9 @@ var matrix_as_mapping = c.PyMappingMethods{
 fn dispatchMatrixOp(
     left: ?*c.PyObject,
     right: ?*c.PyObject,
-    mat_mat_op: fn (*Matrix(f64), *Matrix(f64)) Matrix(f64),
-    mat_scalar_op: fn (*Matrix(f64), f64) Matrix(f64),
-    scalar_mat_op: ?fn (f64, *Matrix(f64)) Matrix(f64),
+    mat_mat_op: fn (*Matrix(f64), *Matrix(f64)) MatrixResult,
+    mat_scalar_op: fn (*Matrix(f64), f64) MatrixResult,
+    scalar_mat_op: ?fn (f64, *Matrix(f64)) MatrixResult,
 ) ?*c.PyObject {
     const left_is_mat = c.PyObject_IsInstance(left, @ptrCast(&MatrixType)) == 1;
     const right_is_mat = c.PyObject_IsInstance(right, @ptrCast(&MatrixType)) == 1;
@@ -646,33 +646,36 @@ fn dispatchMatrixOp(
     return python.notImplemented();
 }
 
-fn op_add(a: *Matrix(f64), b: *Matrix(f64)) Matrix(f64) {
+const MatrixError = zignal.MatrixError;
+const MatrixResult = MatrixError!Matrix(f64);
+
+fn op_add(a: *Matrix(f64), b: *Matrix(f64)) MatrixResult {
     return a.add(b.*);
 }
-fn op_add_scalar(a: *Matrix(f64), s: f64) Matrix(f64) {
+fn op_add_scalar(a: *Matrix(f64), s: f64) MatrixResult {
     return a.offset(s);
 }
-fn op_radd_scalar(s: f64, a: *Matrix(f64)) Matrix(f64) {
+fn op_radd_scalar(s: f64, a: *Matrix(f64)) MatrixResult {
     return a.offset(s);
 }
-fn op_sub(a: *Matrix(f64), b: *Matrix(f64)) Matrix(f64) {
+fn op_sub(a: *Matrix(f64), b: *Matrix(f64)) MatrixResult {
     return a.sub(b.*);
 }
-fn op_sub_scalar(a: *Matrix(f64), s: f64) Matrix(f64) {
+fn op_sub_scalar(a: *Matrix(f64), s: f64) MatrixResult {
     return a.offset(-s);
 }
-fn op_rsub_scalar(s: f64, a: *Matrix(f64)) Matrix(f64) {
-    var negated = a.scale(-1.0);
+fn op_rsub_scalar(s: f64, a: *Matrix(f64)) MatrixResult {
+    var negated = try a.scale(-1.0);
     defer negated.deinit();
     return negated.offset(s);
 }
-fn op_mul(a: *Matrix(f64), b: *Matrix(f64)) Matrix(f64) {
+fn op_mul(a: *Matrix(f64), b: *Matrix(f64)) MatrixResult {
     return a.times(b.*);
 }
-fn op_mul_scalar(a: *Matrix(f64), s: f64) Matrix(f64) {
+fn op_mul_scalar(a: *Matrix(f64), s: f64) MatrixResult {
     return a.scale(s);
 }
-fn op_rmul_scalar(s: f64, a: *Matrix(f64)) Matrix(f64) {
+fn op_rmul_scalar(s: f64, a: *Matrix(f64)) MatrixResult {
     return a.scale(s);
 }
 
@@ -728,11 +731,11 @@ fn matrix_negative(obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
 }
 
 // Helper function to convert Zig Matrix to Python MatrixObject
-fn matrixToObject(matrix: Matrix(f64)) ?*c.PyObject {
-    if (matrix.err) |e| {
+fn matrixToObject(matrix_or_err: MatrixResult) ?*c.PyObject {
+    const matrix = matrix_or_err catch |e| {
         python.mapZigError(e, "Matrix");
         return null;
-    }
+    };
 
     const self: ?*MatrixObject = @ptrCast(c.PyType_GenericAlloc(@ptrCast(&MatrixType), 0));
     if (self == null) return null;

--- a/build.zig
+++ b/build.zig
@@ -145,7 +145,15 @@ pub fn build(b: *Build) void {
         else => ".so",
     };
 
-    // Python type stub generation
+    // Python type stub generation.
+    //
+    // `python-stubs` is its own step rather than a hard dependency of
+    // `python-bindings`. The .pyi files are checked into the package, so
+    // the runtime extension can build and run tests without regenerating
+    // them — useful when the stub generator (a native executable) hits
+    // upstream toolchain issues like zig#22875 (zig's lld can't yet handle
+    // the .sframe relocations in /usr/lib/crt1.o shipped by gcc >= 15.2).
+    // Run `zig build python-stubs` explicitly to refresh the .pyi files.
     const python_stubs_step = b.step("python-stubs", "Generate Python type stub files (.pyi)");
     const stub_generator = b.addExecutable(.{
         .name = "python_stubs",
@@ -170,8 +178,9 @@ pub fn build(b: *Build) void {
     const install_cli = b.addInstallArtifact(exe, .{});
     py_bindings_step.dependOn(&install_cli.step);
 
-    // Make python-bindings depend on stub generation so stubs are always up to date
-    py_bindings_step.dependOn(&run_stub_generator.step);
+    // python-bindings only depends on the runtime extension. Stub regeneration
+    // is its own `python-stubs` step (see comment at the stub_generator
+    // declaration above for context).
     py_bindings_step.dependOn(&install_py_module.step);
 
     // Also copy the built extension into the source package directory for local development

--- a/src/fdm.zig
+++ b/src/fdm.zig
@@ -228,15 +228,15 @@ pub fn FeatureDistributionMatching(comptime T: type) type {
                 var u_source = try Matrix(f64).fromSMatrix(self.allocator, source_svd.u);
                 defer u_source.deinit();
 
-                var u_target_t = self.target_cov_u.transpose();
+                var u_target_t = try self.target_cov_u.transpose();
                 defer u_target_t.deinit();
 
                 // w_temp = u_source * sigma_combined
-                var w_temp = try u_source.dot(sigma_combined).eval();
+                var w_temp = try u_source.dot(sigma_combined);
                 defer w_temp.deinit();
 
                 // w = w_temp * u_target_t
-                var w = try w_temp.dot(u_target_t).eval();
+                var w = try w_temp.dot(u_target_t);
                 defer w.deinit();
 
                 // Apply W to every pixel

--- a/src/geometry/transforms.zig
+++ b/src/geometry/transforms.zig
@@ -174,24 +174,23 @@ pub fn AffineTransform(comptime T: type) type {
             // Use Matrix operations to perform matrix operations
             // Compute the pseudo-inverse so we can support additional correspondences
             var effective_rank: u32 = 0;
-            var pinv_chain = p.pseudoInverse(.{ .effective_rank = &effective_rank });
-            var pinv = try pinv_chain.eval();
+            var pinv = try p.pseudoInverse(.{ .effective_rank = &effective_rank });
             defer pinv.deinit();
             if (effective_rank < 3) {
                 return error.RankDeficient;
             }
 
             // Calculate m = q * p^+
-            var m = try q.dot(pinv).eval();
+            var m = try q.dot(pinv);
             defer m.deinit();
 
             // Extract the 2x2 matrix
-            var sub_matrix = try m.subMatrix(0, 0, 2, 2).eval();
+            var sub_matrix = try m.subMatrix(0, 0, 2, 2);
             defer sub_matrix.deinit();
             self.matrix = sub_matrix.toSMatrix(2, 2);
 
             // Extract the bias column
-            var bias_col = try m.col(2).eval();
+            var bias_col = try m.col(2);
             defer bias_col.deinit();
             self.bias = bias_col.toSMatrix(2, 1);
         }

--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -5,10 +5,13 @@
 // Re-export all matrix functionality
 pub const SMatrix = @import("matrix/SMatrix.zig").SMatrix;
 pub const Matrix = @import("matrix/Matrix.zig").Matrix;
+pub const MatrixError = @import("matrix/Matrix.zig").MatrixError;
+pub const Chain = @import("matrix/Chain.zig").Chain;
 
 test {
     _ = @import("matrix/SMatrix.zig");
     _ = @import("matrix/Matrix.zig");
+    _ = @import("matrix/Chain.zig");
     _ = @import("matrix/svd.zig");
     _ = @import("matrix/svd_static.zig");
     _ = @import("matrix/formatting.zig");

--- a/src/matrix/Chain.zig
+++ b/src/matrix/Chain.zig
@@ -74,6 +74,11 @@ pub fn Chain(comptime T: type) type {
         ///
         /// Calling `toOwned()` on a chain with zero ops returns a duplicate
         /// of the input (since the caller didn't transfer ownership of it).
+        ///
+        /// Mirrors `std.ArrayList.toOwnedSlice`: after the move, the chain
+        /// is reset to an empty (0×0) state so further calls don't UAF the
+        /// moved buffer. Calling chainable ops on a moved chain will either
+        /// error on a dimension check or operate on the empty matrix.
         pub fn toOwned(self: *Self) MatrixError!Matrix(T) {
             if (self.err) |e| {
                 self.deinit();
@@ -84,6 +89,12 @@ pub fn Chain(comptime T: type) type {
                 return self.current.dupe(self.allocator);
             }
             const out = self.current;
+            // Reset self.current to an empty matrix. The items slice is
+            // truncated to length 0 so the (now stale) pointer is never
+            // dereferenced even if the caller has freed the returned buffer.
+            self.current.items = self.current.items[0..0];
+            self.current.rows = 0;
+            self.current.cols = 0;
             self.owns_current = false;
             return out;
         }
@@ -301,6 +312,26 @@ test "Chain: zero-op chain returns a duplicate" {
     // Mutating r must not affect a.
     r.at(0, 0).* = 0;
     try std.testing.expectEqual(@as(f64, 7.0), a.at(0, 0).*);
+}
+
+test "Chain: post-toOwned state is safe to reuse and deinit" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .initAll(allocator, 2, 2, 1.0);
+    defer a.deinit();
+
+    var p = a.chain();
+    defer p.deinit();
+    var first = try p.scale(2.0).toOwned();
+    // Free the result; the chain must not retain a live pointer into it.
+    first.deinit();
+
+    // A second toOwned() on the moved chain returns a 0×0 matrix from the
+    // reset empty state — not a UAF on `first`'s freed buffer.
+    var second = try p.toOwned();
+    defer second.deinit();
+    try std.testing.expectEqual(@as(u32, 0), second.rows);
+    try std.testing.expectEqual(@as(u32, 0), second.cols);
+    // p.deinit() runs via defer; must also be safe on the empty state.
 }
 
 test "Chain: abandoned chain (no toOwned) leaks nothing" {

--- a/src/matrix/Chain.zig
+++ b/src/matrix/Chain.zig
@@ -1,0 +1,319 @@
+//! Chain(T): a matrix-operation chain.
+//!
+//! Wraps a `Matrix(T)` for fluent chaining. Each chainable op executes
+//! eagerly, frees the previous intermediate, and stores the new result on
+//! the same `Chain`. Errors are deferred onto an internal field and
+//! surfaced by `toOwned()`.
+//!
+//! ## Usage
+//!
+//! ```zig
+//! var p = m.chain();
+//! defer p.deinit();
+//! const result = try p.dot(b).transpose().scale(0.5).toOwned();
+//! defer result.deinit();
+//! ```
+//!
+//! `defer p.deinit()` is safe whether or not `toOwned()` ran — `toOwned`
+//! clears ownership of the final matrix so a subsequent `deinit` is a no-op.
+//!
+//! ## Single-op shortcut
+//!
+//! For one-shot operations, call the method directly on `Matrix(T)`:
+//!
+//! ```zig
+//! const result = try a.dot(b);
+//! defer result.deinit();
+//! ```
+//!
+//! `Chain` is only needed when chaining 2+ ops, where its eager-free
+//! behaviour avoids the leak-by-default that an arena workaround used to
+//! address.
+
+const std = @import("std");
+const matrix_module = @import("Matrix.zig");
+const Matrix = matrix_module.Matrix;
+const MatrixError = matrix_module.MatrixError;
+
+pub fn Chain(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        /// The current "head" of the chain — the result of the last successful op,
+        /// or the borrowed input matrix if no ops have run yet.
+        current: Matrix(T),
+        /// True iff `current` is heap-owned by Chain. The initial input is
+        /// borrowed (false); every chainable op produces an owned result (true).
+        owns_current: bool,
+        /// Allocator used for newly produced matrices. Inherited from the input.
+        allocator: std.mem.Allocator,
+        /// Deferred error from any chainable op; surfaced by `toOwned()`.
+        err: ?MatrixError = null,
+
+        /// Lift a `Matrix(T)` into a `Chain(T)`. The matrix is borrowed —
+        /// callers retain ownership and remain responsible for its `deinit`.
+        pub fn from(matrix: Matrix(T)) Self {
+            return .{
+                .current = matrix,
+                .owns_current = false,
+                .allocator = matrix.allocator,
+            };
+        }
+
+        /// Free the chain's current intermediate (if owned). Safe to call
+        /// after `toOwned()` (in which case it's a no-op) or to abort a chain
+        /// without consuming the result.
+        pub fn deinit(self: *Self) void {
+            if (self.owns_current) self.current.deinit();
+            self.owns_current = false;
+        }
+
+        /// Terminal operation — yields the final matrix or surfaces the
+        /// deferred error. On success, ownership of the result transfers to
+        /// the caller and a subsequent `deinit` becomes a no-op.
+        ///
+        /// Calling `toOwned()` on a chain with zero ops returns a duplicate
+        /// of the input (since the caller didn't transfer ownership of it).
+        pub fn toOwned(self: *Self) MatrixError!Matrix(T) {
+            if (self.err) |e| {
+                self.deinit();
+                return e;
+            }
+            if (!self.owns_current) {
+                // Zero-op chain: input is borrowed; return a fresh copy.
+                return self.current.dupe(self.allocator);
+            }
+            const out = self.current;
+            self.owns_current = false;
+            return out;
+        }
+
+        // === Internal helper ===
+
+        /// Run a `Matrix(T)`-method that returns `MatrixError!Matrix(T)` and
+        /// install the result as the new `current`, freeing the previous one
+        /// if owned. On failure, store the error and leave `current` alone.
+        fn step(self: *Self, result: MatrixError!Matrix(T)) *Self {
+            if (self.err != null) return self;
+            const new_matrix = result catch |e| {
+                self.err = e;
+                return self;
+            };
+            if (self.owns_current) self.current.deinit();
+            self.current = new_matrix;
+            self.owns_current = true;
+            return self;
+        }
+
+        // === Chainable operations ===
+
+        /// Element-wise addition.
+        pub fn add(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.add(other));
+        }
+
+        /// Element-wise subtraction.
+        pub fn sub(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.sub(other));
+        }
+
+        /// Element-wise multiplication (Hadamard product).
+        pub fn times(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.times(other));
+        }
+
+        /// Scale all elements by a scalar.
+        pub fn scale(self: *Self, value: T) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.scale(value));
+        }
+
+        /// Add a scalar to every element.
+        pub fn offset(self: *Self, value: T) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.offset(value));
+        }
+
+        /// Raise every element to power `n`.
+        pub fn pow(self: *Self, n: T) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.pow(n));
+        }
+
+        /// Apply a function element-wise. Extra `args` are forwarded to `func`
+        /// after the element value.
+        pub fn apply(self: *Self, comptime func: anytype, args: anytype) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.apply(func, args));
+        }
+
+        /// Transpose.
+        pub fn transpose(self: *Self) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.transpose());
+        }
+
+        /// Matrix multiplication (dot product).
+        pub fn dot(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.dot(other));
+        }
+
+        /// Scaled matrix multiplication: α * A * B.
+        pub fn scaledDot(self: *Self, other: Matrix(T), alpha: T) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.scaledDot(other, alpha));
+        }
+
+        /// Matrix multiplication with right-side transpose: A * B^T.
+        pub fn dotTranspose(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.dotTranspose(other));
+        }
+
+        /// Matrix multiplication with left-side transpose: A^T * B.
+        pub fn transposeDot(self: *Self, other: Matrix(T)) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.transposeDot(other));
+        }
+
+        /// General matrix multiply: C = α · op(self) · op(other) + β · c
+        pub fn gemm(
+            self: *Self,
+            trans_a: bool,
+            other: Matrix(T),
+            trans_b: bool,
+            alpha: T,
+            beta: T,
+            c: ?Matrix(T),
+        ) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.gemm(trans_a, other, trans_b, alpha, beta, c));
+        }
+
+        /// Gram matrix: A · A^T.
+        pub fn gram(self: *Self) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.gram());
+        }
+
+        /// Covariance matrix: A^T · A.
+        pub fn covariance(self: *Self) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.covariance());
+        }
+
+        /// Matrix inverse.
+        pub fn inverse(self: *Self) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.inverse());
+        }
+
+        /// Moore-Penrose pseudo-inverse.
+        pub fn pseudoInverse(self: *Self, options: Matrix(T).PseudoInverseOptions) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.pseudoInverse(options));
+        }
+
+        /// Cholesky decomposition (lower triangular L such that A = L · L^T).
+        pub fn cholesky(self: *Self) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.cholesky());
+        }
+
+        /// Extract a submatrix.
+        pub fn subMatrix(self: *Self, row_begin: u32, col_begin: u32, row_count: u32, col_count: u32) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.subMatrix(row_begin, col_begin, row_count, col_count));
+        }
+
+        /// Extract a single column.
+        pub fn col(self: *Self, col_idx: u32) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.col(col_idx));
+        }
+
+        /// Extract a single row.
+        pub fn row(self: *Self, row_idx: u32) *Self {
+            if (self.err != null) return self;
+            return self.step(self.current.row(row_idx));
+        }
+    };
+}
+
+test "Chain: single-op success" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .initAll(allocator, 2, 2, 1.0);
+    defer a.deinit();
+
+    var p = a.chain();
+    defer p.deinit();
+    var r = try p.scale(2.0).toOwned();
+    defer r.deinit();
+    try std.testing.expectEqual(@as(f64, 2.0), r.at(0, 0).*);
+}
+
+test "Chain: multi-op chain frees intermediates" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .init(allocator, 2, 2);
+    defer a.deinit();
+    a.at(0, 0).* = 1.0;
+    a.at(0, 1).* = 2.0;
+    a.at(1, 0).* = 3.0;
+    a.at(1, 1).* = 4.0;
+
+    var p = a.chain();
+    defer p.deinit();
+    var r = try p.scale(2.0).offset(1.0).transpose().toOwned();
+    defer r.deinit();
+    // (a * 2 + 1) transposed: original a={1,2,3,4} -> {3,5,7,9} -> transpose
+    try std.testing.expectEqual(@as(f64, 3.0), r.at(0, 0).*);
+    try std.testing.expectEqual(@as(f64, 7.0), r.at(0, 1).*);
+    try std.testing.expectEqual(@as(f64, 5.0), r.at(1, 0).*);
+    try std.testing.expectEqual(@as(f64, 9.0), r.at(1, 1).*);
+}
+
+test "Chain: error short-circuits and toOwned surfaces it" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .initAll(allocator, 2, 3, 1.0);
+    defer a.deinit();
+    var b: Matrix(f64) = try .initAll(allocator, 4, 5, 1.0);
+    defer b.deinit();
+
+    var p = a.chain();
+    defer p.deinit();
+    try std.testing.expectError(error.DimensionMismatch, p.add(b).scale(2.0).toOwned());
+}
+
+test "Chain: zero-op chain returns a duplicate" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .initAll(allocator, 2, 2, 7.0);
+    defer a.deinit();
+
+    var p = a.chain();
+    defer p.deinit();
+    var r = try p.toOwned();
+    defer r.deinit();
+    try std.testing.expectEqual(@as(f64, 7.0), r.at(0, 0).*);
+    // Mutating r must not affect a.
+    r.at(0, 0).* = 0;
+    try std.testing.expectEqual(@as(f64, 7.0), a.at(0, 0).*);
+}
+
+test "Chain: abandoned chain (no toOwned) leaks nothing" {
+    const allocator = std.testing.allocator;
+    var a: Matrix(f64) = try .initAll(allocator, 2, 2, 1.0);
+    defer a.deinit();
+    var b: Matrix(f64) = try .initAll(allocator, 2, 2, 2.0);
+    defer b.deinit();
+
+    {
+        var p = a.chain();
+        defer p.deinit();
+        _ = p.add(b).scale(3.0); // never toOwned
+    }
+    // testing.allocator panics on leaks; reaching here means deinit cleaned up.
+}

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -1,37 +1,30 @@
 //! Dynamic matrix with runtime dimensions
 //!
-//! ## Chainable Operations
+//! ## Single operations
 //!
-//! Matrix operations can be chained together for expressive linear algebra:
-//! ```zig
-//! const result = try matrix.transpose().inverse().scale(2.0).eval();
-//! ```
-//!
-//! Each operation executes immediately and returns a new Matrix. Errors are
-//! stored internally and checked when you call `.eval()` at the end of the chain.
-//!
-//! ## Memory Management
-//!
-//! **Important**: When chaining multiple operations, each operation creates a new
-//! matrix. For optimal memory usage, use an ArenaAllocator:
+//! Each operation that produces a new matrix returns `MatrixError!Matrix(T)`.
+//! Use standard Zig error handling:
 //!
 //! ```zig
-//! var arena = std.heap.ArenaAllocator.init(allocator);
-//! defer arena.deinit();
-//!
-//! var matrix = try Matrix(f64).init(arena.allocator(), 10, 10);
-//! // ... initialize matrix ...
-//!
-//! // Chain operations - intermediate matrices are managed by arena
-//! const result = try matrix
-//!     .transpose()
-//!     .dot(other_matrix)
-//!     .inverse()
-//!     .eval();
+//! const product = try a.dot(b);
+//! defer product.deinit();
 //! ```
 //!
-//! With an arena allocator, all intermediate matrices created during the chain
-//! are automatically freed when the arena is destroyed, preventing memory leaks.
+//! ## Chained operations
+//!
+//! For multi-step chains, use `chain()` to obtain a `Chain(T)`. The
+//! `Chain` frees each intermediate as the next op runs, so peak memory is
+//! at most two matrices regardless of chain length.
+//!
+//! ```zig
+//! var p = matrix.chain();
+//! defer p.deinit();
+//! const result = try p.transpose().dot(other).inverse().toOwned();
+//! defer result.deinit();
+//! ```
+//!
+//! `defer p.deinit()` is safe whether or not `toOwned()` ran — `toOwned`
+//! transfers ownership of the final matrix to the caller and clears the chain.
 //!
 //! ## Available Operations
 //!
@@ -52,6 +45,7 @@ const meta = @import("../meta.zig");
 const formatting = @import("formatting.zig");
 const SMatrix = @import("SMatrix.zig").SMatrix;
 const svd_module = @import("svd.zig");
+const Chain = @import("Chain.zig").Chain;
 
 /// Matrix-specific errors
 pub const MatrixError = error{
@@ -114,7 +108,6 @@ pub fn Matrix(comptime T: type) type {
         rows: u32,
         cols: u32,
         allocator: std.mem.Allocator,
-        err: ?MatrixError = null,
 
         pub const PseudoInverseOptions = struct {
             /// Optional absolute tolerance used to discard very small singular values.
@@ -150,15 +143,17 @@ pub fn Matrix(comptime T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            // Poisoned matrices from failed chains have an undefined pointer;
-            // freeing that would be UB. Valid 0x0 matrices are safe to free.
-            if (self.err != null) return;
             self.allocator.free(self.items);
+        }
+
+        /// Lift this matrix into a `Chain(T)` for fluent chaining of multiple ops.
+        /// The matrix is borrowed — callers retain ownership and must still `deinit` it.
+        pub fn chain(self: Self) Chain(T) {
+            return Chain(T).from(self);
         }
 
         /// Cast the underlying items of the matrix from T to U.
         pub fn as(self: Self, allocator: std.mem.Allocator, comptime U: type) !Matrix(U) {
-            if (self.err) |e| return Matrix(U).errorMatrix(allocator, e);
             var result: Matrix(U) = try .init(allocator, self.rows, self.cols);
             for (0..self.rows) |r| {
                 for (0..self.cols) |c| {
@@ -171,16 +166,7 @@ pub fn Matrix(comptime T: type) type {
 
         /// Create a duplicate of this matrix with the specified allocator.
         /// The caller owns the returned matrix and must call deinit() on it.
-        ///
-        /// Error propagation: if this matrix carries a deferred error (`self.err != null`),
-        /// the duplicate will also carry the same error and no allocation is performed.
-        /// This preserves failure state across chains.
-        ///
-        /// Example:
-        /// var copy = try matrix.dupe(allocator);
-        /// defer copy.deinit();
         pub fn dupe(self: Self, allocator: std.mem.Allocator) !Self {
-            if (self.err) |e| return errorMatrix(allocator, e);
             const result = try Self.init(allocator, self.rows, self.cols);
             @memcpy(result.items, self.items);
             return result;
@@ -229,18 +215,11 @@ pub fn Matrix(comptime T: type) type {
         // ===== Chainable operations (return Self) =====
 
         /// Add another matrix element-wise
-        pub fn add(self: Self, other: Self) Self {
-            if (self.err != null) return self;
-            if (other.err != null) return other;
-
+        pub fn add(self: Self, other: Self) MatrixError!Self {
             if (self.rows != other.rows or self.cols != other.cols) {
-                return errorMatrix(self.allocator, error.DimensionMismatch);
+                return error.DimensionMismatch;
             }
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = self.items[i] + other.items[i];
             }
@@ -248,18 +227,11 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Subtract another matrix element-wise
-        pub fn sub(self: Self, other: Self) Self {
-            if (self.err != null) return self;
-            if (other.err != null) return other;
-
+        pub fn sub(self: Self, other: Self) MatrixError!Self {
             if (self.rows != other.rows or self.cols != other.cols) {
-                return errorMatrix(self.allocator, error.DimensionMismatch);
+                return error.DimensionMismatch;
             }
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = self.items[i] - other.items[i];
             }
@@ -267,13 +239,8 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Scale all elements by a value
-        pub fn scale(self: Self, value: T) Self {
-            if (self.err != null) return self;
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn scale(self: Self, value: T) MatrixError!Self {
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = self.items[i] * value;
             }
@@ -281,13 +248,8 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Transpose the matrix
-        pub fn transpose(self: Self) Self {
-            if (self.err != null) return self;
-
-            var result = Matrix(T).init(self.allocator, self.cols, self.rows) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn transpose(self: Self) MatrixError!Self {
+            var result = try Matrix(T).init(self.allocator, self.cols, self.rows);
             for (0..self.rows) |r| {
                 for (0..self.cols) |c| {
                     result.at(c, r).* = self.at(r, c).*;
@@ -297,18 +259,11 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Perform element-wise multiplication
-        pub fn times(self: Self, other: Self) Self {
-            if (self.err != null) return self;
-            if (other.err != null) return other;
-
+        pub fn times(self: Self, other: Self) MatrixError!Self {
             if (self.rows != other.rows or self.cols != other.cols) {
-                return errorMatrix(self.allocator, error.DimensionMismatch);
+                return error.DimensionMismatch;
             }
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = self.items[i] * other.items[i];
             }
@@ -316,34 +271,26 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Matrix multiplication (dot product) - changes dimensions
-        pub fn dot(self: Self, other: Self) Self {
+        pub fn dot(self: Self, other: Self) MatrixError!Self {
             return self.gemm(false, other, false, 1.0, 0.0, null);
         }
 
         /// Inverts the matrix using analytical formulas for small matrices (≤3x3)
         /// and Gauss-Jordan elimination for larger matrices
-        pub fn inverse(self: Self) Self {
-            if (self.err != null) return self;
-
-            if (self.rows != self.cols) {
-                return errorMatrix(self.allocator, error.NotSquare);
-            }
+        pub fn inverse(self: Self) MatrixError!Self {
+            if (self.rows != self.cols) return error.NotSquare;
 
             const n = self.rows;
 
             // Use analytical formulas for small matrices (more efficient)
             if (n <= 3) {
-                const det = self.determinant() catch |e| {
-                    return errorMatrix(self.allocator, e);
-                };
+                const det = try self.determinant();
 
                 if (@abs(det) < std.math.floatEps(T)) {
-                    return errorMatrix(self.allocator, error.Singular);
+                    return error.Singular;
                 }
 
-                var inv = Matrix(T).init(self.allocator, n, n) catch |e| {
-                    return errorMatrix(self.allocator, e);
-                };
+                var inv = try Matrix(T).init(self.allocator, n, n);
 
                 switch (n) {
                     1 => inv.at(0, 0).* = 1 / det,
@@ -378,53 +325,39 @@ pub fn Matrix(comptime T: type) type {
         /// Works for rectangular matrices and gracefully handles rank deficiency
         /// by discarding singular values below the provided tolerance. The optional
         /// `effective_rank` pointer receives the number of singular values kept.
-        pub fn pseudoInverse(self: Self, options: PseudoInverseOptions) Self {
-            if (self.err != null) return self;
-
-            if (self.rows == 0 or self.cols == 0) {
-                return errorMatrix(self.allocator, error.DimensionMismatch);
-            }
+        pub fn pseudoInverse(self: Self, options: PseudoInverseOptions) MatrixError!Self {
+            if (self.rows == 0 or self.cols == 0) return error.DimensionMismatch;
 
             if (self.rows >= self.cols) {
                 return self.pseudoInverseTall(options);
             }
 
-            var transposed = self.transpose();
-            if (transposed.err != null) return transposed;
+            var transposed = try self.transpose();
             defer transposed.deinit();
 
-            var pinv_transposed = transposed.pseudoInverseTall(options);
-            if (pinv_transposed.err != null) return pinv_transposed;
+            var pinv_transposed = try transposed.pseudoInverseTall(options);
+            defer pinv_transposed.deinit();
 
-            const result = pinv_transposed.transpose();
-            pinv_transposed.deinit();
-            return result;
+            return pinv_transposed.transpose();
         }
 
-        fn pseudoInverseTall(self: Self, options: PseudoInverseOptions) Self {
-            if (self.err != null) return self;
+        fn pseudoInverseTall(self: Self, options: PseudoInverseOptions) MatrixError!Self {
             std.debug.assert(self.rows >= self.cols);
 
             const allocator = self.allocator;
             const svd_options = SvdOptions{ .with_u = true, .with_v = true, .mode = .skinny_u };
 
-            var svd_result = self.svd(allocator, svd_options) catch |e| {
-                return errorMatrix(allocator, e);
-            };
+            var svd_result = try self.svd(allocator, svd_options);
             defer svd_result.deinit();
 
-            if (svd_result.converged != 0) {
-                return errorMatrix(allocator, error.NotConverged);
-            }
+            if (svd_result.converged != 0) return error.NotConverged;
 
             const singular_count = svd_result.s.rows;
             const sigma_max: T = if (singular_count > 0) svd_result.s.at(0, 0).* else 0;
             if (sigma_max == 0) {
                 const zero_rows = self.cols;
                 const zero_cols = self.rows;
-                const zero = Matrix(T).initAll(allocator, zero_rows, zero_cols, 0) catch |e| {
-                    return errorMatrix(allocator, e);
-                };
+                const zero = try Matrix(T).initAll(allocator, zero_rows, zero_cols, 0);
                 if (options.effective_rank) |rank_ptr| {
                     rank_ptr.* = 0;
                 }
@@ -434,9 +367,7 @@ pub fn Matrix(comptime T: type) type {
             const default_tol: T = sigma_max * @as(T, @floatFromInt(max_dim)) * std.math.floatEps(T);
             const tol = options.tolerance orelse default_tol;
 
-            var sigma_inv = Matrix(T).initAll(allocator, singular_count, singular_count, 0) catch |e| {
-                return errorMatrix(allocator, e);
-            };
+            var sigma_inv = try Matrix(T).initAll(allocator, singular_count, singular_count, 0);
             defer sigma_inv.deinit();
 
             var effective_rank: u32 = 0;
@@ -452,12 +383,10 @@ pub fn Matrix(comptime T: type) type {
                 rank_ptr.* = effective_rank;
             }
 
-            var u_t = svd_result.u.transpose();
-            if (u_t.err != null) return u_t;
+            var u_t = try svd_result.u.transpose();
             defer u_t.deinit();
 
-            var v_sigma = svd_result.v.dot(sigma_inv);
-            if (v_sigma.err != null) return v_sigma;
+            var v_sigma = try svd_result.v.dot(sigma_inv);
             defer v_sigma.deinit();
 
             return v_sigma.dot(u_t);
@@ -465,15 +394,11 @@ pub fn Matrix(comptime T: type) type {
 
         /// Inverts the matrix using Gauss-Jordan elimination with partial pivoting
         /// This is a general method that works for any size square matrix
-        fn inverseGaussJordan(self: Self) Self {
-            if (self.err != null) return self;
-
+        fn inverseGaussJordan(self: Self) MatrixError!Self {
             const n = self.rows;
 
             // Create augmented matrix [A | I]
-            var augmented = Matrix(T).init(self.allocator, n, 2 * n) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
+            var augmented = try Matrix(T).init(self.allocator, n, 2 * n);
             defer augmented.deinit();
 
             // Copy original matrix to left half and identity to right half
@@ -499,9 +424,7 @@ pub fn Matrix(comptime T: type) type {
                 }
 
                 // Check for singular matrix
-                if (max_val < std.math.floatEps(T) * 10) {
-                    return errorMatrix(self.allocator, error.Singular);
-                }
+                if (max_val < std.math.floatEps(T) * 10) return error.Singular;
 
                 // Swap rows if needed
                 if (max_row != pivot_col) {
@@ -530,9 +453,7 @@ pub fn Matrix(comptime T: type) type {
             }
 
             // Extract inverse from right half of augmented matrix
-            var inv = Matrix(T).init(self.allocator, n, n) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
+            var inv = try Matrix(T).init(self.allocator, n, n);
 
             for (0..n) |i| {
                 for (0..n) |j| {
@@ -544,75 +465,50 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Extract a submatrix - changes dimensions
-        pub fn subMatrix(self: Self, row_begin: u32, col_begin: u32, row_count: u32, col_count: u32) Self {
-            if (self.err != null) return self;
-
+        pub fn subMatrix(self: Self, row_begin: u32, col_begin: u32, row_count: u32, col_count: u32) MatrixError!Self {
             if (row_begin + row_count > self.rows or col_begin + col_count > self.cols) {
-                return errorMatrix(self.allocator, error.OutOfBounds);
+                return error.OutOfBounds;
             }
-
-            var result = Matrix(T).init(self.allocator, row_count, col_count) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+            var result = try Matrix(T).init(self.allocator, row_count, col_count);
             for (0..row_count) |r| {
                 for (0..col_count) |c| {
                     result.at(r, c).* = self.at(row_begin + r, col_begin + c).*;
                 }
             }
-
             return result;
         }
 
         /// Extract a column - changes dimensions
-        pub fn col(self: Self, col_idx: u32) Self {
-            if (self.err != null) return self;
-
-            if (col_idx >= self.cols) {
-                return errorMatrix(self.allocator, error.OutOfBounds);
-            }
-
-            var result = Matrix(T).init(self.allocator, self.rows, 1) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn col(self: Self, col_idx: u32) MatrixError!Self {
+            if (col_idx >= self.cols) return error.OutOfBounds;
+            var result = try Matrix(T).init(self.allocator, self.rows, 1);
             for (0..self.rows) |r| {
                 result.at(r, 0).* = self.at(r, col_idx).*;
             }
-
             return result;
         }
 
         /// Extract a row - changes dimensions
-        pub fn row(self: Self, row_idx: u32) Self {
-            if (self.err != null) return self;
-
-            if (row_idx >= self.rows) {
-                return errorMatrix(self.allocator, error.OutOfBounds);
-            }
-
-            var result = Matrix(T).init(self.allocator, 1, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn row(self: Self, row_idx: u32) MatrixError!Self {
+            if (row_idx >= self.rows) return error.OutOfBounds;
+            var result = try Matrix(T).init(self.allocator, 1, self.cols);
             for (0..self.cols) |c| {
                 result.at(0, c).* = self.at(row_idx, c).*;
             }
-
             return result;
         }
 
         /// Compute Gram matrix: X * X^T
         /// Useful for kernel methods and when rows < columns
         /// The resulting matrix is rows × rows
-        pub fn gram(self: Self) Self {
+        pub fn gram(self: Self) MatrixError!Self {
             return self.gemm(false, self, true, 1.0, 0.0, null);
         }
 
         /// Compute covariance matrix: X^T * X
         /// Useful for statistical analysis and when rows > columns
         /// The resulting matrix is columns × columns
-        pub fn covariance(self: Self) Self {
+        pub fn covariance(self: Self) MatrixError!Self {
             return self.gemm(true, self, false, 1.0, 0.0, null);
         }
 
@@ -696,14 +592,7 @@ pub fn Matrix(comptime T: type) type {
             alpha: T,
             beta: T,
             c: ?Self,
-        ) Self {
-            if (self.err != null) return self;
-            if (other.err != null) return other;
-
-            if (c) |c_mat| {
-                if (c_mat.err != null) return c_mat;
-            }
-
+        ) MatrixError!Self {
             // Determine dimensions after potential transposition
             const a_rows = if (trans_a) self.cols else self.rows;
             const a_cols = if (trans_a) self.rows else self.cols;
@@ -711,19 +600,15 @@ pub fn Matrix(comptime T: type) type {
             const b_cols = if (trans_b) other.rows else other.cols;
 
             // Verify matrix multiplication compatibility
-            if (a_cols != b_rows) {
-                return errorMatrix(self.allocator, error.DimensionMismatch);
-            }
+            if (a_cols != b_rows) return error.DimensionMismatch;
 
-            var result = Matrix(T).init(self.allocator, a_rows, b_cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
+            var result = try Matrix(T).init(self.allocator, a_rows, b_cols);
+            errdefer result.deinit();
 
             // Initialize with scaled C matrix if provided
             if (c) |c_mat| {
                 if (c_mat.rows != a_rows or c_mat.cols != b_cols) {
-                    result.deinit();
-                    return errorMatrix(self.allocator, error.DimensionMismatch);
+                    return error.DimensionMismatch;
                 }
                 if (beta != 0) {
                     for (0..a_rows) |i| {
@@ -759,10 +644,7 @@ pub fn Matrix(comptime T: type) type {
                             std.mem.eql(T, self.items, other.items))
                         {
                             // For A * A, we need to transpose A for the second operand
-                            var a_transposed = Matrix(T).init(self.allocator, b_cols, a_cols) catch |e| {
-                                result.deinit();
-                                return errorMatrix(self.allocator, e);
-                            };
+                            var a_transposed = try Matrix(T).init(self.allocator, b_cols, a_cols);
                             defer a_transposed.deinit();
                             for (0..a_cols) |k| {
                                 for (0..b_cols) |j| {
@@ -772,10 +654,7 @@ pub fn Matrix(comptime T: type) type {
                             simdGemmKernel(VecType, &result, self, a_transposed, alpha, a_rows, a_cols, b_cols);
                         } else {
                             // General case: transpose B for cache-friendly row-major access
-                            var b_transposed = Matrix(T).init(self.allocator, b_cols, a_cols) catch |e| {
-                                result.deinit();
-                                return errorMatrix(self.allocator, e);
-                            };
+                            var b_transposed = try Matrix(T).init(self.allocator, b_cols, a_cols);
                             defer b_transposed.deinit();
                             for (0..a_cols) |k| {
                                 for (0..b_cols) |j| {
@@ -786,10 +665,7 @@ pub fn Matrix(comptime T: type) type {
                         }
                     } else if (trans_a and !trans_b) {
                         // Case 2: A^T * B - transpose A for cache-friendly row-major access
-                        var a_transposed = Matrix(T).init(self.allocator, a_rows, a_cols) catch |e| {
-                            result.deinit();
-                            return errorMatrix(self.allocator, e);
-                        };
+                        var a_transposed = try Matrix(T).init(self.allocator, a_rows, a_cols);
                         defer a_transposed.deinit();
                         // Transpose A: a_transposed[i,j] = A[j,i]
                         for (0..a_cols) |k| {
@@ -806,10 +682,7 @@ pub fn Matrix(comptime T: type) type {
                             simdGemmKernel(VecType, &result, a_transposed, a_transposed, alpha, a_rows, a_cols, b_cols);
                         } else {
                             // General case: transpose B for row-wise access
-                            var b_transposed = Matrix(T).init(self.allocator, b_cols, a_cols) catch |e| {
-                                result.deinit();
-                                return errorMatrix(self.allocator, e);
-                            };
+                            var b_transposed = try Matrix(T).init(self.allocator, b_cols, a_cols);
                             defer b_transposed.deinit();
                             for (0..a_cols) |k| {
                                 for (0..b_cols) |j| {
@@ -827,10 +700,7 @@ pub fn Matrix(comptime T: type) type {
                             std.mem.eql(T, self.items, other.items))
                         {
                             // For A * A^T, we need to transpose A for the second operand
-                            var a_transposed = Matrix(T).init(self.allocator, b_cols, a_cols) catch |e| {
-                                result.deinit();
-                                return errorMatrix(self.allocator, e);
-                            };
+                            var a_transposed = try Matrix(T).init(self.allocator, b_cols, a_cols);
                             defer a_transposed.deinit();
                             for (0..a_cols) |k| {
                                 for (0..b_cols) |j| {
@@ -844,10 +714,7 @@ pub fn Matrix(comptime T: type) type {
                         }
                     } else if (trans_a and trans_b) {
                         // Case 4: A^T * B^T - transpose A so rows are contiguous, reuse B rows directly
-                        var a_transposed = Matrix(T).init(self.allocator, a_rows, a_cols) catch |e| {
-                            result.deinit();
-                            return errorMatrix(self.allocator, e);
-                        };
+                        var a_transposed = try Matrix(T).init(self.allocator, a_rows, a_cols);
                         defer a_transposed.deinit();
                         for (0..a_rows) |i| {
                             for (0..a_cols) |j| {
@@ -880,30 +747,25 @@ pub fn Matrix(comptime T: type) type {
 
         /// Scaled matrix multiplication: α * A * B
         /// Convenience method for common GEMM use case
-        pub fn scaledDot(self: Self, other: Self, alpha: T) Self {
+        pub fn scaledDot(self: Self, other: Self, alpha: T) MatrixError!Self {
             return self.gemm(false, other, false, alpha, 0.0, null);
         }
 
         /// Matrix multiplication with transpose: A * B^T
         /// Convenience method for common GEMM use case
-        pub fn dotTranspose(self: Self, other: Self) Self {
+        pub fn dotTranspose(self: Self, other: Self) MatrixError!Self {
             return self.gemm(false, other, true, 1.0, 0.0, null);
         }
 
         /// Transpose matrix multiplication: A^T * B
         /// Convenience method for common GEMM use case
-        pub fn transposeDot(self: Self, other: Self) Self {
+        pub fn transposeDot(self: Self, other: Self) MatrixError!Self {
             return self.gemm(true, other, false, 1.0, 0.0, null);
         }
 
         /// Apply a function to all matrix elements with optional arguments
-        pub fn apply(self: Self, comptime func: anytype, args: anytype) Self {
-            if (self.err != null) return self;
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn apply(self: Self, comptime func: anytype, args: anytype) MatrixError!Self {
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = @call(.auto, func, .{self.items[i]} ++ args);
             }
@@ -911,13 +773,8 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Add scalar to all elements
-        pub fn offset(self: Self, value: T) Self {
-            if (self.err != null) return self;
-
-            var result = Matrix(T).init(self.allocator, self.rows, self.cols) catch |e| {
-                return errorMatrix(self.allocator, e);
-            };
-
+        pub fn offset(self: Self, value: T) MatrixError!Self {
+            var result = try Matrix(T).init(self.allocator, self.rows, self.cols);
             for (0..result.items.len) |i| {
                 result.items[i] = self.items[i] + value;
             }
@@ -925,7 +782,7 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Raise all elements to power n (convenience method)
-        pub fn pow(self: Self, n: T) Self {
+        pub fn pow(self: Self, n: T) MatrixError!Self {
             const powN = struct {
                 fn f(x: T, exponent: T) T {
                     return std.math.pow(T, x, exponent);
@@ -939,28 +796,10 @@ pub fn Matrix(comptime T: type) type {
                 @compileError(context ++ " requires floating-point elements");
         }
 
-        /// Terminal operation - evaluates the chain and returns result or error
-        pub fn eval(self: Self) MatrixError!Self {
-            if (self.err) |e| return e;
-            return self;
-        }
-
-        /// Helper to create an error matrix
-        fn errorMatrix(allocator: std.mem.Allocator, err: MatrixError) Self {
-            return Self{
-                .items = @as([*]align(simd_alignment) T, undefined)[0..0],
-                .rows = 0,
-                .cols = 0,
-                .allocator = allocator,
-                .err = err,
-            };
-        }
-
         // ===== Query operations (return values, not Self) =====
 
         /// Sums all the elements in a matrix.
         pub fn sum(self: Self) T {
-            assert(self.err == null);
             var accum: T = 0;
             for (self.items) |val| {
                 accum += val;
@@ -971,7 +810,7 @@ pub fn Matrix(comptime T: type) type {
         /// Computes the Frobenius norm of the matrix.
         pub fn frobeniusNorm(self: Self) T {
             ensureFloat("frobeniusNorm");
-            assert(self.err == null);
+
             var squared_sum: T = 0;
             for (self.items) |val| {
                 squared_sum += val * val;
@@ -981,14 +820,12 @@ pub fn Matrix(comptime T: type) type {
 
         /// Mean (average) of all elements
         pub fn mean(self: Self) T {
-            assert(self.err == null);
             assert(self.items.len > 0);
             return self.sum() / @as(T, @floatFromInt(self.items.len));
         }
 
         /// Variance: E[(X - μ)²]
         pub fn variance(self: Self) T {
-            assert(self.err == null);
             assert(self.items.len > 0);
             const mu = self.mean();
             var sum_sq_diff: T = 0;
@@ -1002,13 +839,12 @@ pub fn Matrix(comptime T: type) type {
         /// Standard deviation: sqrt(variance)
         pub fn stdDev(self: Self) T {
             ensureFloat("stdDev");
-            assert(self.err == null);
+
             return @sqrt(self.variance());
         }
 
         /// Minimum element
         pub fn min(self: Self) T {
-            assert(self.err == null);
             assert(self.items.len > 0);
             var min_val = self.items[0];
             for (self.items[1..]) |val| {
@@ -1021,7 +857,6 @@ pub fn Matrix(comptime T: type) type {
 
         /// Maximum element
         pub fn max(self: Self) T {
-            assert(self.err == null);
             assert(self.items.len > 0);
             var max_val = self.items[0];
             for (self.items[1..]) |val| {
@@ -1035,7 +870,7 @@ pub fn Matrix(comptime T: type) type {
         /// Entrywise L1 norm: sum of absolute values of all elements
         pub fn l1Norm(self: Self) T {
             ensureFloat("l1Norm");
-            assert(self.err == null);
+
             var sum_abs: T = 0;
             for (self.items) |val| {
                 sum_abs += @abs(val);
@@ -1046,7 +881,7 @@ pub fn Matrix(comptime T: type) type {
         /// Max norm (L-infinity): maximum absolute value
         pub fn maxNorm(self: Self) T {
             ensureFloat("maxNorm");
-            assert(self.err == null);
+
             var max_abs: T = 0;
             for (self.items) |val| {
                 const abs_val = @abs(val);
@@ -1060,7 +895,7 @@ pub fn Matrix(comptime T: type) type {
         /// Minimum absolute value among all elements.
         pub fn minNorm(self: Self) T {
             ensureFloat("minNorm");
-            assert(self.err == null);
+
             if (self.items.len == 0) return 0;
             var min_abs = @abs(self.items[0]);
             for (self.items[1..]) |val| {
@@ -1075,7 +910,7 @@ pub fn Matrix(comptime T: type) type {
         /// Counts non-zero elements.
         pub fn sparseNorm(self: Self) T {
             ensureFloat("sparseNorm");
-            assert(self.err == null);
+
             var count: T = 0;
             for (self.items) |val| {
                 if (val != 0) count += 1;
@@ -1086,7 +921,7 @@ pub fn Matrix(comptime T: type) type {
         /// Entrywise ℓᵖ norm with optional runtime exponent.
         pub fn elementNorm(self: Self, p: T) MatrixError!T {
             ensureFloat("elementNorm");
-            if (self.err) |e| return e;
+
             if (std.math.isInf(p)) {
                 if (p > 0) {
                     return self.maxNorm();
@@ -1119,12 +954,11 @@ pub fn Matrix(comptime T: type) type {
 
         fn leadingSingularValue(self: Self, allocator: std.mem.Allocator) !T {
             ensureFloat("leadingSingularValue");
-            if (self.err) |e| return e;
+
             if (self.rows == 0 or self.cols == 0) return 0;
 
             if (self.rows < self.cols) {
-                var transposed = self.transpose();
-                if (transposed.err) |err| return err;
+                var transposed = try self.transpose();
                 defer transposed.deinit();
                 return transposed.leadingSingularValue(allocator);
             }
@@ -1139,7 +973,7 @@ pub fn Matrix(comptime T: type) type {
 
         fn sumSingularP(self: Self, allocator: std.mem.Allocator, exponent: T) !T {
             ensureFloat("schattenNorm");
-            if (self.err) |e| return e;
+
             if (self.rows == 0 or self.cols == 0) return 0;
 
             if (self.rows >= self.cols) {
@@ -1155,8 +989,7 @@ pub fn Matrix(comptime T: type) type {
                 return accum;
             }
 
-            var transposed = self.transpose();
-            if (transposed.err) |err| return err;
+            var transposed = try self.transpose();
             defer transposed.deinit();
             return transposed.sumSingularP(allocator, exponent);
         }
@@ -1164,7 +997,7 @@ pub fn Matrix(comptime T: type) type {
         /// Schatten p-norm of the matrix.
         pub fn schattenNorm(self: Self, allocator: std.mem.Allocator, p: T) !T {
             ensureFloat("schattenNorm");
-            if (self.err) |e| return e;
+
             if (std.math.isInf(p)) {
                 if (p > 0) {
                     return self.leadingSingularValue(allocator);
@@ -1197,7 +1030,7 @@ pub fn Matrix(comptime T: type) type {
         /// Induced operator norms with p ∈ {1, 2, ∞}.
         pub fn inducedNorm(self: Self, allocator: std.mem.Allocator, p: T) !T {
             ensureFloat("inducedNorm");
-            if (self.err) |e| return e;
+
             if (p == 1) {
                 var max_sum: T = 0;
                 for (0..self.cols) |c| {
@@ -1230,7 +1063,6 @@ pub fn Matrix(comptime T: type) type {
 
         /// Trace: sum of diagonal elements (square matrices only)
         pub fn trace(self: Self) T {
-            assert(self.err == null);
             assert(self.rows == self.cols);
             var sum_diag: T = 0;
             for (0..self.rows) |i| {
@@ -1261,7 +1093,6 @@ pub fn Matrix(comptime T: type) type {
         /// Compute LU decomposition with partial pivoting
         /// Returns L, U matrices and permutation vector such that PA = LU
         pub fn lu(self: Self) !LuResult {
-            if (self.err) |e| return e;
             comptime assert(@typeInfo(T) == .float);
             const n = self.rows;
             if (n != self.cols) return error.NotSquare;
@@ -1365,13 +1196,12 @@ pub fn Matrix(comptime T: type) type {
 
         /// Computes the Cholesky decomposition of a symmetric positive-definite matrix.
         /// Returns L such that A = L * L^T where L is lower triangular.
-        /// This is a chainable operation.
-        pub fn cholesky(self: Self) Self {
-            if (self.err != null) return self;
+        pub fn cholesky(self: Self) MatrixError!Self {
             ensureFloat("cholesky");
-            if (self.rows != self.cols) return errorMatrix(self.allocator, error.NotSquare);
+            if (self.rows != self.cols) return error.NotSquare;
             const n = self.rows;
-            var l = Matrix(T).init(self.allocator, n, n) catch |e| return errorMatrix(self.allocator, e);
+            var l = try Matrix(T).init(self.allocator, n, n);
+            errdefer l.deinit();
             @memset(l.items, 0);
             for (0..n) |i| {
                 for (0..i + 1) |j| {
@@ -1379,10 +1209,7 @@ pub fn Matrix(comptime T: type) type {
                     for (0..j) |k| accum += l.at(i, k).* * l.at(j, k).*;
                     if (i == j) {
                         const val = self.at(i, i).* - accum;
-                        if (val <= 0) {
-                            l.deinit();
-                            return errorMatrix(self.allocator, error.NotPositiveDefinite);
-                        }
+                        if (val <= 0) return error.NotPositiveDefinite;
                         l.at(i, i).* = @sqrt(val);
                     } else {
                         const val = self.at(i, j).* - accum;
@@ -1396,7 +1223,6 @@ pub fn Matrix(comptime T: type) type {
         /// Computes the determinant of the matrix using analytical formulas for small matrices
         /// and LU decomposition for larger matrices
         pub fn determinant(self: Self) !T {
-            if (self.err) |e| return e;
             comptime assert(@typeInfo(T) == .float);
             if (self.rows != self.cols) return error.NotSquare;
             if (self.rows == 0) return error.DimensionMismatch;
@@ -1452,7 +1278,6 @@ pub fn Matrix(comptime T: type) type {
         /// Returns Q, R matrices and permutation such that A*P = Q*R where Q is orthogonal and R is upper triangular
         /// Also computes the numerical rank of the matrix
         pub fn qr(self: Self) !QrResult {
-            if (self.err) |e| return e;
             comptime assert(@typeInfo(T) == .float);
             const m = self.rows;
             const n = self.cols;
@@ -1608,7 +1433,6 @@ pub fn Matrix(comptime T: type) type {
         /// The rank is determined by counting non-zero diagonal elements in R
         /// above a tolerance based on machine precision and matrix norm
         pub fn rank(self: Self) !u32 {
-            if (self.err) |e| return e;
             comptime assert(@typeInfo(T) == .float);
             // Compute QR decomposition with column pivoting
             var qr_result = try self.qr();
@@ -1636,7 +1460,6 @@ pub fn Matrix(comptime T: type) type {
         ///
         /// Requires rows >= cols. See `SvdOptions` for configuration details.
         pub fn svd(self: Self, allocator: std.mem.Allocator, options: SvdOptions) !SvdResult(T) {
-            if (self.err) |e| return e;
             comptime assert(@typeInfo(T) == .float);
             if (self.rows < self.cols) return error.DimensionMismatch;
             return svd_module.svd(T, allocator, self, options);
@@ -1688,47 +1511,34 @@ test "Matrix as" {
 }
 
 // Tests for dynamic Matrix functionality
-test "matrix propagates chained errors" {
+test "matrix surfaces errors at the source op" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
+    const alloc = arena.allocator();
 
-    var singular = try Matrix(f64).init(arena.allocator(), 2, 2);
+    var singular = try Matrix(f64).init(alloc, 2, 2);
     defer singular.deinit();
-
     singular.at(0, 0).* = 1;
     singular.at(0, 1).* = 2;
     singular.at(1, 0).* = 2;
     singular.at(1, 1).* = 4;
 
-    var invalid = singular.inverse();
-    defer invalid.deinit();
+    // Singular inverse surfaces error directly — no deferred state.
+    try expectError(MatrixError.Singular, singular.inverse());
 
-    var valid: Matrix(f64) = try .initAll(arena.allocator(), 2, 2, 1.0);
-    defer valid.deinit();
+    // Dimension mismatch surfaces from the failing op directly.
+    var a = try Matrix(f64).initAll(alloc, 2, 3, 1.0);
+    defer a.deinit();
+    var b = try Matrix(f64).initAll(alloc, 3, 2, 1.0);
+    defer b.deinit();
+    try expectError(MatrixError.DimensionMismatch, a.add(b));
+    try expectError(MatrixError.DimensionMismatch, a.sub(b));
+    try expectError(MatrixError.DimensionMismatch, a.times(b));
 
-    var left_error = invalid.add(valid);
-    defer left_error.deinit();
-    try expectError(MatrixError.Singular, left_error.eval());
-
-    var right_error = valid.add(invalid);
-    defer right_error.deinit();
-    try expectError(MatrixError.Singular, right_error.eval());
-
-    var sub_error = valid.sub(invalid);
-    defer sub_error.deinit();
-    try expectError(MatrixError.Singular, sub_error.eval());
-
-    var times_error = valid.times(invalid);
-    defer times_error.deinit();
-    try expectError(MatrixError.Singular, times_error.eval());
-
-    var gemm_other_error = valid.gemm(false, invalid, false, 1.0, 0.0, null);
-    defer gemm_other_error.deinit();
-    try expectError(MatrixError.Singular, gemm_other_error.eval());
-
-    var gemm_c_error = valid.gemm(false, valid, false, 1.0, 1.0, invalid);
-    defer gemm_c_error.deinit();
-    try expectError(MatrixError.Singular, gemm_c_error.eval());
+    // Chains short-circuit at the failing step and free intermediates.
+    var p = a.chain();
+    defer p.deinit();
+    try expectError(MatrixError.DimensionMismatch, p.add(b).scale(2.0).toOwned());
 }
 
 test "matrix elementNorm invalid exponent" {

--- a/src/matrix/test_ops_advanced.zig
+++ b/src/matrix/test_ops_advanced.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const expectEqual = std.testing.expectEqual;
-const matrix_module = @import("Matrix.zig");
-const Matrix = matrix_module.Matrix;
-const MatrixError = matrix_module.MatrixError;
+const Matrix = @import("Matrix.zig").Matrix;
 
 test "Matrix apply method" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
@@ -18,7 +16,7 @@ test "Matrix apply method" {
     mat.at(1, 2).* = 36.0;
 
     // Test apply with no arguments (sqrt)
-    var result1 = try mat.apply(std.math.sqrt, .{}).eval();
+    var result1 = try mat.apply(std.math.sqrt, .{});
     defer result1.deinit();
 
     try expectEqual(@as(f64, 1.0), result1.at(0, 0).*);
@@ -34,7 +32,7 @@ test "Matrix apply method" {
             return std.math.pow(f64, x, n);
         }
     }.f;
-    var result2 = try result1.apply(pow2, .{@as(f64, 2.0)}).eval();
+    var result2 = try result1.apply(pow2, .{@as(f64, 2.0)});
     defer result2.deinit();
 
     try expectEqual(@as(f64, 1.0), result2.at(0, 0).*);
@@ -51,7 +49,7 @@ test "Matrix apply method" {
         }
     }.f;
 
-    var result3 = try result1.apply(reciprocal, .{}).eval();
+    var result3 = try result1.apply(reciprocal, .{});
     defer result3.deinit();
 
     try expectEqual(@as(f64, 1.0), result3.at(0, 0).*);
@@ -119,32 +117,17 @@ test "Matrix norms" {
     try expectEqual(@as(f64, 5.0), mat.trace());
 }
 
-test "Matrix poisoned chain: deinit safe and !T queries surface err" {
+test "Matrix dimension errors surface at the failing op" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    const a: Matrix(f64) = try .init(alloc, 2, 3);
-    @memset(a.items, 1.0);
-    const b: Matrix(f64) = try .init(alloc, 4, 5);
-    @memset(b.items, 1.0);
+    const a: Matrix(f64) = try .initAll(alloc, 2, 3, 1.0);
+    const b: Matrix(f64) = try .initAll(alloc, 4, 5, 1.0);
 
-    // add() with mismatched dims produces a poisoned matrix without unwrapping.
-    var poisoned = a.add(b);
-    try std.testing.expectEqual(@as(MatrixError, error.DimensionMismatch), poisoned.err.?);
-
-    // deinit on a poisoned matrix must not free the undefined pointer.
-    poisoned.deinit();
-
-    // eval() on a fresh poisoned matrix surfaces the deferred error.
-    var poisoned2 = a.add(b);
-    try std.testing.expectError(error.DimensionMismatch, poisoned2.eval());
-    poisoned2.deinit();
-
-    // Already-`!T` query ops surface the deferred error rather than asserting.
-    var poisoned3 = a.add(b);
-    try std.testing.expectError(error.DimensionMismatch, poisoned3.elementNorm(2.0));
-    poisoned3.deinit();
+    try std.testing.expectError(error.DimensionMismatch, a.add(b));
+    try std.testing.expectError(error.DimensionMismatch, a.sub(b));
+    try std.testing.expectError(error.DimensionMismatch, a.times(b));
 }
 
 test "Matrix offset and pow" {
@@ -159,7 +142,7 @@ test "Matrix offset and pow" {
     mat.at(1, 1).* = 4.0;
 
     // Test offset
-    var result1 = try mat.offset(5.0).eval();
+    var result1 = try mat.offset(5.0);
     defer result1.deinit();
 
     try expectEqual(@as(f64, 6.0), result1.at(0, 0).*);
@@ -168,7 +151,7 @@ test "Matrix offset and pow" {
     try expectEqual(@as(f64, 9.0), result1.at(1, 1).*);
 
     // Test pow
-    var result2 = try mat.pow(2.0).eval();
+    var result2 = try mat.pow(2.0);
     defer result2.deinit();
 
     try expectEqual(@as(f64, 1.0), result2.at(0, 0).*);

--- a/src/matrix/test_ops_basic.zig
+++ b/src/matrix/test_ops_basic.zig
@@ -18,11 +18,13 @@ test "complex operation chaining" {
     const dynamic_a = try static_a.toMatrix(arena.allocator());
     const dynamic_b = try static_b.toMatrix(arena.allocator());
 
-    const dynamic_result = try dynamic_a
+    var p = dynamic_a.chain();
+    defer p.deinit();
+    const dynamic_result = try p
         .dot(dynamic_b)
         .transpose()
         .scale(0.5)
-        .eval();
+        .toOwned();
 
     // Verify both approaches give identical results
     for (0..2) |r| {
@@ -46,13 +48,13 @@ test "row and column extraction with Matrix" {
     // Test Matrix row/col extraction
     const dynamic_matrix = try test_matrix.toMatrix(arena.allocator());
 
-    const dynamic_row = try dynamic_matrix.row(1).eval();
+    const dynamic_row = try dynamic_matrix.row(1);
     try expectEqual(@as(usize, 1), dynamic_row.rows);
     try expectEqual(@as(usize, 2), dynamic_row.cols);
     try expectEqual(@as(f32, 3.0), dynamic_row.at(0, 0).*);
     try expectEqual(@as(f32, 4.0), dynamic_row.at(0, 1).*);
 
-    const dynamic_col = try dynamic_matrix.col(1).eval();
+    const dynamic_col = try dynamic_matrix.col(1);
     try expectEqual(@as(usize, 3), dynamic_col.rows);
     try expectEqual(@as(usize, 1), dynamic_col.cols);
     try expectEqual(@as(f32, 2.0), dynamic_col.at(0, 0).*);
@@ -85,18 +87,18 @@ test "Matrix operations: add, sub, scale, transpose" {
     const dynamic_matrix = try static_matrix.toMatrix(arena.allocator());
 
     // Test scale
-    const dynamic_scaled = try dynamic_matrix.scale(2.0).eval();
+    const dynamic_scaled = try dynamic_matrix.scale(2.0);
 
     // Test transpose
-    const dynamic_transposed = try dynamic_matrix.transpose().eval();
+    const dynamic_transposed = try dynamic_matrix.transpose();
 
     // Test add
     const add_matrix: Matrix(f32) = try .initAll(arena.allocator(), 2, 3, 1.0);
-    const dynamic_added = try dynamic_matrix.add(add_matrix).eval();
+    const dynamic_added = try dynamic_matrix.add(add_matrix);
 
     // Test subtract
     const dynamic_operand = try static_operand.toMatrix(arena.allocator());
-    const dynamic_subtracted = try dynamic_matrix.sub(dynamic_operand).eval();
+    const dynamic_subtracted = try dynamic_matrix.sub(dynamic_operand);
 
     // Verify results match
     for (0..2) |r| {

--- a/src/matrix/test_ops_decomposition.zig
+++ b/src/matrix/test_ops_decomposition.zig
@@ -79,7 +79,7 @@ test "Matrix LU decomposition" {
     defer p_mat.deinit();
 
     // Compute P * A
-    var pa_from_mat = try p_mat.dot(mat).eval();
+    var pa_from_mat = try p_mat.dot(mat);
     defer pa_from_mat.deinit();
 
     // Re-verify that rows of PA match rows of L*U (or permuted rows of A)
@@ -247,7 +247,7 @@ test "Matrix QR decomposition" {
     defer p_mat.deinit();
 
     // Compute A * P
-    var ap_from_mat = try mat.dot(p_mat).eval();
+    var ap_from_mat = try mat.dot(p_mat);
     defer ap_from_mat.deinit();
 
     // Re-verify that columns of AP match permuted columns of A
@@ -517,7 +517,7 @@ test "Matrix Cholesky decomposition" {
     mat.at(2, 1).* = 3.0;
     mat.at(2, 2).* = 6.0;
 
-    var chol = try mat.cholesky().eval();
+    var chol = try mat.cholesky();
     defer chol.deinit();
 
     // Check L
@@ -537,9 +537,9 @@ test "Matrix Cholesky decomposition" {
     }
 
     // Verify L * L^T = A
-    var lt = chol.transpose();
+    var lt = try chol.transpose();
     defer lt.deinit();
-    var recon = try chol.dot(lt).eval();
+    var recon = try chol.dot(lt);
     defer recon.deinit();
 
     for (0..3) |i| {
@@ -555,5 +555,5 @@ test "Matrix Cholesky decomposition" {
     non_spd.at(1, 0).* = 2.0;
     non_spd.at(1, 1).* = 1.0; // Det = 1 - 4 = -3, not positive definite
 
-    try std.testing.expectError(MatrixError.NotPositiveDefinite, non_spd.cholesky().eval());
+    try std.testing.expectError(MatrixError.NotPositiveDefinite, non_spd.cholesky());
 }

--- a/src/matrix/test_ops_gemm.zig
+++ b/src/matrix/test_ops_gemm.zig
@@ -16,7 +16,7 @@ test "Matrix gram and covariance matrices" {
     data.at(2, 1).* = 6.0;
 
     // Test Gram matrix (X * X^T) - should be 3×3
-    const gram_result = try data.gram().eval();
+    const gram_result = try data.gram();
 
     try expectEqual(@as(usize, 3), gram_result.rows);
     try expectEqual(@as(usize, 3), gram_result.cols);
@@ -28,7 +28,7 @@ test "Matrix gram and covariance matrices" {
     try expectEqual(@as(f64, 17.0), gram_result.at(0, 2).*);
 
     // Test Covariance matrix (X^T * X) - should be 2×2
-    const cov_result = try data.covariance().eval();
+    const cov_result = try data.covariance();
 
     try expectEqual(@as(usize, 2), cov_result.rows);
     try expectEqual(@as(usize, 2), cov_result.cols);
@@ -63,7 +63,7 @@ test "Matrix GEMM operations" {
     });
 
     // Test basic matrix multiplication: A * B using dot() method
-    const dot_result = try a.dot(b).eval();
+    const dot_result = try a.dot(b);
 
     try expectEqual(@as(f32, 58.0), dot_result.at(0, 0).*); // 1*7 + 2*9 + 3*11
     try expectEqual(@as(f32, 64.0), dot_result.at(0, 1).*); // 1*8 + 2*10 + 3*12
@@ -71,7 +71,7 @@ test "Matrix GEMM operations" {
     try expectEqual(@as(f32, 154.0), dot_result.at(1, 1).*); // 4*8 + 5*10 + 6*12
 
     // Test basic matrix multiplication: A * B using gemm() method
-    const result1 = try a.gemm(false, b, false, 1.0, 0.0, null).eval();
+    const result1 = try a.gemm(false, b, false, 1.0, 0.0, null);
 
     try expectEqual(@as(f32, 58.0), result1.at(0, 0).*); // 1*7 + 2*9 + 3*11
     try expectEqual(@as(f32, 64.0), result1.at(0, 1).*); // 1*8 + 2*10 + 3*12
@@ -79,19 +79,19 @@ test "Matrix GEMM operations" {
     try expectEqual(@as(f32, 154.0), result1.at(1, 1).*); // 4*8 + 5*10 + 6*12
 
     // Test scaled multiplication: 2 * A * B
-    const result2 = try a.gemm(false, b, false, 2.0, 0.0, null).eval();
+    const result2 = try a.gemm(false, b, false, 2.0, 0.0, null);
 
     try expectEqual(@as(f32, 116.0), result2.at(0, 0).*); // 2 * 58
     try expectEqual(@as(f32, 128.0), result2.at(0, 1).*); // 2 * 64
 
     // Test accumulation: A * B + C
-    const result3 = try a.gemm(false, b, false, 1.0, 1.0, c).eval();
+    const result3 = try a.gemm(false, b, false, 1.0, 1.0, c);
 
     try expectEqual(@as(f32, 59.0), result3.at(0, 0).*); // 58 + 1
     try expectEqual(@as(f32, 65.0), result3.at(0, 1).*); // 64 + 1
 
     // Test Gram matrix using GEMM: A * A^T
-    const gram = try a.gemm(false, a, true, 1.0, 0.0, null).eval();
+    const gram = try a.gemm(false, a, true, 1.0, 0.0, null);
 
     try expectEqual(@as(usize, 2), gram.rows);
     try expectEqual(@as(usize, 2), gram.cols);
@@ -99,7 +99,7 @@ test "Matrix GEMM operations" {
     try expectEqual(@as(f32, 32.0), gram.at(0, 1).*); // 1*4 + 2*5 + 3*6
 
     // Test covariance using GEMM: A^T * A
-    const cov = try a.gemm(true, a, false, 1.0, 0.0, null).eval();
+    const cov = try a.gemm(true, a, false, 1.0, 0.0, null);
 
     try expectEqual(@as(usize, 3), cov.rows);
     try expectEqual(@as(usize, 3), cov.cols);
@@ -127,7 +127,7 @@ test "Matrix SIMD case 2: A^T * B with same matrix (covariance)" {
     data.at(3, 2).* = 12.0;
 
     // Test covariance using Matrix (should use SIMD)
-    const simd_result = try data.covariance().eval();
+    const simd_result = try data.covariance();
 
     // Compute expected result manually
     var expected: Matrix(f32) = try .init(arena.allocator(), 3, 3);
@@ -157,7 +157,7 @@ test "Matrix SIMD case 2: A^T * B with same matrix (covariance)" {
     }
 
     // Also test direct GEMM call with same matrix
-    const direct_result = try data.gemm(true, data, false, 1.0, 0.0, null).eval();
+    const direct_result = try data.gemm(true, data, false, 1.0, 0.0, null);
 
     // Verify direct GEMM gives same result
     for (0..3) |i| {
@@ -189,7 +189,7 @@ test "Matrix GEMM all transpose cases with same matrix" {
     square_a.at(1, 1).* = 4.0;
 
     // Case 1: A * A (SIMD same-matrix handling)
-    const result1 = try square_a.gemm(false, square_a, false, 1.0, 0.0, null).eval();
+    const result1 = try square_a.gemm(false, square_a, false, 1.0, 0.0, null);
 
     // Expected: A * A = [[1*1+2*3, 1*2+2*4], [3*1+4*3, 3*2+4*4]] = [[7, 10], [15, 22]]
     try expectEqual(@as(usize, 2), result1.rows);
@@ -200,7 +200,7 @@ test "Matrix GEMM all transpose cases with same matrix" {
     try expectEqual(@as(f32, 22.0), result1.at(1, 1).*); // 3*2 + 4*4
 
     // Case 2: A^T * A (covariance - SIMD same-matrix handling)
-    const result2 = try a.gemm(true, a, false, 1.0, 0.0, null).eval();
+    const result2 = try a.gemm(true, a, false, 1.0, 0.0, null);
 
     // Expected: A^T * A (3x2 -> 2x2 result)
     // A^T = [[1,3,5], [2,4,6]]
@@ -213,7 +213,7 @@ test "Matrix GEMM all transpose cases with same matrix" {
     try expectEqual(@as(f32, 56.0), result2.at(1, 1).*); // 2*2 + 4*4 + 6*6
 
     // Case 3: A * A^T (gram matrix - SIMD same-matrix handling)
-    const result3 = try a.gemm(false, a, true, 1.0, 0.0, null).eval();
+    const result3 = try a.gemm(false, a, true, 1.0, 0.0, null);
 
     // Expected: A * A^T (3x2 -> 3x3 result)
     // A * A^T = [[1*1+2*2, 1*3+2*4, 1*5+2*6], [3*1+4*2, 3*3+4*4, 3*5+4*6], [5*1+6*2, 5*3+6*4, 5*5+6*6]]
@@ -231,7 +231,7 @@ test "Matrix GEMM all transpose cases with same matrix" {
     try expectEqual(@as(f32, 61.0), result3.at(2, 2).*); // 5*5 + 6*6
 
     // Case 4: A^T * A^T (both transposed - SIMD same-matrix handling)
-    const result4 = try square_a.gemm(true, square_a, true, 1.0, 0.0, null).eval();
+    const result4 = try square_a.gemm(true, square_a, true, 1.0, 0.0, null);
 
     // Expected: A^T * A^T where A^T = [[1,3], [2,4]]
     // A^T * A^T = [[1*1+3*2, 1*3+3*4], [2*1+4*2, 2*3+4*4]] = [[7, 15], [10, 22]]
@@ -258,7 +258,7 @@ test "Matrix SIMD 9x9 matrix with known values" {
     }
 
     // Test Case 1: A * A (should use SIMD same-matrix optimization)
-    const result1 = try test_matrix.gemm(false, test_matrix, false, 1.0, 0.0, null).eval();
+    const result1 = try test_matrix.gemm(false, test_matrix, false, 1.0, 0.0, null);
 
     // Verify Case 1: A * A (uses SIMD same-matrix optimization)
     try expectEqual(@as(usize, 9), result1.rows);
@@ -268,7 +268,7 @@ test "Matrix SIMD 9x9 matrix with known values" {
     try expectEqual(@as(f32, 405.0), result1.at(8, 8).*); // Row 8 * Col 8
 
     // Test Case 2: A^T * A (covariance)
-    const result2 = try test_matrix.gemm(true, test_matrix, false, 1.0, 0.0, null).eval();
+    const result2 = try test_matrix.gemm(true, test_matrix, false, 1.0, 0.0, null);
 
     // Verify Case 2: A^T * A (covariance, uses SIMD same-matrix optimization)
     try expectEqual(@as(usize, 9), result2.rows);
@@ -277,7 +277,7 @@ test "Matrix SIMD 9x9 matrix with known values" {
     try expectEqual(@as(f32, 285.0), result2.at(8, 8).*); // Same for all diagonal elements
 
     // Test Case 3: A * A^T (gram matrix)
-    const result3 = try test_matrix.gemm(false, test_matrix, true, 1.0, 0.0, null).eval();
+    const result3 = try test_matrix.gemm(false, test_matrix, true, 1.0, 0.0, null);
 
     // Verify Case 3: A * A^T (gram matrix, uses SIMD same-matrix optimization)
     try expectEqual(@as(usize, 9), result3.rows);
@@ -287,7 +287,7 @@ test "Matrix SIMD 9x9 matrix with known values" {
     try expectEqual(@as(f32, 729.0), result3.at(8, 8).*); // 9² * 9 elements
 
     // Test Case 4: A^T * A^T
-    const result4 = try test_matrix.gemm(true, test_matrix, true, 1.0, 0.0, null).eval();
+    const result4 = try test_matrix.gemm(true, test_matrix, true, 1.0, 0.0, null);
 
     // Verify Case 4: A^T * A^T (uses SIMD same-matrix optimization)
     try expectEqual(@as(usize, 9), result4.rows);
@@ -319,7 +319,7 @@ test "Matrix GEMM double transpose respects operands" {
     }
 
     // Forces SIMD path: a_rows * a_cols * b_cols = 3 * 40 * 5 = 600 >= 512
-    const simd_result = try a.gemm(true, b, true, 1.0, 0.0, null).eval();
+    const simd_result = try a.gemm(true, b, true, 1.0, 0.0, null);
 
     const expected = blk: {
         var temp = try Matrix(f64).init(arena.allocator(), a.cols, b.rows);

--- a/src/matrix/test_ops_inverse.zig
+++ b/src/matrix/test_ops_inverse.zig
@@ -12,10 +12,10 @@ test "Matrix inverse - small matrices" {
     mat2.at(1, 0).* = 2.0;
     mat2.at(1, 1).* = 6.0;
 
-    const inv2 = try mat2.inverse().eval();
+    const inv2 = try mat2.inverse();
 
     // Verify A * A^(-1) = I
-    const identity2 = try mat2.dot(inv2).eval();
+    const identity2 = try mat2.dot(inv2);
 
     const eps = 1e-10;
     try std.testing.expect(@abs(identity2.at(0, 0).* - 1.0) < eps);
@@ -35,10 +35,10 @@ test "Matrix inverse - small matrices" {
     mat3.at(2, 1).* = 6.0;
     mat3.at(2, 2).* = 0.0;
 
-    const inv3 = try mat3.inverse().eval();
+    const inv3 = try mat3.inverse();
 
     // Verify A * A^(-1) = I
-    const identity3 = try mat3.dot(inv3).eval();
+    const identity3 = try mat3.dot(inv3);
 
     for (0..3) |i| {
         for (0..3) |j| {
@@ -72,10 +72,10 @@ test "Matrix inverse - large matrices using Gauss-Jordan" {
     mat4.at(3, 2).* = 0.0;
     mat4.at(3, 3).* = 4.0;
 
-    const inv4 = try mat4.inverse().eval();
+    const inv4 = try mat4.inverse();
 
     // Verify A * A^(-1) = I
-    const identity4 = try mat4.dot(inv4).eval();
+    const identity4 = try mat4.dot(inv4);
 
     const eps = 1e-10;
     for (0..4) |i| {
@@ -98,10 +98,10 @@ test "Matrix inverse - large matrices using Gauss-Jordan" {
         }
     }
 
-    const inv5 = try mat5.inverse().eval();
+    const inv5 = try mat5.inverse();
 
     // Verify A * A^(-1) = I
-    const identity5 = try mat5.dot(inv5).eval();
+    const identity5 = try mat5.dot(inv5);
 
     for (0..5) |i| {
         for (0..5) |j| {
@@ -122,7 +122,7 @@ test "Matrix inverse - singular matrix error" {
     sing2.at(1, 0).* = 2.0;
     sing2.at(1, 1).* = 4.0; // Second row is multiple of first
 
-    try std.testing.expectError(error.Singular, sing2.inverse().eval());
+    try std.testing.expectError(error.Singular, sing2.inverse());
 
     // Test singular 4x4 matrix (uses Gauss-Jordan)
     var sing4: Matrix(f64) = try .init(arena.allocator(), 4, 4);
@@ -144,7 +144,7 @@ test "Matrix inverse - singular matrix error" {
     sing4.at(3, 2).* = 11.0;
     sing4.at(3, 3).* = 12.0;
 
-    try std.testing.expectError(error.Singular, sing4.inverse().eval());
+    try std.testing.expectError(error.Singular, sing4.inverse());
 }
 
 test "Matrix pseudo-inverse handles tall and wide matrices" {
@@ -168,11 +168,15 @@ test "Matrix pseudo-inverse handles tall and wide matrices" {
     tall.at(3, 2).* = 2.0;
 
     var tall_rank: u32 = undefined;
-    var tall_pinv = try tall.pseudoInverse(.{ .effective_rank = &tall_rank }).eval();
+    var tall_pinv = try tall.pseudoInverse(.{ .effective_rank = &tall_rank });
     defer tall_pinv.deinit();
-    var tall_recon = try tall.dot(tall_pinv).dot(tall).eval();
+    var tall_recon_chain = tall.chain();
+    defer tall_recon_chain.deinit();
+    var tall_recon = try tall_recon_chain.dot(tall_pinv).dot(tall).toOwned();
     defer tall_recon.deinit();
-    var tall_pinv_recon = try tall_pinv.dot(tall).dot(tall_pinv).eval();
+    var tall_pinv_recon_chain = tall_pinv.chain();
+    defer tall_pinv_recon_chain.deinit();
+    var tall_pinv_recon = try tall_pinv_recon_chain.dot(tall).dot(tall_pinv).toOwned();
     defer tall_pinv_recon.deinit();
 
     const tol = 1e-9;
@@ -207,11 +211,15 @@ test "Matrix pseudo-inverse handles tall and wide matrices" {
     wide.at(2, 4).* = 0.25;
 
     var wide_rank: u32 = undefined;
-    var wide_pinv = try wide.pseudoInverse(.{ .effective_rank = &wide_rank }).eval();
+    var wide_pinv = try wide.pseudoInverse(.{ .effective_rank = &wide_rank });
     defer wide_pinv.deinit();
-    var wide_recon = try wide.dot(wide_pinv).dot(wide).eval();
+    var wide_recon_chain = wide.chain();
+    defer wide_recon_chain.deinit();
+    var wide_recon = try wide_recon_chain.dot(wide_pinv).dot(wide).toOwned();
     defer wide_recon.deinit();
-    var wide_pinv_recon = try wide_pinv.dot(wide).dot(wide_pinv).eval();
+    var wide_pinv_recon_chain = wide_pinv.chain();
+    defer wide_pinv_recon_chain.deinit();
+    var wide_pinv_recon = try wide_pinv_recon_chain.dot(wide).dot(wide_pinv).toOwned();
     defer wide_pinv_recon.deinit();
 
     try std.testing.expectEqual(wide.cols, wide_pinv.rows);
@@ -239,7 +247,7 @@ test "Matrix pseudo-inverse zero matrix" {
     defer zero.deinit();
 
     var rank: u32 = 1234;
-    var pinv = try zero.pseudoInverse(.{ .effective_rank = &rank }).eval();
+    var pinv = try zero.pseudoInverse(.{ .effective_rank = &rank });
     defer pinv.deinit();
 
     try std.testing.expectEqual(@as(u32, 2), pinv.rows);

--- a/src/pca.zig
+++ b/src/pca.zig
@@ -298,7 +298,7 @@ pub fn Pca(comptime T: type) type {
             }
 
             // Compute centered * components
-            return try centered_matrix.gemm(false, self.components, false, 1.0, 0.0, null).eval();
+            return centered_matrix.gemm(false, self.components, false, 1.0, 0.0, null);
         }
 
         /// Get the mean vector
@@ -325,7 +325,7 @@ pub fn Pca(comptime T: type) type {
 
             // Use GEMM directly: scale * (X^T * X) + 0 * C
             // This combines matrix multiplication and scaling in one optimized operation
-            var cov_matrix = try data_matrix.gemm(true, data_matrix.*, false, scale, 0.0, null).eval();
+            var cov_matrix = try data_matrix.gemm(true, data_matrix.*, false, scale, 0.0, null);
             defer cov_matrix.deinit();
 
             const n = cov_matrix.rows;
@@ -381,7 +381,7 @@ pub fn Pca(comptime T: type) type {
 
             // Use GEMM directly: scale * (X * X^T) + 0 * C
             // This combines matrix multiplication and scaling in one optimized operation
-            var gram_matrix = try data_matrix.gemm(false, data_matrix.*, true, scale, 0.0, null).eval();
+            var gram_matrix = try data_matrix.gemm(false, data_matrix.*, true, scale, 0.0, null);
             defer gram_matrix.deinit();
 
             const n = gram_matrix.rows;

--- a/src/root.zig
+++ b/src/root.zig
@@ -85,6 +85,8 @@ pub const jpeg = @import("jpeg.zig");
 const matrix = @import("matrix.zig");
 pub const SMatrix = matrix.SMatrix;
 pub const Matrix = matrix.Matrix;
+pub const MatrixError = matrix.MatrixError;
+pub const Chain = matrix.Chain;
 pub const meta = @import("meta.zig");
 
 const perlin_mod = @import("perlin.zig");


### PR DESCRIPTION
Replaces the deferred-error chaining design (err field on Matrix(T) + .eval() terminal) with two distinct types:

- Matrix(T) is now a "real" matrix only. Chainable ops return MatrixError!Matrix(T), so single-op users write `try a.dot(b)` and errors surface idiomatically. The err field, eval(), and errorMatrix helper are gone; deinit goes back to a plain free; query ops drop the err-related asserts.
- Chain(T) (new src/matrix/Chain.zig) wraps Matrix(T) for fluent multi-op chains: `var c = m.chain(); defer c.deinit(); try c.dot(b).transpose().toOwned()`. Each chainable op frees the previous intermediate, so peak memory is at most two matrices regardless of chain length — no more leak-by-default without an arena.

Errors short-circuit the chain via Chain.err and are surfaced by toOwned(); deinit() is safe whether or not toOwned() ran. The terminal is named toOwned() to match Zig stdlib precedent (ArrayList.toOwnedSlice moves the buffer out the same way) — explicit about the move semantics and avoids any "lazy evaluation" connotation.