### PR TITLE
refactor(cli): standardize logs and unify common utilities

### DIFF
--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -5,6 +5,18 @@ const builtin = @import("builtin");
 
 pub var runtime_log_level: std.log.Level = if (builtin.mode == .Debug) .debug else .err;
 
+/// Comma-separated list of valid `std.log.Level` names — shared by error messages
+/// and help text so they cannot drift.
+pub const log_level_names: []const u8 = blk: {
+    var names: []const u8 = "";
+    const fields = std.meta.fields(std.log.Level);
+    for (fields, 0..) |field, i| {
+        names = names ++ field.name;
+        if (i < fields.len - 1) names = names ++ ", ";
+    }
+    break :blk names;
+};
+
 /// Configuration for a specific command-line option.
 pub const OptionConfig = struct {
     /// The descriptive help text for this option.
@@ -42,20 +54,11 @@ pub fn parseLogLevel(arg: []const u8, args: *std.process.Args.Iterator) !bool {
     if (!std.mem.eql(u8, arg, "--log-level")) return false;
 
     const level_str = args.next() orelse {
-        std.log.err("Missing value for --log-level", .{});
+        std.log.err("missing value for --log-level", .{});
         return error.InvalidArguments;
     };
     runtime_log_level = std.meta.stringToEnum(std.log.Level, level_str) orelse {
-        const level_names = comptime blk: {
-            var names: []const u8 = "";
-            const fields = std.meta.fields(std.log.Level);
-            for (fields, 0..) |field, i| {
-                names = names ++ field.name;
-                if (i < fields.len - 1) names = names ++ ", ";
-            }
-            break :blk names;
-        };
-        std.log.err("Invalid log level: {s}. Supported levels: {s}", .{ level_str, level_names });
+        std.log.err("invalid log level: {s}. supported levels: {s}", .{ level_str, log_level_names });
         return error.InvalidArguments;
     };
     return true;
@@ -66,7 +69,7 @@ pub fn parseLogLevel(arg: []const u8, args: *std.process.Args.Iterator) !bool {
 /// Boolean fields are treated as flags (no value required).
 /// Supported types: bool, integer types, and []const u8.
 pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Iterator) !ParseResult(T) {
-    std.log.debug("Parsing arguments for type {s}...", .{@typeName(T)});
+    std.log.debug("parsing arguments for type {s}...", .{@typeName(T)});
     var options: T = .{};
     var positionals: std.ArrayList([]const u8) = .empty;
     errdefer positionals.deinit(allocator);
@@ -106,28 +109,28 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
 
                     if (ChildType == bool) {
                         @field(options, field.name) = true;
-                        std.log.debug("Option --{s} set to true", .{field.name});
+                        std.log.debug("option --{s} set to true", .{field.name});
                     } else {
                         const val_str = args.next() orelse {
-                            std.log.err("Missing value for --{s}", .{field.name});
+                            std.log.err("missing value for --{s}", .{field.name});
                             return error.InvalidArguments;
                         };
 
                         if (ChildType == []const u8) {
                             @field(options, field.name) = val_str;
-                            std.log.debug("Option --{s} set to '{s}'", .{ field.name, val_str });
+                            std.log.debug("option --{s} set to '{s}'", .{ field.name, val_str });
                         } else if (@typeInfo(ChildType) == .int) {
                             @field(options, field.name) = std.fmt.parseInt(ChildType, val_str, 10) catch {
-                                std.log.err("Invalid value for --{s}: {s}", .{ field.name, val_str });
+                                std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
                                 return error.InvalidArguments;
                             };
-                            std.log.debug("Option --{s} set to {s}", .{ field.name, val_str });
+                            std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
                         } else if (@typeInfo(ChildType) == .float) {
                             @field(options, field.name) = std.fmt.parseFloat(ChildType, val_str) catch {
-                                std.log.err("Invalid value for --{s}: {s}", .{ field.name, val_str });
+                                std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
                                 return error.InvalidArguments;
                             };
-                            std.log.debug("Option --{s} set to {s}", .{ field.name, val_str });
+                            std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
                         } else {
                             @compileError("Unsupported type for arg parsing: " ++ @typeName(ChildType));
                         }
@@ -135,11 +138,11 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
                 }
             }
             if (!found) {
-                std.log.err("Unknown option: {s}", .{arg});
+                std.log.err("unknown option: {s}", .{arg});
                 return error.InvalidArguments;
             }
         } else if (std.mem.startsWith(u8, arg, "-")) {
-            std.log.err("Unknown option: {s}", .{arg});
+            std.log.err("unknown option: {s}", .{arg});
             return error.InvalidArguments;
         } else {
             try positionals.append(allocator, arg);

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -85,7 +85,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     var blur_type: BlurType = .gaussian;
     if (parsed.options.type) |t| {
         blur_type = type_map.get(t) orelse {
-            std.log.err("Unknown blur type: {s}", .{t});
+            std.log.err("unknown blur type: {s}", .{t});
             return error.InvalidArguments;
         };
     }
@@ -116,18 +116,17 @@ fn processImage(
     blur_type: BlurType,
     options: Args,
 ) !void {
-    std.log.debug("Loading {s}...", .{input_path});
+    std.log.debug("loading {s}...", .{input_path});
 
-    // Load image
     var img: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
     defer img.deinit(gpa);
 
     var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, img.rows, img.cols);
     defer out.deinit(gpa);
 
-    std.log.info("Applying {s} blur...", .{@tagName(blur_type)});
+    std.log.info("applying {s} blur...", .{@tagName(blur_type)});
 
-    const start_time = std.Io.Clock.awake.now(io);
+    const timer = common.Timer.begin(io);
 
     switch (blur_type) {
         .box => {
@@ -137,7 +136,7 @@ fn processImage(
         .gaussian => {
             const sigma = options.sigma orelse 1.0;
             if (sigma < 0 or !std.math.isFinite(sigma)) {
-                std.log.err("Sigma must be a non-negative finite number.", .{});
+                std.log.err("sigma must be a non-negative finite number.", .{});
                 return error.InvalidArguments;
             }
             try img.gaussianBlur(gpa, sigma, out);
@@ -145,7 +144,7 @@ fn processImage(
         .median => {
             const radius = options.radius orelse 1;
             if (radius > 256) {
-                std.log.err("Median blur radius {d} exceeds maximum limit of 256.", .{radius});
+                std.log.err("median blur radius {d} exceeds maximum limit of 256.", .{radius});
                 return error.InvalidArguments;
             }
             try img.medianBlur(gpa, radius, out);
@@ -155,18 +154,18 @@ fn processImage(
             var dist = options.distance orelse 10.0;
 
             if (!std.math.isFinite(angle_deg) or !std.math.isFinite(dist)) {
-                std.log.err("Angle and distance must be finite numbers.", .{});
+                std.log.err("angle and distance must be finite numbers.", .{});
                 return error.InvalidArguments;
             }
             if (dist < 0) {
-                std.log.err("Distance must be non-negative.", .{});
+                std.log.err("distance must be non-negative.", .{});
                 return error.InvalidArguments;
             }
 
             const max_dim = @as(f32, @floatFromInt(@max(img.rows, img.cols)));
 
             if (dist > max_dim) {
-                std.log.warn("Motion blur distance {d:.1} exceeds image dimensions. Clamping to {d:.1}.", .{ dist, max_dim });
+                std.log.warn("motion blur distance {d:.1} exceeds image dimensions. clamping to {d:.1}.", .{ dist, max_dim });
                 dist = max_dim;
             }
 
@@ -179,16 +178,16 @@ fn processImage(
             const strength = options.strength orelse 0.5;
 
             if (!std.math.isFinite(cx) or !std.math.isFinite(cy) or !std.math.isFinite(strength)) {
-                std.log.err("Radial blur parameters (center-x, center-y, strength) must be finite numbers.", .{});
+                std.log.err("radial blur parameters (center-x, center-y, strength) must be finite numbers.", .{});
                 return error.InvalidArguments;
             }
 
             if (cx < 0 or cx > 1 or cy < 0 or cy > 1) {
-                std.log.warn("Center coordinates ({d:.2}, {d:.2}) are outside the typical [0, 1] range.", .{ cx, cy });
+                std.log.warn("center coordinates ({d:.2}, {d:.2}) are outside the typical [0, 1] range.", .{ cx, cy });
             }
 
             if (strength < 0 or strength > 1) {
-                std.log.err("Strength must be between 0.0 and 1.0.", .{});
+                std.log.err("strength must be between 0.0 and 1.0.", .{});
                 return error.InvalidArguments;
             }
 
@@ -201,19 +200,14 @@ fn processImage(
         },
     }
 
-    const end_time = std.Io.Clock.awake.now(io);
-    const blur_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("Blur operation took {d:.3} ms", .{@as(f64, @floatFromInt(blur_ns)) / std.time.ns_per_ms});
+    timer.logElapsed("blur");
 
     if (target) |tgt| {
-        const output_path = if (tgt.is_directory) try blk_path: {
-            const basename = Io.Dir.path.basename(input_path);
-            break :blk_path Io.Dir.path.join(gpa, &[_][]const u8{ tgt.path, basename });
-        } else tgt.path;
-        defer if (tgt.is_directory) gpa.free(output_path);
+        const resolved = try tgt.resolveOutputPath(gpa, input_path);
+        defer resolved.deinit(gpa);
 
-        std.log.info("Saving to {s}...", .{output_path});
-        try out.save(io, gpa, output_path);
+        std.log.info("saving to {s}...", .{resolved.path});
+        try out.save(io, gpa, resolved.path);
     }
 
     if (should_display) {

--- a/src/cli/common.zig
+++ b/src/cli/common.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const Io = std.Io;
 
 const zignal = @import("zignal");
@@ -6,6 +7,26 @@ const zignal = @import("zignal");
 pub const OutputTarget = struct {
     path: []const u8,
     is_directory: bool,
+
+    /// Resolve the destination path for a given input file. When the target is a
+    /// directory, the result is owned by the caller (free via `ResolvedPath.deinit`).
+    pub fn resolveOutputPath(self: OutputTarget, allocator: Allocator, input_path: []const u8) !ResolvedPath {
+        if (self.is_directory) {
+            const basename = Io.Dir.path.basename(input_path);
+            const joined = try Io.Dir.path.join(allocator, &.{ self.path, basename });
+            return .{ .path = joined, .owned = true };
+        }
+        return .{ .path = self.path, .owned = false };
+    }
+};
+
+pub const ResolvedPath = struct {
+    path: []const u8,
+    owned: bool,
+
+    pub fn deinit(self: ResolvedPath, allocator: Allocator) void {
+        if (self.owned) allocator.free(self.path);
+    }
 };
 
 pub fn resolveOutputTarget(
@@ -15,29 +36,26 @@ pub fn resolveOutputTarget(
 ) !OutputTarget {
     var is_directory = false;
 
-    // Try to open it as a directory first. This is the most robust check.
     if (Io.Dir.cwd().openDir(io, output_arg, .{})) |dir| {
         dir.close(io);
         is_directory = true;
     } else |err| switch (err) {
         error.NotDir => {
-            // It exists but it's not a directory, so it's a file.
             if (is_batch) {
-                std.log.err("Output path '{s}' is a file, but multiple input files were provided. Batch output requires a directory.", .{output_arg});
+                std.log.err("output path '{s}' is a file, but multiple input files were provided. batch output requires a directory.", .{output_arg});
                 return error.InvalidArguments;
             }
             is_directory = false;
         },
         error.FileNotFound => {
-            // It doesn't exist. Infer intent from trailing separator.
             const ends_with_sep = std.mem.endsWith(u8, output_arg, "/") or std.mem.endsWith(u8, output_arg, "\\");
             if (ends_with_sep) {
                 is_directory = true;
-                std.log.debug("Creating output directory '{s}'...", .{output_arg});
+                std.log.debug("creating output directory '{s}'...", .{output_arg});
                 try Io.Dir.cwd().createDirPath(io, output_arg);
             } else {
                 if (is_batch) {
-                    std.log.err("Output path '{s}' does not exist and does not end with a separator. Batch output requires a directory.", .{output_arg});
+                    std.log.err("output path '{s}' does not exist and does not end with a separator. batch output requires a directory.", .{output_arg});
                     return error.InvalidArguments;
                 }
                 is_directory = false;
@@ -52,7 +70,14 @@ pub fn resolveOutputTarget(
     };
 }
 
-pub fn parseFilter(name: []const u8) !zignal.Interpolation {
+/// Resolves the user's `--filter` string (if any) into an interpolation method.
+/// Defaults to bilinear.
+pub fn resolveFilter(name: ?[]const u8) !zignal.Interpolation {
+    const n = name orelse {
+        std.log.debug("using default filter: bilinear", .{});
+        return .bilinear;
+    };
+    std.log.debug("resolving filter: {s}", .{n});
     const filter_map = std.StaticStringMap(zignal.Interpolation).initComptime(.{
         .{ "nearest", .nearest_neighbor },
         .{ "bilinear", .bilinear },
@@ -61,21 +86,24 @@ pub fn parseFilter(name: []const u8) !zignal.Interpolation {
         .{ "catmull-rom", .catmull_rom },
         .{ "mitchell", zignal.Interpolation{ .mitchell = .default } },
     });
-    if (filter_map.get(name)) |f_enum| {
-        return f_enum;
-    } else {
+    return filter_map.get(n) orelse {
+        std.log.err("unknown filter type: {s}", .{n});
         return error.InvalidArguments;
-    }
+    };
 }
 
-pub fn resolveFilter(name: ?[]const u8) !zignal.Interpolation {
-    if (name) |n| {
-        std.log.debug("Resolving filter: {s}", .{n});
-        return parseFilter(n) catch |err| {
-            std.log.err("Unknown filter type: {s}", .{n});
-            return err;
-        };
+/// Measures wall-clock elapsed time and logs it at debug level.
+pub const Timer = struct {
+    io: Io,
+    start: Io.Timestamp,
+
+    pub fn begin(io: Io) Timer {
+        return .{ .io = io, .start = Io.Clock.awake.now(io) };
     }
-    std.log.debug("Using default filter: bilinear", .{});
-    return .bilinear;
-}
+
+    pub fn logElapsed(self: Timer, comptime label: []const u8) void {
+        const end = Io.Clock.awake.now(self.io);
+        const ns = self.start.durationTo(end).toNanoseconds();
+        std.log.debug(label ++ " took {d:.3} ms", .{@as(f64, @floatFromInt(ns)) / std.time.ns_per_ms});
+    }
+};

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const zignal = @import("zignal");
 
 const args = @import("args.zig");
+const common = @import("common.zig");
 const display = @import("display.zig");
 
 const Args = struct {
@@ -57,15 +58,14 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 
     const should_display = parsed.options.display or parsed.options.output == null;
 
-    // Load images
-    std.log.debug("Loading first image: {s}", .{path1});
+    std.log.debug("loading first image: {s}", .{path1});
     var img1 = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path1) catch |err| {
         std.log.err("failed to load image '{s}': {t}", .{ path1, err });
         return;
     };
     defer img1.deinit(gpa);
 
-    std.log.debug("Loading second image: {s}", .{path2});
+    std.log.debug("loading second image: {s}", .{path2});
     var img2 = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path2) catch |err| {
         std.log.err("failed to load image '{s}': {t}", .{ path2, err });
         return;
@@ -73,7 +73,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     defer img2.deinit(gpa);
 
     if (img1.rows != img2.rows or img1.cols != img2.cols) {
-        std.log.err("Dimension mismatch: {d}x{d} vs {d}x{d}", .{
+        std.log.err("dimension mismatch: {d}x{d} vs {d}x{d}", .{
             img1.cols, img1.rows, img2.cols, img2.rows,
         });
         return;
@@ -83,35 +83,27 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const threshold = parsed.options.threshold orelse 0;
     const binary = parsed.options.binary;
 
-    std.log.debug("Computing difference...", .{});
-
     var diff_img = try zignal.Image(zignal.Rgba(u8)).init(gpa, img1.rows, img1.cols);
     defer diff_img.deinit(gpa);
 
-    // Use DiffOptions to handle visualization logic inside the library
     const diff_opts = zignal.Image(zignal.Rgba(u8)).DiffOptions{
         .threshold = @floatFromInt(threshold),
         .scale = scale,
         .binary = binary,
-        .force_opaque = true, // Force visual result to be opaque
+        .force_opaque = true,
     };
 
-    const start_time = std.Io.Clock.awake.now(io);
+    const timer = common.Timer.begin(io);
     const result = try img1.diff(img2, diff_img, diff_opts);
-    const end_time = std.Io.Clock.awake.now(io);
-    const diff_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("Diff computation took {d:.3} ms", .{@as(f64, @floatFromInt(diff_ns)) / std.time.ns_per_ms});
+    timer.logElapsed("diff");
 
-    // If using binary mode, stats.max() will be 255 if any diff found, or 0.
-    // If using absolute mode (with scaling), stats.max() will be the max visualization brightness.
-    // However, users usually want to know the *raw* max difference, but we only have stats of the *processed* image.
-    // For now, reporting the max pixel value in the diff image is consistent with what is shown.
-
-    std.log.info("Max difference found: {d}", .{@as(u32, @trunc(result.stats.max()))});
-    std.log.info("Pixels differing > {d}: {d}", .{ threshold, result.diff_count });
+    // `result.stats` describes the *visualized* diff image (after threshold/scale/binary),
+    // not the raw per-pixel delta — so for binary mode max() is 0 or 255.
+    std.log.info("max difference found: {d}", .{@as(u32, @trunc(result.stats.max()))});
+    std.log.info("pixels differing > {d}: {d}", .{ threshold, result.diff_count });
 
     if (parsed.options.output) |output_path| {
-        std.log.info("Saving difference image to '{s}'...", .{output_path});
+        std.log.info("saving difference image to '{s}'...", .{output_path});
         try diff_img.save(io, gpa, output_path);
     }
 
@@ -127,7 +119,6 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         );
         defer canvas.deinit(gpa);
 
-        std.log.debug("Displaying result...", .{});
         const format = try display.resolveDisplayFormat(parsed.options.protocol, null, null);
         try display.displayCanvas(io, writer, &canvas, format);
     }

--- a/src/cli/display.zig
+++ b/src/cli/display.zig
@@ -43,16 +43,15 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 
     for (parsed.positionals) |path| {
         if (parsed.positionals.len > 1) {
-            std.log.debug("File: {s}", .{path});
+            std.log.debug("file: {s}", .{path});
         }
-        std.log.debug("Loading image: {s}", .{path});
+        std.log.debug("loading image: {s}", .{path});
         var image: zignal.Image(zignal.Rgba(u8)) = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path) catch |err| {
-            std.log.err("Failed to load image '{s}': {}", .{ path, err });
+            std.log.err("failed to load image '{s}': {}", .{ path, err });
             continue;
         };
         defer image.deinit(gpa);
 
-        std.log.debug("Displaying image...", .{});
         try displayCanvas(io, writer, image, display_fmt);
     }
 }
@@ -65,7 +64,7 @@ pub fn resolveDisplayFormat(
     var protocol: zignal.DisplayFormat = .{ .auto = .default };
     if (protocol_name) |p| {
         protocol = parseProtocol(p) catch |err| {
-            std.log.err("Unknown protocol type: {s}", .{p});
+            std.log.err("unknown protocol type: {s}", .{p});
             return err;
         };
     }
@@ -74,7 +73,6 @@ pub fn resolveDisplayFormat(
 }
 
 pub fn parseProtocol(name: []const u8) !zignal.DisplayFormat {
-    std.log.debug("Parsing protocol: {s}", .{name});
     const protocol_map = std.StaticStringMap(zignal.DisplayFormat).initComptime(.{
         .{ "kitty", zignal.DisplayFormat{ .kitty = .default } },
         .{ "sixel", zignal.DisplayFormat{ .sixel = .default } },
@@ -82,16 +80,9 @@ pub fn parseProtocol(name: []const u8) !zignal.DisplayFormat {
         .{ "braille", zignal.DisplayFormat{ .braille = .default } },
         .{ "auto", zignal.DisplayFormat{ .auto = .default } },
     });
-    if (protocol_map.get(name)) |p_enum| {
-        return p_enum;
-    } else {
-        return error.InvalidArguments;
-    }
+    return protocol_map.get(name) orelse error.InvalidArguments;
 }
 
-/// Applies user-provided scaling and filter options to a display protocol.
-/// Note: If width and height are null, the protocol will automatically enforce
-/// the global 2048x2048 dimension cap during rendering.
 pub fn applyOptions(protocol: *zignal.DisplayFormat, width: ?u32, height: ?u32) void {
     switch (protocol.*) {
         .kitty => |*opts| {
@@ -120,10 +111,6 @@ pub fn applyOptions(protocol: *zignal.DisplayFormat, width: ?u32, height: ?u32) 
     }
 }
 
-/// Helper function to display an image canvas in the terminal.
-/// Automatically handles protocol selection and scaling options.
-/// Note: Implicitly caps image dimensions to 2048x2048 via aspectScale to prevent
-/// excessive memory usage in the terminal.
 pub fn displayCanvas(
     io: Io,
     writer: *Io.Writer,
@@ -143,10 +130,7 @@ pub fn createHorizontalComposite(
 ) !zignal.Image(T) {
     if (images.len == 0) return zignal.Image(T).init(allocator, 1, 1);
 
-    // Use the first image as reference for aspect ratio scaling
     const ref_img = images[0];
-
-    // Calculate scale based on user constraints relative to the first image
     const scale_factor = zignal.terminal.aspectScale(
         user_width,
         user_height,
@@ -154,20 +138,16 @@ pub fn createHorizontalComposite(
         ref_img.cols,
     );
 
-    // Calculate dimensions for each sub-image
     const w: u32 = @round(@as(f32, @floatFromInt(ref_img.cols)) * scale_factor);
     const h: u32 = @round(@as(f32, @floatFromInt(ref_img.rows)) * scale_factor);
-
-    // Safety check for zero dimensions
-    const final_w = if (w == 0) 1 else w;
-    const final_h = if (h == 0) 1 else h;
+    const final_w = @max(w, 1);
+    const final_h = @max(h, 1);
 
     const canvas_w = @as(u32, @intCast(images.len)) * final_w;
     const canvas_h = final_h;
 
     var canvas = try zignal.Image(T).init(allocator, canvas_h, canvas_w);
 
-    // Fill background
     if (@hasDecl(T, "black")) {
         canvas.fill(T.black);
     } else {
@@ -179,7 +159,6 @@ pub fn createHorizontalComposite(
 
     for (images, 0..) |img, i| {
         const offset_x = @as(f32, @floatFromInt(i)) * wf;
-        // Use .none blend mode to overwrite (copy) pixels directly
         canvas.insert(img, .{ .l = offset_x, .t = 0, .r = offset_x + wf, .b = hf }, 0, .bilinear, .none);
     }
 

--- a/src/cli/edges.zig
+++ b/src/cli/edges.zig
@@ -72,7 +72,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     var algo: Algo = .sobel;
     if (parsed.options.filter) |f| {
         algo = algo_map.get(f) orelse {
-            std.log.err("Unknown filter: {s}. Supported: sobel, canny, shen-castan", .{f});
+            std.log.err("unknown filter: {s}. supported: sobel, canny, shen-castan", .{f});
             return error.InvalidArguments;
         };
     }
@@ -104,15 +104,15 @@ fn processImage(
     algo: Algo,
     options: Args,
 ) !void {
-    std.log.debug("Loading image: {s}", .{input_path});
+    std.log.debug("loading image: {s}", .{input_path});
     var img = try zignal.Image(u8).load(io, gpa, input_path);
     defer img.deinit(gpa);
 
     var out_img = try zignal.Image(u8).init(gpa, img.rows, img.cols);
     defer out_img.deinit(gpa);
 
-    std.log.debug("Applying {s} edge detection...", .{@tagName(algo)});
-    const start_time = std.Io.Clock.awake.now(io);
+    std.log.debug("applying {s} edge detection...", .{@tagName(algo)});
+    const timer = common.Timer.begin(io);
 
     switch (algo) {
         .sobel => {
@@ -122,7 +122,7 @@ fn processImage(
             const sigma = options.sigma orelse 1.0;
             const low = options.low orelse 50.0;
             const high = options.high orelse 100.0;
-            std.log.debug("Canny params: sigma={d:.2}, low={d:.2}, high={d:.2}", .{ sigma, low, high });
+            std.log.debug("canny params: sigma={d:.2}, low={d:.2}, high={d:.2}", .{ sigma, low, high });
             try img.canny(gpa, sigma, low, high, out_img);
         },
         .shen_castan => {
@@ -133,26 +133,21 @@ fn processImage(
                 .low_rel = options.low orelse 0.5,
                 .use_nms = options.nms,
             };
-            std.log.debug("Shen-Castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
+            std.log.debug("shen-castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
                 opts.smooth, opts.window_size, opts.high_ratio, opts.low_rel, opts.use_nms,
             });
             try img.shenCastan(gpa, opts, out_img);
         },
     }
 
-    const end_time = std.Io.Clock.awake.now(io);
-    const duration_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("Edge detection took {d:.3} ms", .{@as(f64, @floatFromInt(duration_ns)) / std.time.ns_per_ms});
+    timer.logElapsed("edge detection");
 
     if (target) |tgt| {
-        const output_path = if (tgt.is_directory) try blk_path: {
-            const basename = Io.Dir.path.basename(input_path);
-            break :blk_path Io.Dir.path.join(gpa, &[_][]const u8{ tgt.path, basename });
-        } else tgt.path;
-        defer if (tgt.is_directory) gpa.free(output_path);
+        const resolved = try tgt.resolveOutputPath(gpa, input_path);
+        defer resolved.deinit(gpa);
 
-        std.log.info("Saving result to {s}...", .{output_path});
-        try out_img.save(io, gpa, output_path);
+        std.log.info("saving result to {s}...", .{resolved.path});
+        try out_img.save(io, gpa, resolved.path);
     }
 
     if (should_display) {

--- a/src/cli/fdm.zig
+++ b/src/cli/fdm.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const zignal = @import("zignal");
 
 const args = @import("args.zig");
+const common = @import("common.zig");
 const display = @import("display.zig");
 
 const Args = struct {
@@ -42,44 +43,36 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const target_path = parsed.positionals[1];
     const output_path = if (parsed.positionals.len == 3) parsed.positionals[2] else null;
 
-    // Display if requested OR if no output file is specified
     const should_display = parsed.options.display or output_path == null;
 
-    // Use Rgb(u8) for style transfer
     const Pixel = zignal.Rgb(u8);
 
-    // Load source image
-    std.log.debug("Loading source image: {s}", .{source_path});
+    std.log.debug("loading source image: {s}", .{source_path});
     var source_img: zignal.Image(Pixel) = try .load(io, gpa, source_path);
     defer source_img.deinit(gpa);
 
-    // Keep a copy of the original for display if needed
+    // FDM mutates `source_img` in place; keep an original copy for the side-by-side preview.
     var original_source: ?zignal.Image(Pixel) = null;
     if (should_display) {
         original_source = try source_img.dupe(gpa);
     }
     defer if (original_source) |*img| img.deinit(gpa);
 
-    // Load target image
-    std.log.debug("Loading target image: {s}", .{target_path});
+    std.log.debug("loading target image: {s}", .{target_path});
     var target_img: zignal.Image(Pixel) = try .load(io, gpa, target_path);
     defer target_img.deinit(gpa);
 
-    // Initialize FDM
     var fdm: zignal.FeatureDistributionMatching(Pixel) = .init(gpa);
     defer fdm.deinit();
 
-    std.log.debug("Applying FDM style transfer...", .{});
+    std.log.debug("applying fdm style transfer...", .{});
 
-    const start_time = std.Io.Clock.awake.now(io);
-    // Apply match
+    const timer = common.Timer.begin(io);
     try fdm.match(source_img, target_img);
-    const end_time = std.Io.Clock.awake.now(io);
-    const fdm_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("FDM took {d:.3} ms", .{@as(f64, @floatFromInt(fdm_ns)) / std.time.ns_per_ms});
+    timer.logElapsed("fdm");
 
     if (output_path) |out_path| {
-        std.log.info("Saving result to {s}...", .{out_path});
+        std.log.info("saving result to {s}...", .{out_path});
         try source_img.save(io, gpa, out_path);
     }
 

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -9,6 +9,7 @@ const bmp = zignal.bmp;
 const gif = zignal.gif;
 
 const args = @import("args.zig");
+const common = @import("common.zig");
 
 const Args = struct {
     stats: bool = false,
@@ -35,7 +36,6 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    // Buffer for reading file data
     var read_buffer: [4096]u8 = undefined;
 
     for (parsed.positionals) |image_path| {
@@ -43,89 +43,83 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
             try writer.print("File: {s}\n", .{image_path});
         }
 
-        // Use a block to catch errors for individual files so we can continue to the next one
         const result = blk: {
-            std.log.debug("Detecting format for: {s}", .{image_path});
-            const image_format = zignal.ImageFormat.detectFromPath(io, gpa, image_path) catch |err| break :blk err;
-            if (image_format) |fmt| {
-                std.log.debug("Format detected: {s}", .{@tagName(fmt)});
-                const file = Io.Dir.cwd().openFile(io, image_path, .{}) catch |err| break :blk err;
-                defer file.close(io);
+            std.log.debug("inspecting: {s}", .{image_path});
+            const file = Io.Dir.cwd().openFile(io, image_path, .{}) catch |err| break :blk err;
+            defer file.close(io);
 
-                var reader = file.reader(io, &read_buffer);
+            var reader = file.reader(io, &read_buffer);
+            const peek = reader.interface.peek(8) catch |err| break :blk err;
+            const image_format = zignal.ImageFormat.detectFromBytes(peek) orelse break :blk error.UnsupportedImageFormat;
+            std.log.debug("format detected: {s}", .{@tagName(image_format)});
 
-                switch (fmt) {
-                    .png => {
-                        const info = png.getInfo(&reader.interface, .{}) catch |err| break :blk err;
+            switch (image_format) {
+                .png => {
+                    const info = png.getInfo(&reader.interface, .{}) catch |err| break :blk err;
 
-                        try writer.print("Format:      PNG\n", .{});
-                        try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
-                        try writer.print("Bit Depth:   {d}\n", .{info.bit_depth});
-                        try writer.print("Channels:    {d}\n", .{info.channels()});
-                        try writer.print("Color Space: {s}\n", .{@tagName(info.color_type)});
+                    try writer.print("Format:      PNG\n", .{});
+                    try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
+                    try writer.print("Bit Depth:   {d}\n", .{info.bit_depth});
+                    try writer.print("Channels:    {d}\n", .{info.channels()});
+                    try writer.print("Color Space: {s}\n", .{@tagName(info.color_type)});
 
-                        if (info.gamma) |g| {
-                            try writer.print("Gamma:       {d}\n", .{g});
-                        }
-                        if (info.srgb_intent) |intent| {
-                            try writer.print("sRGB:        {s}\n", .{@tagName(intent)});
-                        }
-                    },
-                    .jpeg => {
-                        const info = jpeg.getInfo(&reader.interface, .{}) catch |err| break :blk err;
+                    if (info.gamma) |g| {
+                        try writer.print("Gamma:       {d}\n", .{g});
+                    }
+                    if (info.srgb_intent) |intent| {
+                        try writer.print("sRGB:        {s}\n", .{@tagName(intent)});
+                    }
+                },
+                .jpeg => {
+                    const info = jpeg.getInfo(&reader.interface, .{}) catch |err| break :blk err;
 
-                        try writer.print("Format:      JPEG\n", .{});
-                        try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
-                        try writer.print("Bit Depth:   {d}\n", .{info.precision});
-                        try writer.print("Channels:    {d}\n", .{info.num_components});
-                        try writer.print("Color Space: {s}\n", .{if (info.num_components == 1) "Grayscale" else "YCbCr"});
-                        try writer.print("Frame Type:  {s}\n", .{@tagName(info.frame_type)});
-                    },
-                    .bmp => {
-                        const info = bmp.getInfo(&reader.interface, .{}) catch |err| break :blk err;
+                    try writer.print("Format:      JPEG\n", .{});
+                    try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
+                    try writer.print("Bit Depth:   {d}\n", .{info.precision});
+                    try writer.print("Channels:    {d}\n", .{info.num_components});
+                    try writer.print("Color Space: {s}\n", .{if (info.num_components == 1) "Grayscale" else "YCbCr"});
+                    try writer.print("Frame Type:  {s}\n", .{@tagName(info.frame_type)});
+                },
+                .bmp => {
+                    const info = bmp.getInfo(&reader.interface, .{}) catch |err| break :blk err;
 
-                        try writer.print("Format:      BMP\n", .{});
-                        try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
-                        try writer.print("Bit Depth:   {d}\n", .{info.bit_depth});
-                        try writer.print("Compression: {s}\n", .{@tagName(info.compression)});
-                        try writer.print("DIB Header:  {s}\n", .{@tagName(info.dib_kind)});
-                        try writer.print("Top-down:    {s}\n", .{if (info.top_down) "yes" else "no"});
-                        if (info.palette_entries > 0) {
-                            try writer.print("Palette:     {d} entries\n", .{info.palette_entries});
-                        }
-                        if (info.hasAlpha()) {
-                            try writer.print("Alpha:       yes\n", .{});
-                        }
-                    },
-                    .gif => {
-                        const info = gif.getInfo(&reader.interface, .{}) catch |err| break :blk err;
+                    try writer.print("Format:      BMP\n", .{});
+                    try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
+                    try writer.print("Bit Depth:   {d}\n", .{info.bit_depth});
+                    try writer.print("Compression: {s}\n", .{@tagName(info.compression)});
+                    try writer.print("DIB Header:  {s}\n", .{@tagName(info.dib_kind)});
+                    try writer.print("Top-down:    {s}\n", .{if (info.top_down) "yes" else "no"});
+                    if (info.palette_entries > 0) {
+                        try writer.print("Palette:     {d} entries\n", .{info.palette_entries});
+                    }
+                    if (info.hasAlpha()) {
+                        try writer.print("Alpha:       yes\n", .{});
+                    }
+                },
+                .gif => {
+                    const info = gif.getInfo(&reader.interface, .{}) catch |err| break :blk err;
 
-                        try writer.print("Format:      GIF\n", .{});
-                        try writer.print("Version:     {s}\n", .{@tagName(info.version)});
-                        try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
-                        try writer.print("Frames:      {d}\n", .{info.frame_count});
-                        if (info.loop_count == 0) {
-                            try writer.print("Loop count:  infinite\n", .{});
-                        } else {
-                            try writer.print("Loop count:  {d}\n", .{info.loop_count});
-                        }
-                        if (info.has_global_color_table) {
-                            try writer.print("Palette:     {d} entries (global)\n", .{info.global_color_table_size});
-                        }
-                    },
-                }
-            } else {
-                break :blk error.UnsupportedImageFormat;
+                    try writer.print("Format:      GIF\n", .{});
+                    try writer.print("Version:     {s}\n", .{@tagName(info.version)});
+                    try writer.print("Dimensions:  {d}x{d}\n", .{ info.width, info.height });
+                    try writer.print("Frames:      {d}\n", .{info.frame_count});
+                    if (info.loop_count == 0) {
+                        try writer.print("Loop count:  infinite\n", .{});
+                    } else {
+                        try writer.print("Loop count:  {d}\n", .{info.loop_count});
+                    }
+                    if (info.has_global_color_table) {
+                        try writer.print("Palette:     {d} entries (global)\n", .{info.global_color_table_size});
+                    }
+                },
             }
 
             if (parsed.options.stats) {
-                // Load image as RGBA(u8)
-                std.log.debug("Loading image for stats: {s}", .{image_path});
+                std.log.debug("loading image for stats: {s}", .{image_path});
                 var image = zignal.Image(zignal.Rgba(u8)).load(io, gpa, image_path) catch |err| break :blk err;
                 defer image.deinit(gpa);
 
-                std.log.debug("Computing statistics...", .{});
-                const start_time = std.Io.Clock.awake.now(io);
+                const timer = common.Timer.begin(io);
                 var r_stats: zignal.RunningStats(f64) = .init();
                 var g_stats: zignal.RunningStats(f64) = .init();
                 var b_stats: zignal.RunningStats(f64) = .init();
@@ -135,9 +129,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
                     g_stats.add(pixel.g);
                     b_stats.add(pixel.b);
                 }
-                const end_time = std.Io.Clock.awake.now(io);
-                const stats_ns = start_time.durationTo(end_time).toNanoseconds();
-                std.log.debug("Statistics computed in {d:.3} ms", .{@as(f64, @floatFromInt(stats_ns)) / std.time.ns_per_ms});
+                timer.logElapsed("statistics");
 
                 try writer.print("\n{s: <8} {s: >8} {s: >8} {s: >10} {s: >10}\n", .{ "Channel", "Min", "Max", "Mean", "StdDev" });
                 inline for (.{ .{ "Red", &r_stats }, .{ "Green", &g_stats }, .{ "Blue", &b_stats } }) |entry| {
@@ -153,9 +145,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
             break :blk {};
         };
 
-        if (result) |_| {
-            // Success
-        } else |err| {
+        if (result) |_| {} else |err| {
             std.log.err("failed to get info for '{s}': {t}", .{ image_path, err });
         }
 

--- a/src/cli/metrics.zig
+++ b/src/cli/metrics.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const zignal = @import("zignal");
 
 const args = @import("args.zig");
+const common = @import("common.zig");
 
 const Args = struct {};
 
@@ -34,16 +35,14 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const ref_path = parsed.positionals[0];
     const targets = parsed.positionals[1..];
 
-    std.log.debug("Reference image: {s}", .{ref_path});
-    std.log.debug("Loading reference image...", .{});
+    std.log.debug("loading reference image: {s}", .{ref_path});
     var ref_img = try zignal.Image(zignal.Rgba(u8)).load(io, gpa, ref_path);
     defer ref_img.deinit(gpa);
 
     for (targets) |path| {
         try writer.print("\nComparing: {s}\n", .{path});
 
-        // Load target image
-        std.log.debug("Loading target image: {s}", .{path});
+        std.log.debug("loading target image: {s}", .{path});
         var img = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path) catch |err| {
             std.log.err("failed to load image '{s}': {t}", .{ path, err });
             continue;
@@ -57,24 +56,20 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
             continue;
         }
 
-        std.log.debug("Calculating metrics...", .{});
-        const start_time = std.Io.Clock.awake.now(io);
+        const timer = common.Timer.begin(io);
 
         const psnr_val = ref_img.psnr(img) catch unreachable;
         const mean_err = ref_img.meanPixelError(img) catch unreachable;
 
-        // SSIM calculation
+        // SSIM requires the window to fit, so 11x11 is the minimum.
         var ssim_val: f64 = 0;
-        // SSIM requires minimum 11x11
         if (img.rows >= 11 and img.cols >= 11) {
             ssim_val = try ref_img.ssim(img);
         } else {
-            std.log.warn("Image {s} is too small for SSIM (min 11x11)", .{path});
+            std.log.warn("image {s} is too small for ssim (min 11x11)", .{path});
         }
 
-        const end_time = std.Io.Clock.awake.now(io);
-        const metrics_ns = start_time.durationTo(end_time).toNanoseconds();
-        std.log.debug("Metrics calculation took {d:.3} ms", .{@as(f64, @floatFromInt(metrics_ns)) / std.time.ns_per_ms});
+        timer.logElapsed("metrics");
 
         try writer.print("  PSNR: {d:.4} dB\n", .{psnr_val});
         try writer.print("  SSIM: {d:.4}\n", .{ssim_val});

--- a/src/cli/resize.zig
+++ b/src/cli/resize.zig
@@ -41,29 +41,27 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     }
 
     const output_arg = parsed.options.output orelse {
-        std.log.err("Missing mandatory option: --output <file_or_dir>", .{});
+        std.log.err("missing mandatory option: --output <file_or_dir>", .{});
         return error.InvalidArguments;
     };
 
-    // Validate conflicting options
     if (parsed.options.scale != null and (parsed.options.width != null or parsed.options.height != null)) {
-        std.log.err("Cannot specify both --scale and --width/--height", .{});
+        std.log.err("cannot specify both --scale and --width/--height", .{});
         return error.InvalidArguments;
     }
 
     if (parsed.options.scale == null and parsed.options.width == null and parsed.options.height == null) {
-        std.log.err("Must specify at least one of --scale, --width, or --height", .{});
+        std.log.err("must specify at least one of --scale, --width, or --height", .{});
         return error.InvalidArguments;
     }
 
-    // Parse filter once
     const filter = try common.resolveFilter(parsed.options.filter);
 
     const is_batch = parsed.positionals.len > 1;
     const target = try common.resolveOutputTarget(io, output_arg, is_batch);
 
     for (parsed.positionals) |input_path| {
-        processImage(io, gpa, input_path, target.path, target.is_directory, is_batch, filter, parsed.options) catch |err| {
+        processImage(io, gpa, input_path, target, is_batch, filter, parsed.options) catch |err| {
             std.log.err("failed to resize '{s}': {t}", .{ input_path, err });
             if (!is_batch) return err;
         };
@@ -74,83 +72,68 @@ fn processImage(
     io: Io,
     gpa: Allocator,
     input_path: []const u8,
-    output_arg: []const u8,
-    use_as_dir: bool,
+    target: common.OutputTarget,
     is_batch: bool,
     filter: zignal.Interpolation,
     options: Args,
 ) !void {
-    if (is_batch) {
-        std.log.debug("Processing {s}...", .{input_path});
-    } else {
-        std.log.debug("Loading {s}...", .{input_path});
-    }
+    std.log.debug("{s} {s}...", .{ if (is_batch) "processing" else "loading", input_path });
 
-    const output_path = if (use_as_dir) try blk_path: {
-        const basename = Io.Dir.path.basename(input_path);
-        break :blk_path Io.Dir.path.join(gpa, &[_][]const u8{ output_arg, basename });
-    } else output_arg;
-    defer if (use_as_dir) gpa.free(output_path);
+    const resolved = try target.resolveOutputPath(gpa, input_path);
+    defer resolved.deinit(gpa);
 
-    // Load image
     var img: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
     defer img.deinit(gpa);
 
     if (img.rows == 0 or img.cols == 0) {
-        std.log.err("Input image has zero dimensions ({d}x{d})", .{ img.cols, img.rows });
+        std.log.err("input image has zero dimensions ({d}x{d})", .{ img.cols, img.rows });
         return error.InvalidDimensions;
     }
 
-    // Calculate new dimensions
-    var new_width: u32 = 0;
-    var new_height: u32 = 0;
+    const dims = try computeTargetDimensions(img, options);
+
+    const indent: []const u8 = if (is_batch) "  " else "";
+    std.log.info("{s}resizing from {d}x{d} to {d}x{d} using {s}...", .{ indent, img.cols, img.rows, dims.width, dims.height, @tagName(filter) });
+
+    var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, dims.height, dims.width);
+    defer out.deinit(gpa);
+
+    const timer = common.Timer.begin(io);
+    img.resize(gpa, out, filter);
+    timer.logElapsed("resize");
+
+    std.log.info("{s}saving to {s}...", .{ indent, resolved.path });
+    try out.save(io, gpa, resolved.path);
+}
+
+const Dimensions = struct { width: u32, height: u32 };
+
+fn computeTargetDimensions(img: zignal.Image(zignal.Rgba(u8)), options: Args) !Dimensions {
+    var width: u32 = 0;
+    var height: u32 = 0;
 
     if (options.scale) |s| {
         if (s <= 0 or !std.math.isFinite(s)) {
-            std.log.err("Scale factor must be positive and finite", .{});
+            std.log.err("scale factor must be positive and finite", .{});
             return error.InvalidArguments;
         }
-        new_width = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(img.cols)) * s) catch return error.InvalidDimensions;
-        new_height = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(img.rows)) * s) catch return error.InvalidDimensions;
-    } else {
-        if (options.width != null and options.height != null) {
-            new_width = options.width.?;
-            new_height = options.height.?;
-        } else if (options.width) |w| {
-            new_width = w;
-            const aspect = @as(f32, @floatFromInt(img.rows)) / @as(f32, @floatFromInt(img.cols));
-            new_height = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(w)) * aspect) catch return error.InvalidDimensions;
-        } else if (options.height) |h| {
-            new_height = h;
-            const aspect = @as(f32, @floatFromInt(img.cols)) / @as(f32, @floatFromInt(img.rows));
-            new_width = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(h)) * aspect) catch return error.InvalidDimensions;
-        }
+        width = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(img.cols)) * s) catch return error.InvalidDimensions;
+        height = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(img.rows)) * s) catch return error.InvalidDimensions;
+    } else if (options.width != null and options.height != null) {
+        width = options.width.?;
+        height = options.height.?;
+    } else if (options.width) |w| {
+        width = w;
+        const aspect = @as(f32, @floatFromInt(img.rows)) / @as(f32, @floatFromInt(img.cols));
+        height = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(w)) * aspect) catch return error.InvalidDimensions;
+    } else if (options.height) |h| {
+        height = h;
+        const aspect = @as(f32, @floatFromInt(img.cols)) / @as(f32, @floatFromInt(img.rows));
+        width = zignal.meta.safeCast(u32, @as(f32, @floatFromInt(h)) * aspect) catch return error.InvalidDimensions;
     }
 
-    if (new_width == 0) new_width = 1;
-    if (new_height == 0) new_height = 1;
-
-    if (is_batch) {
-        std.log.info("  Resizing from {d}x{d} to {d}x{d} using {s}...", .{ img.cols, img.rows, new_width, new_height, @tagName(filter) });
-    } else {
-        std.log.info("Resizing from {d}x{d} to {d}x{d} using {s}...", .{ img.cols, img.rows, new_width, new_height, @tagName(filter) });
-    }
-
-    // Perform resize
-    var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, new_height, new_width);
-    defer out.deinit(gpa);
-
-    const start_time = std.Io.Clock.awake.now(io);
-    img.resize(gpa, out, filter);
-    const end_time = std.Io.Clock.awake.now(io);
-    const resize_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("Resize operation took {d:.3} ms", .{@as(f64, @floatFromInt(resize_ns)) / std.time.ns_per_ms});
-
-    // Save output
-    if (is_batch) {
-        std.log.info("  Saving to {s}...", .{output_path});
-    } else {
-        std.log.info("Saving to {s}...", .{output_path});
-    }
-    try out.save(io, gpa, output_path);
+    return .{
+        .width = @max(width, 1),
+        .height = @max(height, 1),
+    };
 }

--- a/src/cli/tile.zig
+++ b/src/cli/tile.zig
@@ -5,6 +5,7 @@ const Io = std.Io;
 const zignal = @import("zignal");
 
 const args = @import("args.zig");
+const common = @import("common.zig");
 const display = @import("display.zig");
 
 const LayoutMode = enum {
@@ -58,7 +59,6 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const img_count = input_paths.len;
     const output_path = parsed.options.output;
 
-    // Display if requested OR if no output file is specified
     const should_display = parsed.options.display or output_path == null;
 
     var mode: LayoutMode = .square;
@@ -73,12 +73,11 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         if (mode_map.get(m)) |val| {
             mode = val;
         } else {
-            std.log.err("Unknown layout mode: {s}", .{m});
+            std.log.err("unknown layout mode: {s}", .{m});
             return error.InvalidArguments;
         }
     }
 
-    // Determine Grid Dimensions
     var rows: u32 = 0;
     var cols: u32 = 0;
 
@@ -98,19 +97,19 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         },
         .grid => {
             if (parsed.options.rows == null or parsed.options.cols == null) {
-                std.log.err("Mode 'grid' requires --rows and --cols", .{});
+                std.log.err("mode 'grid' requires --rows and --cols", .{});
                 return error.InvalidArguments;
             }
             rows = parsed.options.rows.?;
             cols = parsed.options.cols.?;
             if (rows * cols < img_count) {
-                std.log.warn("Grid size ({d}x{d}={d}) is smaller than image count ({d}). Some images will be ignored.", .{ rows, cols, rows * cols, img_count });
+                std.log.warn("grid size ({d}x{d}={d}) is smaller than image count ({d}). some images will be ignored.", .{ rows, cols, rows * cols, img_count });
             } else if (rows * cols > img_count) {
-                std.log.debug("Grid size ({d}x{d}={d}) is larger than image count ({d}). Empty cells will be black.", .{ rows, cols, rows * cols, img_count });
+                std.log.debug("grid size ({d}x{d}={d}) is larger than image count ({d}). empty cells will be black.", .{ rows, cols, rows * cols, img_count });
             }
         },
         .factors => {
-            // Find factors closest to square
+            // Largest factor pair closest to a square; prefer landscape below.
             const n = @as(u32, @intCast(img_count));
             var best_r: u32 = 1;
             var i: u32 = 1;
@@ -121,32 +120,22 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
             }
             rows = best_r;
             cols = n / best_r;
-            // Prefer landscape orientation (more cols than rows)
-            if (rows > cols) {
-                const tmp = rows;
-                rows = cols;
-                cols = tmp;
-            }
-            std.log.debug("Factors mode: calculated {d}x{d} grid for {d} images", .{ rows, cols, n });
+            if (rows > cols) std.mem.swap(u32, &rows, &cols);
+            std.log.debug("factors mode: calculated {d}x{d} grid for {d} images", .{ rows, cols, n });
         },
     }
 
-    std.log.info("Tiling {d} images into a {d}x{d} grid ({s})...", .{ img_count, cols, rows, @tagName(mode) });
+    std.log.info("tiling {d} images into a {d}x{d} grid ({s})...", .{ img_count, cols, rows, @tagName(mode) });
 
-    // Determine Cell Size
-    var cell_w: u32 = 0;
-    var cell_h: u32 = 0;
+    var cell_w: u32 = parsed.options.width orelse 0;
+    var cell_h: u32 = parsed.options.height orelse 0;
+    // Caches the first image so we don't load it twice when it doubles as the
+    // reference for cell sizing.
     var reference_img: ?zignal.Image(zignal.Rgba(u8)) = null;
     defer if (reference_img) |*img| img.deinit(gpa);
 
-    if (parsed.options.width) |w| cell_w = w;
-    if (parsed.options.height) |h| cell_h = h;
-
     if (cell_w == 0 or cell_h == 0) {
-        // Load first image to establish dimensions
-        std.log.debug("Analyzing reference image: {s}...", .{input_paths[0]});
-
-        // Use RGBA for safety to handle transparency
+        std.log.debug("analyzing reference image: {s}...", .{input_paths[0]});
         reference_img = try zignal.Image(zignal.Rgba(u8)).load(io, gpa, input_paths[0]);
 
         const ref_w_f = @as(f32, @floatFromInt(reference_img.?.cols));
@@ -155,11 +144,9 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         if (cell_w == 0 and cell_h == 0) {
             cell_w = @intCast(reference_img.?.cols);
             cell_h = @intCast(reference_img.?.rows);
-        } else if (cell_w != 0 and cell_h == 0) {
-            // Scale height proportionally
+        } else if (cell_h == 0) {
             cell_h = @round((@as(f32, @floatFromInt(cell_w)) / ref_w_f) * ref_h_f);
-        } else if (cell_w == 0 and cell_h != 0) {
-            // Scale width proportionally
+        } else {
             cell_w = @round((@as(f32, @floatFromInt(cell_h)) / ref_h_f) * ref_w_f);
         }
     }
@@ -167,54 +154,35 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const canvas_w = cols * cell_w;
     const canvas_h = rows * cell_h;
 
-    std.log.debug("Cell Size: {d}x{d}", .{ cell_w, cell_h });
-    std.log.debug("Canvas Size: {d}x{d}", .{ canvas_w, canvas_h });
+    std.log.debug("cell size: {d}x{d}", .{ cell_w, cell_h });
+    std.log.debug("canvas size: {d}x{d}", .{ canvas_w, canvas_h });
 
-    // Create Canvas
-    std.log.debug("Creating canvas...", .{});
     var canvas = try zignal.Image(zignal.Rgba(u8)).init(gpa, canvas_h, canvas_w);
     defer canvas.deinit(gpa);
-    canvas.fill(.{ .r = 0, .g = 0, .b = 0, .a = 255 }); // Fill black (opaque)
+    canvas.fill(.{ .r = 0, .g = 0, .b = 0, .a = 255 });
 
-    // Process Images
-    const start_time = std.Io.Clock.awake.now(io);
+    const timer = common.Timer.begin(io);
     for (input_paths, 0..) |path, idx| {
         if (idx >= rows * cols) break;
 
         const r = idx / cols;
         const c = idx % cols;
 
-        std.log.debug("[{d}/{d}] Processing {s}...", .{ idx + 1, img_count, path });
+        std.log.debug("[{d}/{d}] processing {s}...", .{ idx + 1, img_count, path });
 
         var img: zignal.Image(zignal.Rgba(u8)) = undefined;
         var loaded_new = false;
-
-        // Optimization: Use the already loaded reference if it's the first one
         if (idx == 0 and reference_img != null) {
-            std.log.debug("Using reference image for slot {d}", .{idx});
             img = reference_img.?;
         } else {
-            // Load
-            std.log.debug("Loading image for slot {d}: {s}", .{ idx, path });
             img = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path) catch |err| {
-                std.log.warn("Failed to load {s}: {s}. Skipping slot.", .{ path, @errorName(err) });
+                std.log.warn("failed to load {s}: {s}. skipping slot.", .{ path, @errorName(err) });
                 continue;
             };
             loaded_new = true;
         }
         defer if (loaded_new) img.deinit(gpa);
 
-        // Check if resize is needed
-        if (img.cols != cell_w or img.rows != cell_h) {
-            // We need to resize.
-            // Create a temp buffer for the resized image
-            // Note: We can resize directly into the canvas using insert?
-            // Image.insert supports scaling?
-            // Checking src/image.zig: insert(self, source, rect, angle, method, blend_mode)
-            // It scales source to fit rect! Perfect.
-        }
-
-        // Calculate aspect-preserving destination rectangle
         const scale_x = @as(f32, @floatFromInt(cell_w)) / @as(f32, @floatFromInt(img.cols));
         const scale_y = @as(f32, @floatFromInt(cell_h)) / @as(f32, @floatFromInt(img.rows));
         const scale = @min(scale_x, scale_y);
@@ -237,12 +205,10 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 
         canvas.insert(img, dest_rect, 0, .bilinear, .none);
     }
-    const end_time = std.Io.Clock.awake.now(io);
-    const tile_ns = start_time.durationTo(end_time).toNanoseconds();
-    std.log.debug("Tiling operation took {d:.3} ms", .{@as(f64, @floatFromInt(tile_ns)) / std.time.ns_per_ms});
+    timer.logElapsed("tiling");
 
     if (output_path) |out_path| {
-        std.log.info("Saving to {s}...", .{out_path});
+        std.log.info("saving to {s}...", .{out_path});
         try canvas.save(io, gpa, out_path);
     }
 

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -26,7 +26,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    std.log.debug("Printing version info...", .{});
+    std.log.debug("printing version info...", .{});
     try writer.print("{s}\n", .{zignal.version});
     try writer.flush();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,7 +134,7 @@ pub const Cli = struct {
                 return;
             }
 
-            std.log.err("Unknown command: '{s}'", .{cmd_name});
+            std.log.err("unknown command: '{s}'", .{cmd_name});
             try self.printHelp(stdout, null);
             std.process.exit(1);
         }
@@ -169,15 +169,6 @@ pub const Cli = struct {
     }
 
     fn printGeneralHelp(self: Cli, stdout: *Io.Writer) !void {
-        const level_names = comptime blk: {
-            var names: []const u8 = "";
-            const fields = std.meta.fields(std.log.Level);
-            for (fields, 0..) |field, i| {
-                names = names ++ field.name;
-                if (i < fields.len - 1) names = names ++ ", ";
-            }
-            break :blk names;
-        };
         try stdout.print(
             \\Usage: zignal [options] <command> [command-options]
             \\
@@ -186,7 +177,7 @@ pub const Cli = struct {
             \\
             \\Commands:
             \\
-        , .{level_names});
+        , .{cli_args.log_level_names});
 
         var max_len: usize = 0;
         for (self.commands) |cmd| {


### PR DESCRIPTION
Standardizes log messages to lowercase across all CLI modules. Introduces `common.Timer` for consistent performance measurement and `OutputTarget.resolveOutputPath` to deduplicate file path logic.