### PR TITLE
refactor: rename nearest_neighbor to nearest

### DIFF
--- a/bindings/python/src/image.zig
+++ b/bindings/python/src/image.zig
@@ -722,7 +722,7 @@ fn image_format(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) 
             .dither = .auto,
             .width = dims.width,
             .height = dims.height,
-            .interpolation = .nearest_neighbor,
+            .interpolation = .nearest,
         } };
     } else if (std.mem.eql(u8, spec_slice, "kitty"))
         .{ .kitty = .default }

--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -21,7 +21,7 @@ const Rgb = zignal.Rgb(u8);
 const InterpTag = @typeInfo(Interpolation).@"union".tag_type.?;
 fn tagToInterpolation(tag: InterpTag) Interpolation {
     return switch (tag) {
-        .nearest_neighbor => .nearest_neighbor,
+        .nearest => .nearest,
         .bilinear => .bilinear,
         .bicubic => .bicubic,
         .catmull_rom => .catmull_rom,
@@ -261,7 +261,7 @@ pub const image_rotate_doc =
     \\rotated = img.rotate(math.radians(45))
     \\
     \\# Rotate 90 degrees with nearest neighbor
-    \\rotated = img.rotate(math.radians(90), Interpolation.NEAREST_NEIGHBOR)
+    \\rotated = img.rotate(math.radians(90), Interpolation.NEAREST)
     \\
     \\# Rotate with mirror border
     \\rotated = img.rotate(math.radians(45), border=BorderMode.MIRROR)

--- a/bindings/python/src/interpolation.zig
+++ b/bindings/python/src/interpolation.zig
@@ -8,14 +8,14 @@ pub const interpolation_doc =
     \\
     \\Performance and quality comparison:
     \\
-    \\| Method            | Quality | Speed | Best Use Case       | Overshoot |
-    \\|-------------------|---------|-------|---------------------|-----------|
-    \\| NEAREST_NEIGHBOR  | ★☆☆☆☆   | ★★★★★ | Pixel art, masks    | No        |
-    \\| BILINEAR          | ★★☆☆☆   | ★★★★☆ | Real-time, preview  | No        |
-    \\| BICUBIC           | ★★★☆☆   | ★★★☆☆ | General purpose     | Yes       |
-    \\| CATMULL_ROM       | ★★★★☆   | ★★★☆☆ | Natural images      | No        |
-    \\| MITCHELL          | ★★★★☆   | ★★☆☆☆ | Balanced quality    | Yes       |
-    \\| LANCZOS           | ★★★★★   | ★☆☆☆☆ | High-quality resize | Yes       |
+    \\| Method      | Quality | Speed | Best Use Case       | Overshoot |
+    \\|-------------|---------|-------|---------------------|-----------|
+    \\| NEAREST     | ★☆☆☆☆   | ★★★★★ | Pixel art, masks    | No        |
+    \\| BILINEAR    | ★★☆☆☆   | ★★★★☆ | Real-time, preview  | No        |
+    \\| BICUBIC     | ★★★☆☆   | ★★★☆☆ | General purpose     | Yes       |
+    \\| CATMULL_ROM | ★★★★☆   | ★★★☆☆ | Natural images      | No        |
+    \\| MITCHELL    | ★★★★☆   | ★★☆☆☆ | Balanced quality    | Yes       |
+    \\| LANCZOS     | ★★★★★   | ★☆☆☆☆ | High-quality resize | Yes       |
     \\
     \\Note: "Overshoot" means the filter can create values outside the input range,
     \\which can cause ringing artifacts but may also enhance sharpness.
@@ -23,7 +23,7 @@ pub const interpolation_doc =
 
 // Per-value documentation for stub generation
 pub const interpolation_values = [_]stub_metadata.EnumValueDoc{
-    .{ .name = "NEAREST_NEIGHBOR", .doc = "Fastest, pixelated, good for pixel art" },
+    .{ .name = "NEAREST", .doc = "Fastest, pixelated, good for pixel art" },
     .{ .name = "BILINEAR", .doc = "Fast, smooth, good for real-time" },
     .{ .name = "BICUBIC", .doc = "Balanced quality/speed, general purpose" },
     .{ .name = "CATMULL_ROM", .doc = "Sharp, good for natural images" },

--- a/bindings/python/tests/test_image.py
+++ b/bindings/python/tests/test_image.py
@@ -362,7 +362,7 @@ class TestImage:
         warped = img.warp(sim, shape=(20, 20))
         assert warped is not None
 
-        warped = img.warp(sim, method=zignal.Interpolation.NEAREST_NEIGHBOR)
+        warped = img.warp(sim, method=zignal.Interpolation.NEAREST)
         assert warped is not None
 
         # Works with different image types

--- a/bindings/python/tests/test_transforms.py
+++ b/bindings/python/tests/test_transforms.py
@@ -108,7 +108,7 @@ class TestTransforms:
         # Nearest neighbor and replicate border
         rotated_replicate = img.rotate(
             math.radians(45),
-            method=zignal.Interpolation.NEAREST_NEIGHBOR,
+            method=zignal.Interpolation.NEAREST,
             border=zignal.BorderMode.REPLICATE,
         )
         assert rotated_replicate is not None

--- a/examples/src/image_demo.zig
+++ b/examples/src/image_demo.zig
@@ -24,7 +24,7 @@ pub fn main(init: std.process.Init) !void {
 
     var resized: Image(Rgba) = try .init(init.gpa, image.rows / 2, image.cols / 2);
     defer resized.deinit(init.gpa);
-    image.resize(init.gpa, resized, .nearest_neighbor);
+    image.resize(init.gpa, resized, .nearest);
     try resized.save(init.io, init.gpa, "image-demo-resized-nearest.png");
     image.resize(init.gpa, resized, .bilinear);
     try resized.save(init.io, init.gpa, "image-demo-resized-bilinear.png");

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -32,7 +32,7 @@ const Args = struct {
     protocol: ?[]const u8 = null,
 
     pub const meta = .{
-        .type = .{ .help = "Blur type: box, gaussian, median, motion-linear, motion-zoom, motion-spin (default: gaussian)", .metavar = "name" },
+        .type = .{ .help = "Blur type: " ++ common.joinFieldNames(BlurType) ++ " (default: gaussian)", .metavar = "name" },
         .output = .{ .help = "Output file or directory path", .metavar = "path" },
         .display = .{ .help = "Display the result in the terminal (default if no output)" },
         .radius = .{ .help = "Radius for box/median blur (default: 1)", .metavar = "int" },
@@ -74,18 +74,9 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    const type_map: std.StaticStringMap(BlurType) = .initComptime(.{
-        .{ "box", .box },
-        .{ "gaussian", .gaussian },
-        .{ "median", .median },
-        .{ "motion-linear", .motion_linear },
-        .{ "motion-zoom", .motion_zoom },
-        .{ "motion-spin", .motion_spin },
-    });
-
     var blur_type: BlurType = .gaussian;
     if (parsed.options.type) |t| {
-        blur_type = type_map.get(t) orelse {
+        blur_type = common.parseEnum(BlurType, t) orelse {
             std.log.err("unknown blur type: {s}", .{t});
             return error.InvalidArguments;
         };

--- a/src/cli/common.zig
+++ b/src/cli/common.zig
@@ -78,31 +78,51 @@ pub fn resolveFilter(name: ?[]const u8) !zignal.Interpolation {
         return .bilinear;
     };
     std.log.debug("resolving filter: {s}", .{n});
-    const filter_map = std.StaticStringMap(zignal.Interpolation).initComptime(.{
-        .{ "nearest", .nearest_neighbor },
-        .{ "bilinear", .bilinear },
-        .{ "bicubic", .bicubic },
-        .{ "lanczos", .lanczos },
-        .{ "catmull-rom", .catmull_rom },
-        .{ "mitchell", zignal.Interpolation{ .mitchell = .default } },
-    });
-    return filter_map.get(n) orelse {
+
+    const Tag = @typeInfo(zignal.Interpolation).@"union".tag_type.?;
+    const tag = parseEnum(Tag, n) orelse {
         std.log.err("unknown filter type: {s}", .{n});
         return error.InvalidArguments;
     };
+    return switch (tag) {
+        // The only variant with a payload — every other variant is bare.
+        .mitchell => .{ .mitchell = .default },
+        inline else => |t| @unionInit(zignal.Interpolation, @tagName(t), {}),
+    };
 }
 
-/// Returns a comma-separated string of `T`'s field names, evaluated at comptime.
-/// Useful for help text and error messages derived from an enum or tagged union
-/// so the rendered list cannot drift from the type definition.
+/// Replace `-` with `_`. Used at parse time to normalize kebab-case CLI flag
+/// values into the snake-case form expected by `std.meta.stringToEnum`. The
+/// transform is idempotent on inputs without hyphens.
+pub fn toSnake(name: []const u8, buf: []u8) []const u8 {
+    std.debug.assert(buf.len >= name.len);
+    for (name, 0..) |c, i| buf[i] = if (c == '-') '_' else c;
+    return buf[0..name.len];
+}
+
+/// Looks up `T` from a CLI flag value, accepting either kebab- or snake-case.
+/// Returns null for unknown values or inputs longer than the internal buffer
+/// (64 bytes — far larger than any sensible CLI value).
+pub fn parseEnum(comptime T: type, name: []const u8) ?T {
+    var buf: [64]u8 = undefined;
+    if (name.len > buf.len) return null;
+    return std.meta.stringToEnum(T, toSnake(name, &buf));
+}
+
+/// Returns a comma-separated, kebab-cased string of `T`'s field names,
+/// evaluated at comptime. Use to derive CLI help lists from an enum or
+/// tagged union so help text cannot drift from the type. Tags without
+/// underscores pass through unchanged.
 pub fn joinFieldNames(comptime T: type) []const u8 {
     const fields = std.meta.fields(T);
-    var names: []const u8 = "";
-    for (fields, 0..) |field, i| {
-        names = names ++ field.name;
-        if (i < fields.len - 1) names = names ++ ", ";
+    var result: []const u8 = "";
+    inline for (fields, 0..) |field, i| {
+        inline for (field.name) |c| {
+            result = result ++ &[_]u8{if (c == '_') '-' else c};
+        }
+        if (i < fields.len - 1) result = result ++ ", ";
     }
-    return names;
+    return result;
 }
 
 /// Measures wall-clock elapsed time and logs it at debug level.

--- a/src/cli/edges.zig
+++ b/src/cli/edges.zig
@@ -26,7 +26,7 @@ const Args = struct {
     protocol: ?[]const u8 = null,
 
     pub const meta = .{
-        .filter = .{ .help = "Filter: sobel, canny, shen-castan (default: sobel)", .metavar = "name" },
+        .filter = .{ .help = "Filter: " ++ common.joinFieldNames(Algo) ++ " (default: sobel)", .metavar = "name" },
         .output = .{ .help = "Output file path (default: display only)", .metavar = "path" },
         .display = .{ .help = "Display the result in the terminal (default if no output)" },
         .sigma = .{ .help = "Canny sigma (def: 1.0) or Shen-Castan smoothing (def: 0.9)", .metavar = "float" },
@@ -63,16 +63,10 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    const algo_map = std.StaticStringMap(Algo).initComptime(.{
-        .{ "sobel", .sobel },
-        .{ "canny", .canny },
-        .{ "shen-castan", .shen_castan },
-    });
-
     var algo: Algo = .sobel;
     if (parsed.options.filter) |f| {
-        algo = algo_map.get(f) orelse {
-            std.log.err("unknown filter: {s}. supported: sobel, canny, shen-castan", .{f});
+        algo = common.parseEnum(Algo, f) orelse {
+            std.log.err("unknown filter: {s}", .{f});
             return error.InvalidArguments;
         };
     }
@@ -133,7 +127,7 @@ fn processImage(
                 .low_rel = options.low orelse 0.5,
                 .use_nms = options.nms,
             };
-            std.log.debug("shen-castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
+            std.log.debug("shen_castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
                 opts.smooth, opts.window_size, opts.high_ratio, opts.low_rel, opts.use_nms,
             });
             try img.shenCastan(gpa, opts, out_img);

--- a/src/cli/resize.zig
+++ b/src/cli/resize.zig
@@ -18,7 +18,7 @@ const Args = struct {
         .scale = .{ .help = "Scale factor (e.g. 0.5 for 50%, 2.0 for 200%)", .metavar = "float" },
         .width = .{ .help = "Target width in pixels", .metavar = "pixels" },
         .height = .{ .help = "Target height in pixels", .metavar = "pixels" },
-        .filter = .{ .help = "Interpolation filter (nearest, bilinear, bicubic, catmull-rom, mitchell, lanczos)", .metavar = "name" },
+        .filter = .{ .help = "Interpolation filter (" ++ common.joinFieldNames(zignal.Interpolation) ++ ")", .metavar = "name" },
         .output = .{ .help = "Output file or directory path (mandatory)", .metavar = "path" },
     };
 };

--- a/src/cli/tile.zig
+++ b/src/cli/tile.zig
@@ -27,7 +27,7 @@ const Args = struct {
     protocol: ?[]const u8 = null,
 
     pub const meta = .{
-        .mode = .{ .help = "Layout mode: square, horizontal, vertical, grid, factors", .metavar = "mode" },
+        .mode = .{ .help = "Layout mode: " ++ common.joinFieldNames(LayoutMode), .metavar = "mode" },
         .rows = .{ .help = "Number of rows (for grid mode)", .metavar = "N" },
         .cols = .{ .help = "Number of columns (for grid mode)", .metavar = "N" },
         .width = .{ .help = "Force cell width (default: first image width)", .metavar = "N" },
@@ -63,19 +63,10 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 
     var mode: LayoutMode = .square;
     if (parsed.options.mode) |m| {
-        const mode_map: std.StaticStringMap(LayoutMode) = .initComptime(.{
-            .{ "square", .square },
-            .{ "horizontal", .horizontal },
-            .{ "vertical", .vertical },
-            .{ "grid", .grid },
-            .{ "factors", .factors },
-        });
-        if (mode_map.get(m)) |val| {
-            mode = val;
-        } else {
+        mode = common.parseEnum(LayoutMode, m) orelse {
             std.log.err("unknown layout mode: {s}", .{m});
             return error.InvalidArguments;
-        }
+        };
     }
 
     var rows: u32 = 0;

--- a/src/image/display.zig
+++ b/src/image/display.zig
@@ -123,7 +123,7 @@ pub fn DisplayFormatter(comptime T: type) type {
                             .dither = .auto,
                             .width = options.width,
                             .height = options.height,
-                            .interpolation = options.interpolation orelse .nearest_neighbor,
+                            .interpolation = options.interpolation orelse .nearest,
                         } };
                     } else {
                         continue :fmt .{ .sgr = .{

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -51,7 +51,7 @@ const resolveIndex = @import("border.zig").resolveIndex;
 /// | Mitchell    | ★★★★☆   | ★★☆☆☆ | Balanced quality    | Yes       |
 /// | Lanczos3    | ★★★★★   | ★☆☆☆☆ | High-quality resize | Yes       |
 pub const Interpolation = union(enum) {
-    nearest_neighbor,
+    nearest,
     bilinear,
     bicubic,
     catmull_rom,
@@ -83,7 +83,7 @@ pub fn interpolate(comptime T: type, self: Image(T), x: f32, y: f32, method: Int
     const range_limit = @as(f32, @floatFromInt(std.math.maxInt(isize) / 2));
     if (@abs(x) > range_limit or @abs(y) > range_limit) return null;
     return switch (method) {
-        .nearest_neighbor => interpolateNearestNeighbor(T, self, x, y, border),
+        .nearest => interpolateNearest(T, self, x, y, border),
         .bilinear => interpolateBilinear(T, self, x, y, border),
         .bicubic => interpolateBicubic(T, self, x, y, border),
         .catmull_rom => interpolateCatmullRom(T, self, x, y, border),
@@ -130,7 +130,7 @@ pub fn resize(comptime T: type, allocator: Allocator, self: Image(T), out: Image
     if (comptime meta.isRgb(T)) {
         // Only use optimized path if the method has an implementation in channel_ops
         const has_optimized_plane_op = switch (method) {
-            .nearest_neighbor, .bilinear, .bicubic, .catmull_rom, .mitchell, .lanczos => true,
+            .nearest, .bilinear, .bicubic, .catmull_rom, .mitchell, .lanczos => true,
         };
 
         if (has_optimized_plane_op) {
@@ -167,7 +167,7 @@ pub fn resize(comptime T: type, allocator: Allocator, self: Image(T), out: Image
 
             // Resize each channel using optimized plane functions
             switch (method) {
-                .nearest_neighbor => {
+                .nearest => {
                     inline for (channels, out_channels) |src_ch, dst_ch| {
                         channel_ops.resizePlaneNearestU8(src_ch, dst_ch, self.rows, self.cols, out.rows, out.cols);
                     }
@@ -322,7 +322,7 @@ fn mitchellKernel(x: f32, m_b: f32, m_c: f32) f32 {
 // Generic Interpolation Functions
 // ============================================================================
 
-fn interpolateNearestNeighbor(comptime T: type, self: Image(T), x: f32, y: f32, border: BorderMode) ?T {
+fn interpolateNearest(comptime T: type, self: Image(T), x: f32, y: f32, border: BorderMode) ?T {
     const col = resolveIndex(@round(x), @intCast(self.cols), border) orelse return null;
     const row = resolveIndex(@round(y), @intCast(self.rows), border) orelse return null;
 

--- a/src/image/tests/interpolation.zig
+++ b/src/image/tests/interpolation.zig
@@ -39,13 +39,13 @@ test "nearest neighbor interpolation - exact pixels" {
     defer img.deinit(allocator);
 
     // Test exact pixel positions - should return exact values
-    const val1 = img.interpolate(0, 0, .nearest_neighbor, .mirror);
+    const val1 = img.interpolate(0, 0, .nearest, .mirror);
     try expectEqual(img.at(0, 0).*, val1.?);
 
-    const val2 = img.interpolate(5, 5, .nearest_neighbor, .mirror);
+    const val2 = img.interpolate(5, 5, .nearest, .mirror);
     try expectEqual(img.at(5, 5).*, val2.?);
 
-    const val3 = img.interpolate(9, 9, .nearest_neighbor, .mirror);
+    const val3 = img.interpolate(9, 9, .nearest, .mirror);
     try expectEqual(img.at(9, 9).*, val3.?);
 }
 
@@ -56,16 +56,16 @@ test "nearest neighbor interpolation - rounding" {
 
     // Test rounding behavior
     // At (0.4, 0.4) should round to (0, 0)
-    const val1 = img.interpolate(0.4, 0.4, .nearest_neighbor, .mirror);
+    const val1 = img.interpolate(0.4, 0.4, .nearest, .mirror);
     try expectEqual(@as(u8, 0), val1.?);
 
     // At (0.6, 0.6) should round to (1, 1)
     // Checkerboard: (1, 1) has value 0 because (1+1)%2 == 0
-    const val2 = img.interpolate(0.6, 0.6, .nearest_neighbor, .mirror);
+    const val2 = img.interpolate(0.6, 0.6, .nearest, .mirror);
     try expectEqual(@as(u8, 0), val2.?);
 
     // At (1.5, 0.5) should round to (2, 1)
-    const val3 = img.interpolate(1.5, 0.5, .nearest_neighbor, .mirror);
+    const val3 = img.interpolate(1.5, 0.5, .nearest, .mirror);
     try expectEqual(@as(u8, 255), val3.?);
 }
 
@@ -185,14 +185,14 @@ test "boundary conditions - nearest neighbor" {
     defer img.deinit(allocator);
 
     // Nearest neighbor should work at all boundaries due to mirror reflection
-    try std.testing.expect(img.interpolate(-0.4, 0, .nearest_neighbor, .mirror) != null); // Rounds to (0, 0)
-    try std.testing.expect(img.interpolate(9.4, 9.4, .nearest_neighbor, .mirror) != null); // Rounds to (9, 9)
+    try std.testing.expect(img.interpolate(-0.4, 0, .nearest, .mirror) != null); // Rounds to (0, 0)
+    try std.testing.expect(img.interpolate(9.4, 9.4, .nearest, .mirror) != null); // Rounds to (9, 9)
 
     // Out of bounds - should reflect back into range
-    try std.testing.expect(img.interpolate(-1, 0, .nearest_neighbor, .mirror) != null);
-    try std.testing.expect(img.interpolate(0, -1, .nearest_neighbor, .mirror) != null);
-    try std.testing.expect(img.interpolate(10, 0, .nearest_neighbor, .mirror) != null);
-    try std.testing.expect(img.interpolate(0, 10, .nearest_neighbor, .mirror) != null);
+    try std.testing.expect(img.interpolate(-1, 0, .nearest, .mirror) != null);
+    try std.testing.expect(img.interpolate(0, -1, .nearest, .mirror) != null);
+    try std.testing.expect(img.interpolate(10, 0, .nearest, .mirror) != null);
+    try std.testing.expect(img.interpolate(0, 10, .nearest, .mirror) != null);
 }
 
 test "boundary conditions - bilinear" {
@@ -251,7 +251,7 @@ test "RGB image interpolation" {
 
     // Test nearest neighbor with RGB
     // (1.6, 1.4) rounds to (2, 1)
-    const val_nn = img.interpolate(1.6, 1.4, .nearest_neighbor, .mirror);
+    const val_nn = img.interpolate(1.6, 1.4, .nearest, .mirror);
     try expectEqualDeep(img.at(1, 2).*, val_nn.?);
 
     // Test bilinear with RGB
@@ -459,8 +459,8 @@ test "nearest neighbor discontinuity" {
     img.at(1, 1).* = 200;
 
     // Test discontinuity at boundary
-    const val_before = img.interpolate(0.49, 0, .nearest_neighbor, .mirror);
-    const val_after = img.interpolate(0.51, 0, .nearest_neighbor, .mirror);
+    const val_before = img.interpolate(0.49, 0, .nearest, .mirror);
+    const val_after = img.interpolate(0.51, 0, .nearest, .mirror);
 
     try expectEqual(@as(u8, 0), val_before.?); // rounds to (0, 0)
     try expectEqual(@as(u8, 255), val_after.?); // rounds to (1, 0)
@@ -561,7 +561,7 @@ test "extreme value edge cases" {
 
     // Test all methods handle extreme values correctly
     const methods = [_]Interpolation{
-        .nearest_neighbor,
+        .nearest,
         .bilinear,
         .bicubic,
         .catmull_rom,
@@ -577,7 +577,7 @@ test "extreme value edge cases" {
             if (val) |v| {
                 try expectApproxEqAbs(@as(f32, 0), @as(f32, @floatFromInt(v)), 1.0);
             }
-        } else if (method == .nearest_neighbor or method == .bilinear) {
+        } else if (method == .nearest or method == .bilinear) {
             const val = img.interpolate(0, 0, method, .mirror);
             try expectEqual(@as(u8, 0), val.?);
         }
@@ -592,7 +592,7 @@ test "single pixel image handling" {
     img.at(0, 0).* = 42;
 
     // All methods should work with 1x1 image due to mirror reflection
-    try expectEqual(@as(u8, 42), img.interpolate(0, 0, .nearest_neighbor, .mirror).?);
+    try expectEqual(@as(u8, 42), img.interpolate(0, 0, .nearest, .mirror).?);
     try expectEqual(@as(u8, 42), img.interpolate(0, 0, .bilinear, .mirror).?);
     try expectEqual(@as(u8, 42), img.interpolate(0, 0, .bicubic, .mirror).?);
     try expectEqual(@as(u8, 42), img.interpolate(0, 0, .catmull_rom, .mirror).?);

--- a/src/image/tests/resize.zig
+++ b/src/image/tests/resize.zig
@@ -71,7 +71,7 @@ test "letterbox maintains aspect ratio with padding" {
         var output: Image(Rgb) = try .init(allocator, 4, 12);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(allocator, output, .nearest_neighbor);
+        const rect = src.letterbox(allocator, output, .nearest);
 
         try expectEqual(@as(usize, 1), rect.width());
         try expectEqual(@as(usize, 4), rect.height());
@@ -102,12 +102,12 @@ test "letterbox edge cases" {
         defer src.deinit(allocator);
 
         const output: Image(u8) = .initFromSlice(0, 10, &[_]u8{});
-        const rect1 = src.letterbox(allocator, output, .nearest_neighbor);
+        const rect1 = src.letterbox(allocator, output, .nearest);
         try expectEqual(@as(usize, 0), rect1.width());
         try expectEqual(@as(usize, 0), rect1.height());
 
         const output2: Image(u8) = .initFromSlice(10, 0, &[_]u8{});
-        const rect2 = src.letterbox(allocator, output2, .nearest_neighbor);
+        const rect2 = src.letterbox(allocator, output2, .nearest);
         try expectEqual(@as(usize, 0), rect2.width());
         try expectEqual(@as(usize, 0), rect2.height());
     }
@@ -146,7 +146,7 @@ test "letterbox edge cases" {
         var output: Image(u8) = try .init(allocator, 10, 10);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(allocator, output, .nearest_neighbor);
+        const rect = src.letterbox(allocator, output, .nearest);
 
         // 1x1 scaled to fit 10x10 = 10x10
         try expectEqual(@as(usize, 10), rect.width());
@@ -181,7 +181,7 @@ test "letterbox interpolation methods comparison" {
 
     // Test different interpolation methods
     const methods = [_]@import("../interpolation.zig").Interpolation{
-        .nearest_neighbor,
+        .nearest,
         .bilinear,
         .bicubic,
         .lanczos,
@@ -282,7 +282,7 @@ test "scale image" {
     try expectEqual(@as(usize, 200), double.cols);
 
     // Test non-uniform scaling factors
-    var custom = try img.scale(allocator, 1.5, .nearest_neighbor);
+    var custom = try img.scale(allocator, 1.5, .nearest);
     defer custom.deinit(allocator);
     try expectEqual(@as(usize, 150), custom.rows);
     try expectEqual(@as(usize, 150), custom.cols);

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -248,7 +248,7 @@ test "extract rotated rectangle basic and 90deg" {
     defer out0.deinit(allocator);
 
     // Angle 0: should match the submatrix directly
-    image.extract(rect, 0.0, out0, .nearest_neighbor, .mirror);
+    image.extract(rect, 0.0, out0, .nearest, .mirror);
 
     try expectEqual(@as(u8, 11), out0.at(0, 0).*);
     try expectEqual(@as(u8, 12), out0.at(0, 1).*);
@@ -264,7 +264,7 @@ test "extract rotated rectangle basic and 90deg" {
     var out90: Image(u8) = try .init(allocator, 3, 3);
     defer out90.deinit(allocator);
 
-    image.extract(rect, std.math.pi / 2.0, out90, .nearest_neighbor, .mirror);
+    image.extract(rect, std.math.pi / 2.0, out90, .nearest, .mirror);
 
     try expectEqual(@as(u8, 13), out90.at(0, 0).*);
     try expectEqual(@as(u8, 23), out90.at(0, 1).*);
@@ -294,13 +294,13 @@ test "extract single-pixel axis handling centers correctly" {
     // 1x1 output should sample rectangle center -> source (2,2) => 22
     var out1: Image(u8) = try .init(allocator, 1, 1);
     defer out1.deinit(allocator);
-    image.extract(rect, 0.0, out1, .nearest_neighbor, .mirror);
+    image.extract(rect, 0.0, out1, .nearest, .mirror);
     try expectEqual(@as(u8, 22), out1.at(0, 0).*);
 
     // 1x3: rows==1 should sample center row (y=2), cols span left-to-right
     var out_row1: Image(u8) = try .init(allocator, 1, 3);
     defer out_row1.deinit(allocator);
-    image.extract(rect, 0.0, out_row1, .nearest_neighbor, .mirror);
+    image.extract(rect, 0.0, out_row1, .nearest, .mirror);
     try expectEqual(@as(u8, 21), out_row1.at(0, 0).*);
     try expectEqual(@as(u8, 22), out_row1.at(0, 1).*);
     try expectEqual(@as(u8, 23), out_row1.at(0, 2).*);
@@ -308,7 +308,7 @@ test "extract single-pixel axis handling centers correctly" {
     // 3x1: cols==1 should sample center col (x=2), rows span top-to-bottom
     var out_col1: Image(u8) = try .init(allocator, 3, 1);
     defer out_col1.deinit(allocator);
-    image.extract(rect, 0.0, out_col1, .nearest_neighbor, .mirror);
+    image.extract(rect, 0.0, out_col1, .nearest, .mirror);
     try expectEqual(@as(u8, 12), out_col1.at(0, 0).*);
     try expectEqual(@as(u8, 22), out_col1.at(1, 0).*);
     try expectEqual(@as(u8, 32), out_col1.at(2, 0).*);
@@ -374,7 +374,7 @@ test "insert and extract inverse relationship" {
         }
 
         const avg_error = @as(f32, @floatFromInt(total_error)) / @as(f32, @floatFromInt(pixel_count));
-        const tolerance: f32 = if (tc.method == .nearest_neighbor) 10 else 25;
+        const tolerance: f32 = if (tc.method == .nearest) 10 else 25;
         try std.testing.expect(avg_error < tolerance);
     }
 }
@@ -395,13 +395,13 @@ test "insert applies blending when requested" {
     const rect = Rectangle(f32).init(0, 0, 1, 1);
 
     // Without a blend mode the pixel should be copied directly.
-    dest.insert(source, rect, 0.0, Interpolation.nearest_neighbor, color.Blending.none);
+    dest.insert(source, rect, 0.0, Interpolation.nearest, color.Blending.none);
     try expectEqualDeep(overlay, dest.at(0, 0).*);
 
     // Reset destination pixel and apply blending.
     dest.at(0, 0).* = base;
     const expected = base.blend(overlay, color.Blending.normal);
-    dest.insert(source, rect, 0.0, Interpolation.nearest_neighbor, color.Blending.normal);
+    dest.insert(source, rect, 0.0, Interpolation.nearest, color.Blending.normal);
     try expectEqualDeep(expected, dest.at(0, 0).*);
 }
 
@@ -416,11 +416,11 @@ test "extract from empty image regression" {
     const rect = Rectangle(f32).init(0, 0, 2, 2);
 
     // Should not panic with REPLICATE
-    empty.extract(rect, 0.0, out, .nearest_neighbor, .replicate);
+    empty.extract(rect, 0.0, out, .nearest, .replicate);
     try expectEqual(@as(u8, 0), out.at(0, 0).*);
 
     // Should not panic with WRAP
-    empty.extract(rect, 0.0, out, .nearest_neighbor, .wrap);
+    empty.extract(rect, 0.0, out, .nearest, .wrap);
     try expectEqual(@as(u8, 0), out.at(0, 0).*);
 }
 

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -63,7 +63,7 @@ pub const Options = struct {
     /// If null, original height is preserved
     height: ?u32,
     /// Interpolation method to use when scaling the image
-    interpolation: Interpolation = .nearest_neighbor,
+    interpolation: Interpolation = .nearest,
 
     /// Default options for automatic formatting
     pub const default: Options = .{
@@ -71,7 +71,7 @@ pub const Options = struct {
         .dither = .auto,
         .width = null,
         .height = null,
-        .interpolation = .nearest_neighbor,
+        .interpolation = .nearest,
     };
     /// Fallback options without dithering
     pub const fallback: Options = .{
@@ -79,7 +79,7 @@ pub const Options = struct {
         .dither = .none,
         .width = null,
         .height = null,
-        .interpolation = .nearest_neighbor,
+        .interpolation = .nearest,
     };
 };
 


### PR DESCRIPTION
Renames the interpolation variant for brevity across the library and Python bindings. Refactors CLI argument parsing to use generic enum utilities that support kebab-case normalization.