### PR TITLE
perf(features): optimize FAST and refactor ORB

### DIFF
--- a/examples/src/feature_matching.zig
+++ b/examples/src/feature_matching.zig
@@ -51,11 +51,11 @@ fn createMatchVisualizationWithParams(
     };
 
     // Detect features in both images
-    const features1 = try orb.detectAndCompute(gray1, allocator);
+    const features1 = try orb.detectAndCompute(allocator, gray1);
     defer allocator.free(features1.keypoints);
     defer allocator.free(features1.descriptors);
 
-    const features2 = try orb.detectAndCompute(gray2, allocator);
+    const features2 = try orb.detectAndCompute(allocator, gray2);
     defer allocator.free(features2.keypoints);
     defer allocator.free(features2.descriptors);
 
@@ -69,7 +69,7 @@ fn createMatchVisualizationWithParams(
         .ratio_threshold = ratio_threshold,
     };
 
-    const matches = try matcher.match(features1.descriptors, features2.descriptors, allocator);
+    const matches = try matcher.match(allocator, features1.descriptors, features2.descriptors);
     defer allocator.free(matches);
 
     std.log.info("Found {} matches between images", .{matches.len});
@@ -293,14 +293,14 @@ pub export fn getMatchStats(
         .fast_threshold = fast_threshold,
     };
 
-    const features1 = orb.detectAndCompute(gray1, allocator) catch {
+    const features1 = orb.detectAndCompute(allocator, gray1) catch {
         for (0..6) |i| stats_ptr[i] = 0;
         return;
     };
     defer allocator.free(features1.keypoints);
     defer allocator.free(features1.descriptors);
 
-    const features2 = orb.detectAndCompute(gray2, allocator) catch {
+    const features2 = orb.detectAndCompute(allocator, gray2) catch {
         stats_ptr[0] = @floatFromInt(features1.keypoints.len);
         for (1..6) |i| stats_ptr[i] = 0;
         return;
@@ -315,7 +315,7 @@ pub export fn getMatchStats(
         .ratio_threshold = ratio_threshold,
     };
 
-    const matches = matcher.match(features1.descriptors, features2.descriptors, allocator) catch {
+    const matches = matcher.match(allocator, features1.descriptors, features2.descriptors) catch {
         stats_ptr[0] = @floatFromInt(features1.keypoints.len);
         stats_ptr[1] = @floatFromInt(features2.keypoints.len);
         for (2..6) |i| stats_ptr[i] = 0;

--- a/src/features/Fast.zig
+++ b/src/features/Fast.zig
@@ -36,7 +36,7 @@ const circle_offsets = [16][2]i8{
 };
 
 /// Detect FAST corners in the image
-pub fn detect(self: Fast, image: Image(u8), allocator: Allocator) ![]KeyPoint {
+pub fn detect(self: Fast, allocator: Allocator, image: Image(u8)) ![]KeyPoint {
     assert(image.rows > 7 and image.cols > 7); // Need at least 7x7 for radius 3
 
     var keypoints: ArrayList(KeyPoint) = .empty;
@@ -64,7 +64,7 @@ pub fn detect(self: Fast, image: Image(u8), allocator: Allocator) ![]KeyPoint {
 
     // Second pass: non-maximal suppression
     if (self.nonmax_suppression and keypoints.items.len > 0) {
-        const suppressed = try self.suppressNonMaximal(keypoints.items, allocator);
+        const suppressed = try self.suppressNonMaximal(allocator, keypoints.items);
         keypoints.deinit(allocator);
         return suppressed;
     }
@@ -153,7 +153,7 @@ fn cornerScore(self: Fast, image: Image(u8), row: usize, col: usize) u32 {
 }
 
 /// Apply non-maximal suppression to remove redundant corners
-fn suppressNonMaximal(self: Fast, keypoints: []const KeyPoint, allocator: Allocator) ![]KeyPoint {
+fn suppressNonMaximal(self: Fast, allocator: Allocator, keypoints: []const KeyPoint) ![]KeyPoint {
     _ = self;
 
     if (keypoints.len == 0) {
@@ -301,7 +301,7 @@ test "FAST detector on synthetic corner" {
         .nonmax_suppression = false,
     };
 
-    const keypoints = try fast.detect(image, allocator);
+    const keypoints = try fast.detect(allocator, image);
     defer allocator.free(keypoints);
 
     // Should detect at least one corner near (10, 10)
@@ -355,10 +355,10 @@ test "FAST non-maximal suppression" {
         .nonmax_suppression = true,
     };
 
-    const keypoints_no_nms = try fast_no_nms.detect(image, allocator);
+    const keypoints_no_nms = try fast_no_nms.detect(allocator, image);
     defer allocator.free(keypoints_no_nms);
 
-    const keypoints_with_nms = try fast_with_nms.detect(image, allocator);
+    const keypoints_with_nms = try fast_with_nms.detect(allocator, image);
     defer allocator.free(keypoints_with_nms);
 
     // Non-maximal suppression should reduce the number of keypoints

--- a/src/features/Fast.zig
+++ b/src/features/Fast.zig
@@ -76,6 +76,8 @@ pub fn detect(self: Fast, image: Image(u8), allocator: Allocator) ![]KeyPoint {
 fn isCorner(self: Fast, image: Image(u8), row: usize, col: usize) bool {
     const center = image.at(row, col).*;
     const threshold = self.threshold;
+    const bright_threshold: u8 = if (center > 255 - threshold) 255 else center + threshold;
+    const dark_threshold: u8 = if (center < threshold) 0 else center - threshold;
 
     // Quick rejection test: check pixels at 0, 4, 8, 12 (cardinal directions)
     // At least 3 must be either all brighter or all darker
@@ -87,9 +89,6 @@ fn isCorner(self: Fast, image: Image(u8), row: usize, col: usize) bool {
         const px_row = @as(isize, @intCast(row)) + offset[1];
         const px_col = @as(isize, @intCast(col)) + offset[0];
         const pixel = image.at(@intCast(px_row), @intCast(px_col)).*;
-
-        const bright_threshold = if (center > 255 - threshold) 255 else center + threshold;
-        const dark_threshold = if (center < threshold) 0 else center - threshold;
 
         if (pixel > bright_threshold) {
             bright_count += 1;
@@ -116,9 +115,6 @@ fn isCorner(self: Fast, image: Image(u8), row: usize, col: usize) bool {
         const px_row = @as(isize, @intCast(row)) + offset[1];
         const px_col = @as(isize, @intCast(col)) + offset[0];
         const pixel = image.at(@intCast(px_row), @intCast(px_col)).*;
-
-        const bright_threshold = if (center > 255 - threshold) 255 else center + threshold;
-        const dark_threshold = if (center < threshold) 0 else center - threshold;
 
         if (pixel > bright_threshold) {
             bright_arc += 1;
@@ -238,8 +234,7 @@ fn suppressNonMaximal(self: Fast, keypoints: []const KeyPoint, allocator: Alloca
                         for (grid[neighbor_idx].items) |other| {
                             if (kp.x == other.x and kp.y == other.y) continue;
 
-                            const dist = kp.distance(other);
-                            if (dist < 5.0 and other.response > kp.response) {
+                            if (kp.distanceSquared(other) < 25.0 and other.response > kp.response) {
                                 is_max = false;
                                 break;
                             }

--- a/src/features/Fast.zig
+++ b/src/features/Fast.zig
@@ -76,8 +76,8 @@ pub fn detect(self: Fast, allocator: Allocator, image: Image(u8)) ![]KeyPoint {
 fn isCorner(self: Fast, image: Image(u8), row: usize, col: usize) bool {
     const center = image.at(row, col).*;
     const threshold = self.threshold;
-    const bright_threshold: u8 = if (center > 255 - threshold) 255 else center + threshold;
-    const dark_threshold: u8 = if (center < threshold) 0 else center - threshold;
+    const bright_threshold = center +| threshold;
+    const dark_threshold = center -| threshold;
 
     // Quick rejection test: check pixels at 0, 4, 8, 12 (cardinal directions)
     // At least 3 must be either all brighter or all darker

--- a/src/features/KeyPoint.zig
+++ b/src/features/KeyPoint.zig
@@ -85,9 +85,14 @@ pub fn isInBounds(self: KeyPoint, width: usize, height: usize, margin: usize) bo
 
 /// Compute Euclidean distance to another keypoint
 pub fn distance(self: KeyPoint, other: KeyPoint) f32 {
+    return @sqrt(self.distanceSquared(other));
+}
+
+/// Compute squared Euclidean distance — cheaper than `distance` when comparing magnitudes.
+pub fn distanceSquared(self: KeyPoint, other: KeyPoint) f32 {
     const dx = self.x - other.x;
     const dy = self.y - other.y;
-    return @sqrt(dx * dx + dy * dy);
+    return dx * dx + dy * dy;
 }
 
 /// Check if two keypoints overlap based on their size

--- a/src/features/matcher.zig
+++ b/src/features/matcher.zig
@@ -43,9 +43,9 @@ pub const BruteForceMatcher = struct {
     /// Match descriptors from query set to train set
     pub fn match(
         self: BruteForceMatcher,
+        allocator: Allocator,
         query_descriptors: []const BinaryDescriptor,
         train_descriptors: []const BinaryDescriptor,
-        allocator: Allocator,
     ) ![]Match {
         if (query_descriptors.len == 0 or train_descriptors.len == 0) {
             return try allocator.alloc(Match, 0);
@@ -108,10 +108,10 @@ pub const BruteForceMatcher = struct {
     /// Find k nearest neighbors for each query descriptor
     pub fn knnMatch(
         self: BruteForceMatcher,
+        allocator: Allocator,
         query_descriptors: []const BinaryDescriptor,
         train_descriptors: []const BinaryDescriptor,
         k: usize,
-        allocator: Allocator,
     ) ![][]Match {
         if (query_descriptors.len == 0 or train_descriptors.len == 0 or k == 0) {
             return try allocator.alloc([]Match, 0);
@@ -164,10 +164,10 @@ pub const BruteForceMatcher = struct {
     /// Find radius neighbors - all matches within a distance threshold
     pub fn radiusMatch(
         self: BruteForceMatcher,
+        allocator: Allocator,
         query_descriptors: []const BinaryDescriptor,
         train_descriptors: []const BinaryDescriptor,
         max_dist: f32,
-        allocator: Allocator,
     ) ![][]Match {
         _ = self; // Currently unused, but kept for API consistency
         if (query_descriptors.len == 0 or train_descriptors.len == 0) {
@@ -299,7 +299,7 @@ test "BruteForceMatcher basic matching" {
         .cross_check = false,
     };
 
-    const matches = try matcher.match(&desc1, &desc2, allocator);
+    const matches = try matcher.match(allocator, &desc1, &desc2);
     defer allocator.free(matches);
 
     // Should find matches
@@ -347,10 +347,10 @@ test "BruteForceMatcher cross-check" {
         .cross_check = true,
     };
 
-    const matches_no_cross = try matcher_no_cross.match(&desc1, &desc2, allocator);
+    const matches_no_cross = try matcher_no_cross.match(allocator, &desc1, &desc2);
     defer allocator.free(matches_no_cross);
 
-    const matches_cross = try matcher_cross.match(&desc1, &desc2, allocator);
+    const matches_cross = try matcher_cross.match(allocator, &desc1, &desc2);
     defer allocator.free(matches_cross);
 
     // Cross-check should produce fewer matches
@@ -379,7 +379,7 @@ test "BruteForceMatcher kNN matching" {
 
     const matcher = BruteForceMatcher{};
 
-    const knn_matches = try matcher.knnMatch(&query, &train, 2, allocator);
+    const knn_matches = try matcher.knnMatch(allocator, &query, &train, 2);
     defer {
         for (knn_matches) |matches| {
             allocator.free(matches);

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -119,7 +119,7 @@ pub const ScoreType = enum {
 };
 
 /// Detect keypoints in the image at multiple scales
-pub fn detect(self: Orb, image: Image(u8), allocator: Allocator) ![]KeyPoint {
+pub fn detect(self: Orb, allocator: Allocator, image: Image(u8)) ![]KeyPoint {
     var pyramid = try ImagePyramid(u8).build(
         allocator,
         image,
@@ -129,11 +129,11 @@ pub fn detect(self: Orb, image: Image(u8), allocator: Allocator) ![]KeyPoint {
     );
     defer pyramid.deinit();
 
-    return self.detectWithPyramid(pyramid, allocator);
+    return self.detectWithPyramid(allocator, pyramid);
 }
 
 /// Compute descriptors for detected keypoints
-pub fn compute(self: Orb, image: Image(u8), keypoints: []const KeyPoint, allocator: Allocator) ![]BinaryDescriptor {
+pub fn compute(self: Orb, allocator: Allocator, image: Image(u8), keypoints: []const KeyPoint) ![]BinaryDescriptor {
     var pyramid = try ImagePyramid(u8).build(
         allocator,
         image,
@@ -143,11 +143,11 @@ pub fn compute(self: Orb, image: Image(u8), keypoints: []const KeyPoint, allocat
     );
     defer pyramid.deinit();
 
-    return self.computeWithPyramid(pyramid, keypoints, allocator);
+    return self.computeWithPyramid(allocator, pyramid, keypoints);
 }
 
 /// Detect keypoints using a pre-built pyramid
-fn detectWithPyramid(self: Orb, pyramid: ImagePyramid(u8), allocator: Allocator) ![]KeyPoint {
+fn detectWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8)) ![]KeyPoint {
     // Calculate how many features to detect per level
     const features_per_level = try self.computeFeaturesPerLevel(allocator);
     defer allocator.free(features_per_level);
@@ -174,7 +174,7 @@ fn detectWithPyramid(self: Orb, pyramid: ImagePyramid(u8), allocator: Allocator)
             .min_contiguous = 9,
         };
 
-        const corners = try fast_detector.detect(level_image, allocator);
+        const corners = try fast_detector.detect(allocator, level_image);
         defer allocator.free(corners);
 
         // Compute Harris response if requested
@@ -224,7 +224,7 @@ fn detectWithPyramid(self: Orb, pyramid: ImagePyramid(u8), allocator: Allocator)
 }
 
 /// Compute descriptors using a pre-built pyramid
-fn computeWithPyramid(self: Orb, pyramid: ImagePyramid(u8), keypoints: []const KeyPoint, allocator: Allocator) ![]BinaryDescriptor {
+fn computeWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8), keypoints: []const KeyPoint) ![]BinaryDescriptor {
     var descriptors = try allocator.alloc(BinaryDescriptor, keypoints.len);
 
     for (keypoints, 0..) |kp, i| {
@@ -252,8 +252,8 @@ fn computeWithPyramid(self: Orb, pyramid: ImagePyramid(u8), keypoints: []const K
 /// Detect keypoints and compute their descriptors
 pub fn detectAndCompute(
     self: Orb,
-    image: Image(u8),
     allocator: Allocator,
+    image: Image(u8),
 ) !struct { keypoints: []KeyPoint, descriptors: []BinaryDescriptor } {
     // Build pyramid once for both detection and description
     var pyramid = try ImagePyramid(u8).build(
@@ -266,11 +266,11 @@ pub fn detectAndCompute(
     defer pyramid.deinit();
 
     // Detect keypoints using the pyramid
-    const keypoints = try self.detectWithPyramid(pyramid, allocator);
+    const keypoints = try self.detectWithPyramid(allocator, pyramid);
     errdefer allocator.free(keypoints);
 
     // Compute descriptors using the same pyramid
-    const descriptors = try self.computeWithPyramid(pyramid, keypoints, allocator);
+    const descriptors = try self.computeWithPyramid(allocator, pyramid, keypoints);
 
     return .{
         .keypoints = keypoints,
@@ -617,7 +617,7 @@ test "ORB detect and compute on synthetic image" {
         .fast_threshold = 10, // Lower threshold for test image
     };
 
-    const result = try orb.detectAndCompute(image, allocator);
+    const result = try orb.detectAndCompute(allocator, image);
     defer allocator.free(result.keypoints);
     defer allocator.free(result.descriptors);
 

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -120,7 +120,6 @@ pub const ScoreType = enum {
 
 /// Detect keypoints in the image at multiple scales
 pub fn detect(self: Orb, image: Image(u8), allocator: Allocator) ![]KeyPoint {
-    // Build image pyramid
     var pyramid = try ImagePyramid(u8).build(
         allocator,
         image,
@@ -130,84 +129,11 @@ pub fn detect(self: Orb, image: Image(u8), allocator: Allocator) ![]KeyPoint {
     );
     defer pyramid.deinit();
 
-    // Calculate how many features to detect per level
-    const features_per_level = try self.computeFeaturesPerLevel(allocator);
-    defer allocator.free(features_per_level);
-
-    var all_keypoints: ArrayList(KeyPoint) = .{};
-    defer all_keypoints.deinit(allocator);
-
-    // Detect features at each pyramid level
-    for (0..self.n_levels) |level| {
-        if (level < self.first_level) continue;
-
-        const level_image = pyramid.levels[level];
-        const n_desired = features_per_level[level];
-
-        if (n_desired == 0) continue;
-
-        // Detect FAST corners with adaptive threshold
-        // Lower threshold for higher pyramid levels to maintain detection
-        const adaptive_threshold = self.computeAdaptiveThreshold(level);
-
-        var fast_detector = Fast{
-            .threshold = adaptive_threshold,
-            .nonmax_suppression = true,
-            .min_contiguous = 9,
-        };
-
-        const corners = try fast_detector.detect(level_image, allocator);
-        defer allocator.free(corners);
-
-        // Compute Harris response if requested
-        if (self.score_type == .harris_score) {
-            for (corners) |*corner| {
-                corner.response = computeHarrisResponse(level_image, corner.*);
-            }
-        }
-
-        // Keep only the best corners for this level
-        var level_keypoints = corners;
-        if (corners.len > n_desired) {
-            // Sort by response
-            std.mem.sort(KeyPoint, corners, {}, KeyPoint.compareResponse);
-            level_keypoints = corners[0..n_desired];
-        }
-
-        // Compute orientation and scale coordinates
-        // Scale-aware edge margin: smaller at higher pyramid levels
-        const scale = std.math.pow(f32, self.scale_factor, @as(f32, @floatFromInt(level)));
-        const edge_margin = @as(f32, @floatFromInt(self.edge_threshold)) / scale;
-        const min_margin = 3.0; // Minimum margin for FAST detector
-        const actual_margin = @max(min_margin, edge_margin);
-
-        for (level_keypoints) |*kp| {
-            // Filter out keypoints too close to image borders
-            if (kp.x < actual_margin or kp.x >= @as(f32, @floatFromInt(level_image.cols)) - actual_margin or
-                kp.y < actual_margin or kp.y >= @as(f32, @floatFromInt(level_image.rows)) - actual_margin)
-            {
-                continue;
-            }
-
-            // Compute orientation using intensity centroid
-            kp.angle = self.computeOrientation(level_image, kp.*);
-            kp.octave = @intCast(level);
-
-            // Scale coordinates to original image
-            kp.x *= scale;
-            kp.y *= scale;
-            kp.size *= scale;
-
-            try all_keypoints.append(allocator, kp.*);
-        }
-    }
-
-    return try all_keypoints.toOwnedSlice(allocator);
+    return self.detectWithPyramid(pyramid, allocator);
 }
 
 /// Compute descriptors for detected keypoints
 pub fn compute(self: Orb, image: Image(u8), keypoints: []const KeyPoint, allocator: Allocator) ![]BinaryDescriptor {
-    // Build pyramid for multi-scale description
     var pyramid = try ImagePyramid(u8).build(
         allocator,
         image,
@@ -217,28 +143,7 @@ pub fn compute(self: Orb, image: Image(u8), keypoints: []const KeyPoint, allocat
     );
     defer pyramid.deinit();
 
-    var descriptors = try allocator.alloc(BinaryDescriptor, keypoints.len);
-
-    for (keypoints, 0..) |kp, i| {
-        const level = @min(@as(usize, @intCast(@max(0, kp.octave))), self.n_levels - 1);
-        const level_image = pyramid.levels[level];
-
-        // Scale keypoint to pyramid level
-        const scale = std.math.pow(f32, self.scale_factor, @as(f32, @floatFromInt(level)));
-        const level_kp = KeyPoint{
-            .x = kp.x / scale,
-            .y = kp.y / scale,
-            .size = kp.size / scale,
-            .angle = kp.angle,
-            .response = kp.response,
-            .octave = kp.octave,
-            .class_id = kp.class_id,
-        };
-
-        descriptors[i] = self.computeBriefDescriptor(level_image, level_kp);
-    }
-
-    return descriptors;
+    return self.computeWithPyramid(pyramid, keypoints, allocator);
 }
 
 /// Detect keypoints using a pre-built pyramid
@@ -338,7 +243,7 @@ fn computeWithPyramid(self: Orb, pyramid: ImagePyramid(u8), keypoints: []const K
             .class_id = kp.class_id,
         };
 
-        descriptors[i] = self.computeBriefDescriptor(level_image, level_kp);
+        descriptors[i] = computeBriefDescriptor(level_image, level_kp);
     }
 
     return descriptors;
@@ -419,8 +324,7 @@ fn computeFeaturesPerLevel(self: Orb, allocator: Allocator) ![]usize {
         const desired_float = n_features_f * (1.0 - factor) / (1.0 - factor_to_n) * scale_factor_level;
         const desired_clamped: usize = @min(@as(usize, @round(desired_float)), remaining);
 
-        // Ensure at least some features per level (except possibly last level)
-        // Reduced minimum to allow more flexible distribution, but never exceed remaining budget
+        // Floor each level at a fraction of n_features so small/high pyramid levels aren't starved.
         const base_min = @max(10, self.n_features / (self.n_levels * 3));
         const min_features = @min(remaining, base_min);
 
@@ -524,8 +428,7 @@ fn computeOrientation(self: Orb, image: Image(u8), kp: KeyPoint) f32 {
 }
 
 /// Compute BRIEF descriptor for a keypoint using the learned ORB pattern
-fn computeBriefDescriptor(self: Orb, image: Image(u8), kp: KeyPoint) BinaryDescriptor {
-    _ = self;
+fn computeBriefDescriptor(image: Image(u8), kp: KeyPoint) BinaryDescriptor {
     var descriptor = BinaryDescriptor.init();
 
     const cos_angle = @cos(std.math.degreesToRadians(kp.angle));

--- a/src/features/test_orb_integration.zig
+++ b/src/features/test_orb_integration.zig
@@ -28,11 +28,11 @@ test "ORB full pipeline - detection, description, and matching" {
     };
 
     // Detect and compute features for both images
-    const result1 = try orb.detectAndCompute(image1, allocator);
+    const result1 = try orb.detectAndCompute(allocator, image1);
     defer allocator.free(result1.keypoints);
     defer allocator.free(result1.descriptors);
 
-    const result2 = try orb.detectAndCompute(image2, allocator);
+    const result2 = try orb.detectAndCompute(allocator, image2);
     defer allocator.free(result2.keypoints);
     defer allocator.free(result2.descriptors);
 
@@ -49,7 +49,7 @@ test "ORB full pipeline - detection, description, and matching" {
         .cross_check = false,
     };
 
-    const matches = try matcher.match(result1.descriptors, result2.descriptors, allocator);
+    const matches = try matcher.match(allocator, result1.descriptors, result2.descriptors);
     defer allocator.free(matches);
 
     std.debug.print("[Integration Test] Found {} matches\n", .{matches.len});
@@ -91,11 +91,11 @@ test "ORB rotation invariance" {
     };
 
     // Detect features in both
-    const orig_result = try orb.detectAndCompute(original, allocator);
+    const orig_result = try orb.detectAndCompute(allocator, original);
     defer allocator.free(orig_result.keypoints);
     defer allocator.free(orig_result.descriptors);
 
-    const rot_result = try orb.detectAndCompute(rotated, allocator);
+    const rot_result = try orb.detectAndCompute(allocator, rotated);
     defer allocator.free(rot_result.keypoints);
     defer allocator.free(rot_result.descriptors);
 
@@ -105,7 +105,7 @@ test "ORB rotation invariance" {
         .cross_check = true,
     };
 
-    const matches = try matcher.match(orig_result.descriptors, rot_result.descriptors, allocator);
+    const matches = try matcher.match(allocator, orig_result.descriptors, rot_result.descriptors);
     defer allocator.free(matches);
 
     std.debug.print("\n[Rotation Test] Original: {} features, Rotated: {} features, Matches: {}\n", .{ orig_result.keypoints.len, rot_result.keypoints.len, matches.len });
@@ -140,11 +140,11 @@ test "ORB scale invariance" {
     };
 
     // Detect features
-    const orig_result = try orb.detectAndCompute(original, allocator);
+    const orig_result = try orb.detectAndCompute(allocator, original);
     defer allocator.free(orig_result.keypoints);
     defer allocator.free(orig_result.descriptors);
 
-    const scaled_result = try orb.detectAndCompute(scaled, allocator);
+    const scaled_result = try orb.detectAndCompute(allocator, scaled);
     defer allocator.free(scaled_result.keypoints);
     defer allocator.free(scaled_result.descriptors);
 
@@ -194,18 +194,18 @@ test "ORB kNN matching" {
         .fast_threshold = 10,
     };
 
-    const result1 = try orb.detectAndCompute(image1, allocator);
+    const result1 = try orb.detectAndCompute(allocator, image1);
     defer allocator.free(result1.keypoints);
     defer allocator.free(result1.descriptors);
 
-    const result2 = try orb.detectAndCompute(image2, allocator);
+    const result2 = try orb.detectAndCompute(allocator, image2);
     defer allocator.free(result2.keypoints);
     defer allocator.free(result2.descriptors);
 
     // Test kNN matching
     const matcher = BruteForceMatcher{};
 
-    const knn_matches = try matcher.knnMatch(result1.descriptors, result2.descriptors, 2, allocator);
+    const knn_matches = try matcher.knnMatch(allocator, result1.descriptors, result2.descriptors, 2);
     defer {
         for (knn_matches) |matches| {
             allocator.free(matches);


### PR DESCRIPTION
- Hoist threshold calculations in FAST `isCorner` to avoid recomputation.
- Use squared distance in non-maximal suppression to avoid `sqrt`.
- Refactor ORB `detect` and `compute` to use pyramid helper methods.
- Add `distanceSquared` to `KeyPoint` and make BRIEF descriptor static.