### PR TITLE
refactor(matrix): simplify SVD options by removing redundant with_u

### DIFF
--- a/bindings/python/src/matrix.zig
+++ b/bindings/python/src/matrix.zig
@@ -1859,9 +1859,8 @@ fn matrix_svd_method(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     const compute_uv_bool = params.compute_uv != 0;
 
     const svd_options: Matrix(f64).SvdOptions = .{
-        .with_u = compute_uv_bool,
         .with_v = compute_uv_bool,
-        .mode = if (full_matrices_bool) .full_u else .skinny_u,
+        .mode = if (!compute_uv_bool) .no_u else if (full_matrices_bool) .full_u else .skinny_u,
     };
 
     var svd_result = ptr.svd(allocator, svd_options) catch {

--- a/src/fdm.zig
+++ b/src/fdm.zig
@@ -106,7 +106,6 @@ pub fn FeatureDistributionMatching(comptime T: type) type {
 
                 const cov_static = cov_matrix.toSMatrix(3, 3);
                 const target_svd = cov_static.svd(.{
-                    .with_u = true,
                     .with_v = false,
                     .mode = .skinny_u,
                 });
@@ -206,7 +205,7 @@ pub fn FeatureDistributionMatching(comptime T: type) type {
                 // W = U_s * diag(sqrt(lambda_t / lambda_s)) * U_t^T
 
                 const source_cov_static = source_cov_mat.toSMatrix(3, 3);
-                const source_svd = source_cov_static.svd(.{ .with_u = true, .with_v = false, .mode = .skinny_u });
+                const source_svd = source_cov_static.svd(.{ .with_v = false, .mode = .skinny_u });
 
                 if (source_svd.converged != 0) {
                     return error.NotConverged;

--- a/src/geometry/transforms.zig
+++ b/src/geometry/transforms.zig
@@ -76,7 +76,7 @@ pub fn SimilarityTransform(comptime T: type) type {
             sigma_to /= num_points;
             cov = cov.scale(1.0 / num_points);
             const det_cov = cov.at(0, 0).* * cov.at(1, 1).* - cov.at(0, 1).* * cov.at(1, 0).*;
-            const result = cov.svd(.{ .with_u = true, .with_v = true, .mode = .skinny_u });
+            const result = cov.svd(.{ .with_v = true, .mode = .skinny_u });
             if (result.converged != 0) {
                 return error.NotConverged;
             }
@@ -260,7 +260,7 @@ pub fn ProjectiveTransform(comptime T: type) type {
                 b.setSubMatrix(1, 6, f.scale(-t.at(0, 0).*));
                 accum = accum.add(b.transpose().dot(b));
             }
-            const result = accum.svd(.{ .with_u = true, .with_v = false, .mode = .full_u });
+            const result = accum.svd(.{ .with_v = false, .mode = .full_u });
             if (result.converged != 0) {
                 return error.NotConverged;
             }

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -345,7 +345,7 @@ pub fn Matrix(comptime T: type) type {
             std.debug.assert(self.rows >= self.cols);
 
             const allocator = self.allocator;
-            const svd_options = SvdOptions{ .with_u = true, .with_v = true, .mode = .skinny_u };
+            const svd_options = SvdOptions{ .with_v = true, .mode = .skinny_u };
 
             var svd_result = try self.svd(allocator, svd_options);
             defer svd_result.deinit();
@@ -962,7 +962,7 @@ pub fn Matrix(comptime T: type) type {
                 return transposed.leadingSingularValue(allocator);
             }
 
-            var svd_result = try self.svd(allocator, .{ .with_u = false, .with_v = false, .mode = .skinny_u });
+            var svd_result = try self.svd(allocator, .{ .with_v = false, .mode = .no_u });
             defer svd_result.deinit();
             if (svd_result.converged != 0) {
                 return error.NotConverged;
@@ -976,7 +976,7 @@ pub fn Matrix(comptime T: type) type {
             if (self.rows == 0 or self.cols == 0) return 0;
 
             if (self.rows >= self.cols) {
-                var svd_result = try self.svd(allocator, .{ .with_u = false, .with_v = false, .mode = .skinny_u });
+                var svd_result = try self.svd(allocator, .{ .with_v = false, .mode = .no_u });
                 defer svd_result.deinit();
                 if (svd_result.converged != 0) {
                     return error.NotConverged;

--- a/src/matrix/SMatrix.zig
+++ b/src/matrix/SMatrix.zig
@@ -211,7 +211,7 @@ pub fn SMatrix(comptime T: type, comptime rows: u32, comptime cols: u32) type {
                 return transposed.leadingSingularValue();
             }
 
-            const svd_result = self.svd(.{ .mode = .skinny_u, .with_u = false, .with_v = false });
+            const svd_result = self.svd(.{ .mode = .no_u, .with_v = false });
             return svd_result.s.items[0][0];
         }
 
@@ -224,7 +224,7 @@ pub fn SMatrix(comptime T: type, comptime rows: u32, comptime cols: u32) type {
                 return transposed.sumSingularP(exponent);
             }
 
-            const svd_result = self.svd(.{ .mode = .skinny_u, .with_u = false, .with_v = false });
+            const svd_result = self.svd(.{ .mode = .no_u, .with_v = false });
             var accum: T = 0;
             for (0..svd_result.s.rows) |i| {
                 accum += std.math.pow(T, svd_result.s.items[i][0], exponent);

--- a/src/matrix/svd.zig
+++ b/src/matrix/svd.zig
@@ -29,14 +29,9 @@ const State = enum {
 /// Configuration options for SVD computation.
 /// Allows fine-grained control over which matrices are computed.
 pub const Options = struct {
-    /// Whether to compute the left singular vectors (U matrix).
-    /// Set to false when only singular values are needed.
-    with_u: bool = true,
     /// Whether to compute the right singular vectors (V matrix).
-    /// Set to false when only U and singular values are needed.
     with_v: bool = false,
-    /// Controls the size of the U matrix when with_u is true.
-    /// Ignored when with_u is false.
+    /// Controls computation and size of the U matrix.
     mode: Mode = .full_u,
 };
 
@@ -72,25 +67,13 @@ pub fn Result(comptime T: type) type {
     };
 }
 
-/// Performs singular value decomposition. Code adapted from dlib's svd4, which is, in turn,
-/// translated to 'C' from the original Algol code in "Hanbook for Automatic Computation, vol. II,
-/// Linear Algebra", Springer-Verlag.  Note that this published algorithm is considered to be
-/// the best and numerically stable approach to computing the real-valued svd and is referenced
-/// repeatedly in ieee journal papers, etc where the svd is used.
+/// Singular value decomposition of `a` (m×n with m ≥ n) into U, Σ, V^T.
 ///
-/// This is almost an exact translation from the original, except that an iteration counter
-/// is added to prevent stalls.  This corresponds to similar changes in other translations.
-/// Returns an error code = 0, if no errors and 'k' if a failure to converge at the 'kth'
-/// singular value.
+/// Adapted from dlib's svd4, which translated the original Algol from
+/// "Handbook for Automatic Computation, vol. II, Linear Algebra" (Springer-Verlag) into C.
+/// An iteration counter is added to prevent stalls.
 ///
-/// USAGE: given the singular value decomposition a = u * diagm(q) * trans(v) for an m*n
-/// matrix a with m >= n.  After the svd call, u is an m x m matrix which is columnwise
-/// orthogonal. q will be an n element vector consisting of singular values and v an n x n
-/// orthogonal matrix. eps and tol are tolerance constants.  Suitable values are eps=1e-16
-/// and tol=(1e-300)/eps if T == double.
-///
-/// If options.mode == .no_u, then u won't be computed and similarly if options.with_v == false
-/// then v won't be computed.  If options.mode == .skinny_u then u will be m x n instead of m x m.
+/// Sets `converged = 0` on success, or `k` if the algorithm fails to converge at the k-th singular value.
 pub fn svd(
     comptime T: type,
     allocator: std.mem.Allocator,
@@ -98,26 +81,29 @@ pub fn svd(
     options: Options,
 ) !Result(T) {
     std.debug.assert(a.rows >= a.cols);
+    const max_iterations: usize = 300;
     var eps: T = std.math.floatEps(T);
     const tol: T = std.math.floatMin(T) / eps;
     const m = a.rows;
     const n = a.cols;
 
-    // Allocate matrices based on options
     var u = if (options.mode == .full_u)
         try Matrix(T).initAll(allocator, m, m, 0)
     else
         try Matrix(T).initAll(allocator, m, n, 0);
     errdefer u.deinit();
 
-    var v = try Matrix(T).initAll(allocator, n, n, 0);
+    var v = if (options.with_v)
+        try Matrix(T).initAll(allocator, n, n, 0)
+    else
+        try Matrix(T).init(allocator, 0, 0);
     errdefer v.deinit();
 
     var q = try Matrix(T).initAll(allocator, n, 1, 0);
     errdefer q.deinit();
 
     var e = try Matrix(T).initAll(allocator, n, 1, 0);
-    defer e.deinit(); // e is only used internally
+    defer e.deinit();
 
     var l: usize = 0;
     var retval: usize = 0;
@@ -200,9 +186,7 @@ pub fn svd(
             }
         }
         y = @abs(q.at(i, 0).*) + @abs(e.at(i, 0).*);
-        if (y > x) {
-            x = y;
-        }
+        x = @max(x, y);
     }
 
     // Accumulation of right-hand transformations.
@@ -336,7 +320,7 @@ pub fn svd(
                 }
                 // Shift from bottom 2x2 minor.
                 iter += 1;
-                if (iter > 300) {
+                if (iter > max_iterations) {
                     retval = k;
                     break :state;
                 }
@@ -397,7 +381,6 @@ pub fn svd(
 
             .convergence_check => {
                 if (z < 0) {
-                    // q.at(k, 0) made non-negative
                     q.at(k, 0).* = -z;
                     if (options.with_v) {
                         for (0..n) |j| {
@@ -409,13 +392,10 @@ pub fn svd(
             },
         }
     }
-    // Sort singular values in descending order
-    // This requires swapping columns of U and V accordingly
+    // Sort singular values in descending order.
     for (0..n) |i| {
         var max_idx = i;
         var max_val = q.at(i, 0).*;
-
-        // Find the maximum singular value from i to n
         for (i + 1..n) |j| {
             if (q.at(j, 0).* > max_val) {
                 max_idx = j;
@@ -423,28 +403,16 @@ pub fn svd(
             }
         }
 
-        // Swap if needed
         if (max_idx != i) {
-            // Swap singular values
-            const temp_s = q.at(i, 0).*;
-            q.at(i, 0).* = q.at(max_idx, 0).*;
-            q.at(max_idx, 0).* = temp_s;
-
-            // Swap columns of U
+            std.mem.swap(T, q.at(i, 0), q.at(max_idx, 0));
             if (options.mode != .no_u) {
                 for (0..m) |row| {
-                    const temp_u = u.at(row, i).*;
-                    u.at(row, i).* = u.at(row, max_idx).*;
-                    u.at(row, max_idx).* = temp_u;
+                    std.mem.swap(T, u.at(row, i), u.at(row, max_idx));
                 }
             }
-
-            // Swap columns of V
             if (options.with_v) {
                 for (0..n) |row| {
-                    const temp_v = v.at(row, i).*;
-                    v.at(row, i).* = v.at(row, max_idx).*;
-                    v.at(row, max_idx).* = temp_v;
+                    std.mem.swap(T, v.at(row, i), v.at(row, max_idx));
                 }
             }
         }
@@ -475,7 +443,7 @@ test "svd basic" {
         }
     }
 
-    var res = try a.svd(allocator, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var res = try a.svd(allocator, .{ .with_v = true, .mode = .full_u });
     defer res.deinit();
     const u = &res.u;
     const s = &res.s;
@@ -516,18 +484,18 @@ test "svd modes" {
     });
 
     // Test no_u mode
-    var res_no_u = try a.svd(allocator, .{ .with_u = false, .with_v = true, .mode = .no_u });
+    var res_no_u = try a.svd(allocator, .{ .with_v = true, .mode = .no_u });
     defer res_no_u.deinit();
     const s_no_u = &res_no_u.s;
 
     // Test skinny_u mode
-    var res_skinny = try a.svd(allocator, .{ .with_u = true, .with_v = false, .mode = .skinny_u });
+    var res_skinny = try a.svd(allocator, .{ .with_v = false, .mode = .skinny_u });
     defer res_skinny.deinit();
     const u_skinny = &res_skinny.u;
     const s_skinny = &res_skinny.s;
 
     // Test full_u mode
-    var res_full = try a.svd(allocator, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var res_full = try a.svd(allocator, .{ .with_v = true, .mode = .full_u });
     defer res_full.deinit();
     const u_full = &res_full.u;
     const s_full = &res_full.s;
@@ -552,7 +520,7 @@ test "svd identity matrix" {
     const n: usize = 3;
     var a = try Matrix(f64).identity(allocator, n, n);
 
-    var res = try a.svd(allocator, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var res = try a.svd(allocator, .{ .with_v = true, .mode = .full_u });
     defer res.deinit();
     const s = &res.s;
 
@@ -576,7 +544,7 @@ test "svd singular matrix" {
         1, 2, 3,
     });
 
-    var res = try a.svd(allocator, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var res = try a.svd(allocator, .{ .with_v = true, .mode = .full_u });
     defer res.deinit();
     const s = &res.s;
 

--- a/src/matrix/svd_static.zig
+++ b/src/matrix/svd_static.zig
@@ -29,14 +29,9 @@ const State = enum {
 /// Configuration options for SVD computation.
 /// Allows fine-grained control over which matrices are computed.
 pub const Options = struct {
-    /// Whether to compute the left singular vectors (U matrix).
-    /// Set to false when only singular values are needed.
-    with_u: bool = true,
     /// Whether to compute the right singular vectors (V matrix).
-    /// Set to false when only U and singular values are needed.
     with_v: bool = false,
-    /// Controls the size of the U matrix when with_u is true.
-    /// Ignored when with_u is false.
+    /// Controls computation and size of the U matrix.
     mode: Mode = .full_u,
 };
 
@@ -57,8 +52,8 @@ pub fn Result(
 ) type {
     return struct {
         /// Left singular vectors matrix. Each column is a left singular vector.
-        /// Dimensions: m×m (full_u) or m×n (skinny_u)
-        u: SMatrix(T, rows, if (options.mode == .skinny_u) cols else rows),
+        /// Dimensions: m×m (full_u) or m×n (skinny_u or no_u, contents undefined for no_u).
+        u: SMatrix(T, rows, if (options.mode == .full_u) rows else cols),
         /// Singular values in descending order as a column vector.
         /// These are the diagonal elements of the Σ matrix.
         s: SMatrix(T, cols, 1),
@@ -68,33 +63,16 @@ pub fn Result(
         /// Convergence status: 0 if successful, k if failed at k-th singular value.
         /// Non-zero values indicate the iterative algorithm failed to converge.
         converged: usize,
-
-        // Provide a no-op deinit for compatibility
-        pub fn deinit(self: *@This()) void {
-            _ = self;
-        }
     };
 }
 
-/// Performs singular value decomposition. Code adapted from dlib's svd4, which is, in turn,
-/// translated to 'C' from the original Algol code in "Hanbook for Automatic Computation, vol. II,
-/// Linear Algebra", Springer-Verlag.  Note that this published algorithm is considered to be
-/// the best and numerically stable approach to computing the real-valued svd and is referenced
-/// repeatedly in ieee journal papers, etc where the svd is used.
+/// Singular value decomposition of `a` (m×n with m ≥ n) into U, Σ, V^T.
 ///
-/// This is almost an exact translation from the original, except that an iteration counter
-/// is added to prevent stalls.  This corresponds to similar changes in other translations.
-/// Returns an error code = 0, if no errors and 'k' if a failure to converge at the 'kth'
-/// singular value.
+/// Adapted from dlib's svd4, which translated the original Algol from
+/// "Handbook for Automatic Computation, vol. II, Linear Algebra" (Springer-Verlag) into C.
+/// An iteration counter is added to prevent stalls.
 ///
-/// USAGE: given the singular value decomposition a = u * diagm(q) * trans(v) for an m*n
-/// matrix a with m >= n.  After the svd call, u is an m x m matrix which is columnwise
-/// orthogonal. q will be an n element vector consisting of singular values and v an n x n
-/// orthogonal matrix. eps and tol are tolerance constants.  Suitable values are eps=1e-16
-/// and tol=(1e-300)/eps if T == double.
-///
-/// If options.mode == .no_u, then u won't be computed and similarly if options.with_v == false
-/// then v won't be computed.  If options.mode == .skinny_u then u will be m x n instead of m x m.
+/// Sets `converged = 0` on success, or `k` if the algorithm fails to converge at the k-th singular value.
 pub fn svd(
     comptime T: type,
     comptime rows: usize,
@@ -103,6 +81,7 @@ pub fn svd(
     comptime options: Options,
 ) Result(T, rows, cols, options) {
     comptime std.debug.assert(rows >= cols);
+    const max_iterations: usize = 300;
     var eps: T = std.math.floatEps(T);
     const tol: T = std.math.floatMin(T) / eps;
     const m = rows;
@@ -192,9 +171,7 @@ pub fn svd(
             }
         }
         y = @abs(q.items[i][0]) + @abs(e.items[i][0]);
-        if (y > x) {
-            x = y;
-        }
+        x = @max(x, y);
     }
 
     // Accumulation of right-hand transformations.
@@ -328,7 +305,7 @@ pub fn svd(
                 }
                 // Shift from bottom 2x2 minor.
                 iter += 1;
-                if (iter > 300) {
+                if (iter > max_iterations) {
                     retval = k;
                     break :state;
                 }
@@ -389,7 +366,6 @@ pub fn svd(
 
             .convergence_check => {
                 if (z < 0) {
-                    // q.items[k][0]s made non-negative
                     q.items[k][0] = -z;
                     if (options.with_v) {
                         for (0..n) |j| {
@@ -402,13 +378,10 @@ pub fn svd(
         }
     }
 
-    // Sort singular values in descending order
-    // This requires swapping columns of U and V accordingly
+    // Sort singular values in descending order.
     for (0..n) |i| {
         var max_idx = i;
         var max_val = q.items[i][0];
-
-        // Find the maximum singular value from i to n
         for (i + 1..n) |j| {
             if (q.items[j][0] > max_val) {
                 max_idx = j;
@@ -416,28 +389,16 @@ pub fn svd(
             }
         }
 
-        // Swap if needed
         if (max_idx != i) {
-            // Swap singular values
-            const temp_s = q.items[i][0];
-            q.items[i][0] = q.items[max_idx][0];
-            q.items[max_idx][0] = temp_s;
-
-            // Swap columns of U
+            std.mem.swap(T, &q.items[i][0], &q.items[max_idx][0]);
             if (options.mode != .no_u) {
                 for (0..u.rows) |row| {
-                    const temp_u = u.items[row][i];
-                    u.items[row][i] = u.items[row][max_idx];
-                    u.items[row][max_idx] = temp_u;
+                    std.mem.swap(T, &u.items[row][i], &u.items[row][max_idx]);
                 }
             }
-
-            // Swap columns of V
             if (options.with_v) {
                 for (0..n) |row| {
-                    const temp_v = v.items[row][i];
-                    v.items[row][i] = v.items[row][max_idx];
-                    v.items[row][max_idx] = temp_v;
+                    std.mem.swap(T, &v.items[row][i], &v.items[row][max_idx]);
                 }
             }
         }
@@ -457,7 +418,7 @@ test "svd static basic" {
         .{ 0, 0, 0, 0 },
         .{ 2, 0, 0, 0 },
     });
-    const res = svd(f64, m, n, a, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    const res = svd(f64, m, n, a, .{ .with_v = true, .mode = .full_u });
     const u = &res.u;
     const s = &res.s;
     const v = &res.v;

--- a/src/matrix/test_svd_comparison.zig
+++ b/src/matrix/test_svd_comparison.zig
@@ -25,7 +25,7 @@ test "SVD comparison: basic 5x4 matrix" {
 
     // Static SVD
     const a_static: SMatrix(f64, m, n) = .init(test_matrix);
-    const static_result = svd_static(f64, m, n, a_static, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    const static_result = svd_static(f64, m, n, a_static, .{ .with_v = true, .mode = .full_u });
 
     // Dynamic SVD
     var a_dynamic = try Matrix(f64).init(allocator, m, n);
@@ -35,7 +35,7 @@ test "SVD comparison: basic 5x4 matrix" {
             a_dynamic.at(i, j).* = test_matrix[i][j];
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = true, .mode = .full_u });
     defer dynamic_result.deinit();
 
     // Compare convergence
@@ -79,7 +79,7 @@ test "SVD comparison: identity matrix" {
 
     // Static SVD
     const a_static: SMatrix(f64, n, n) = .identity();
-    const static_result = svd_static(f64, n, n, a_static, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    const static_result = svd_static(f64, n, n, a_static, .{ .with_v = true, .mode = .full_u });
 
     // Dynamic SVD
     var a_dynamic = try Matrix(f64).init(allocator, n, n);
@@ -89,7 +89,7 @@ test "SVD comparison: identity matrix" {
             a_dynamic.at(i, j).* = if (i == j) 1.0 else 0.0;
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = true, .mode = .full_u });
     defer dynamic_result.deinit();
 
     // All singular values should be 1.0 for identity matrix
@@ -116,7 +116,7 @@ test "SVD comparison: singular matrix" {
 
     // Static SVD
     const a_static: SMatrix(f64, m, n) = .init(test_matrix);
-    const static_result = svd_static(f64, m, n, a_static, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    const static_result = svd_static(f64, m, n, a_static, .{ .with_v = true, .mode = .full_u });
 
     // Dynamic SVD
     var a_dynamic = try Matrix(f64).init(allocator, m, n);
@@ -126,7 +126,7 @@ test "SVD comparison: singular matrix" {
             a_dynamic.at(i, j).* = test_matrix[i][j];
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = true, .mode = .full_u });
     defer dynamic_result.deinit();
 
     // Compare singular values
@@ -168,7 +168,7 @@ test "SVD comparison: skinny_u mode" {
 
     // Static SVD with skinny_u
     const a_static: SMatrix(f64, m, n) = .init(test_matrix);
-    const static_result = svd_static(f64, m, n, a_static, .{ .with_u = true, .with_v = false, .mode = .skinny_u });
+    const static_result = svd_static(f64, m, n, a_static, .{ .with_v = false, .mode = .skinny_u });
 
     // Dynamic SVD with skinny_u
     var a_dynamic = try Matrix(f64).init(allocator, m, n);
@@ -178,7 +178,7 @@ test "SVD comparison: skinny_u mode" {
             a_dynamic.at(i, j).* = test_matrix[i][j];
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = false, .mode = .skinny_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = false, .mode = .skinny_u });
     defer dynamic_result.deinit();
 
     // Check dimensions
@@ -211,7 +211,7 @@ test "SVD comparison: rectangular matrix" {
 
     // Static SVD
     const a_static: SMatrix(f64, m, n) = .init(test_matrix);
-    const static_result = svd_static(f64, m, n, a_static, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    const static_result = svd_static(f64, m, n, a_static, .{ .with_v = true, .mode = .full_u });
 
     // Dynamic SVD
     var a_dynamic = try Matrix(f64).init(allocator, m, n);
@@ -221,7 +221,7 @@ test "SVD comparison: rectangular matrix" {
             a_dynamic.at(i, j).* = test_matrix[i][j];
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = true, .mode = .full_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = true, .mode = .full_u });
     defer dynamic_result.deinit();
 
     // Compare convergence
@@ -260,7 +260,7 @@ test "SVD comparison: reconstruction accuracy" {
 
     // Static SVD
     const a_static: SMatrix(f64, m, n) = .init(test_matrix);
-    const static_result = svd_static(f64, m, n, a_static, .{ .with_u = true, .with_v = true, .mode = .skinny_u });
+    const static_result = svd_static(f64, m, n, a_static, .{ .with_v = true, .mode = .skinny_u });
 
     // Dynamic SVD
     var a_dynamic = try Matrix(f64).init(allocator, m, n);
@@ -270,7 +270,7 @@ test "SVD comparison: reconstruction accuracy" {
             a_dynamic.at(i, j).* = test_matrix[i][j];
         }
     }
-    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_u = true, .with_v = true, .mode = .skinny_u });
+    var dynamic_result = try svd_dynamic(f64, allocator, a_dynamic, .{ .with_v = true, .mode = .skinny_u });
     defer dynamic_result.deinit();
 
     // Reconstruct A = U * S * V^T for both implementations

--- a/src/pca.zig
+++ b/src/pca.zig
@@ -337,7 +337,6 @@ pub fn Pca(comptime T: type) type {
 
             // Compute SVD of covariance matrix
             var result = try cov_matrix.svd(self.allocator, .{
-                .with_u = true,
                 .with_v = false,
                 .mode = .skinny_u,
             });
@@ -393,7 +392,6 @@ pub fn Pca(comptime T: type) type {
 
             // Compute SVD of Gram matrix
             var result = try gram_matrix.svd(self.allocator, .{
-                .with_u = true,
                 .with_v = false,
                 .mode = .skinny_u,
             });


### PR DESCRIPTION
Consolidates U matrix computation control into the `mode` option by using `.no_u` instead of a separate boolean flag. This simplifies the API and internal logic. Also refactors column swapping to use `std.mem.swap` for better readability.