### PR TITLE
chore: update zig version to 0.17.0-dev.304

### DIFF
--- a/bindings/python/src/python.zig
+++ b/bindings/python/src/python.zig
@@ -1117,7 +1117,7 @@ pub fn parseArgs(comptime T: type, args: ?*c.PyObject, kwds: ?*c.PyObject, out: 
 
     // Build argument tuple
     const arg_types: [fields.len]type = @splat(*anyopaque);
-    var arg_tuple: std.meta.Tuple(&arg_types) = undefined;
+    var arg_tuple: @Tuple(&arg_types) = undefined;
     inline for (fields, 0..) |field, i| {
         arg_tuple[i] = @ptrCast(&@field(out.*, field.name));
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal,
     .version = "0.11.0-dev",
     .fingerprint = 0x5303c43db377b63a,
-    .minimum_zig_version = "0.17.0-dev.248+95507faf1",
+    .minimum_zig_version = "0.17.0-dev.304+9787df942",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -31,7 +31,6 @@ pub fn build(b: *std.Build) void {
         "blur_box_vs_gaussian",
         "trace_edges",
         "colormaps_demo",
-        "imagemagick_compat",
     };
 
     // Build exec_examples with run steps and check compilation

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal_examples,
     .version = "0.0.0",
     .fingerprint = 0xcf70e6a9b7002db6,
-    .minimum_zig_version = "0.17.0-dev.248+95507faf1",
+    .minimum_zig_version = "0.17.0-dev.304+9787df942",
     .dependencies = .{
         .zignal = .{
             .path = "../",


### PR DESCRIPTION
Updates the minimum Zig version and replaces `std.meta.Tuple` with the builtin `@Tuple` in Python bindings.