### PR TITLE
refactor(pca): optimize SIMD and simplify fit logic

### DIFF
--- a/bindings/python/src/color_factory.zig
+++ b/bindings/python/src/color_factory.zig
@@ -29,7 +29,7 @@ pub fn getConversionMethodDoc(comptime TargetColorType: type) []const u8 {
 /// Generate a color binding with automatic property getters and validation
 pub fn ColorBinding(comptime ZigColorType: type) type {
     const name = comptime getSimpleTypeName(ZigColorType);
-    const fields = @typeInfo(ZigColorType).@"struct".fields;
+    const fields = zignal.meta.structFields(ZigColorType);
     const is_packed = isPacked(ZigColorType);
 
     // Create the Python object type manually (avoiding @Type complexity)
@@ -337,7 +337,7 @@ pub fn ColorBinding(comptime ZigColorType: type) type {
             var alpha_obj: ?*c.PyObject = null;
             if (c.PyArg_ParseTuple(args, "O", &alpha_obj) == 0) return null;
 
-            const field_type = @typeInfo(ZigColorType).@"struct".fields[0].type;
+            const field_type = @typeInfo(ZigColorType).@"struct".field_types[0];
             var alpha: field_type = undefined;
 
             if (@typeInfo(field_type) == .float) {
@@ -497,7 +497,7 @@ pub fn ColorBinding(comptime ZigColorType: type) type {
 
             const ColorType = @TypeOf(zig_color);
             const is_u8_backed = switch (@typeInfo(ColorType)) {
-                .@"struct" => |info| info.fields[0].type == u8,
+                .@"struct" => |info| info.field_types[0] == u8,
                 else => false,
             };
             const float_color = if (is_u8_backed) zig_color.as(f64) else zig_color;

--- a/bindings/python/src/color_utils.zig
+++ b/bindings/python/src/color_utils.zig
@@ -36,7 +36,7 @@ const zignalColorTypes = .{
 
 fn objectToZigColor(comptime ColorType: type, comptime Binding: type, obj: *c.PyObject) ColorType {
     const py_obj: *Binding.PyObjectType = @ptrCast(@alignCast(obj));
-    const fields = @typeInfo(ColorType).@"struct".fields;
+    const fields = comptime zignal.meta.structFields(ColorType);
 
     if (comptime zignal.meta.isPacked(ColorType)) {
         comptime {

--- a/bindings/python/src/enum_utils.zig
+++ b/bindings/python/src/enum_utils.zig
@@ -39,16 +39,16 @@ pub fn registerEnum(
     defer c.Py_DecRef(values);
 
     const EI = getEnumInfo(E);
-    inline for (EI.fields) |field| {
+    inline for (EI.field_names, EI.field_values) |field_name, field_value| {
         // Uppercase name for Python convention
         var up: [129]u8 = undefined;
-        const n = field.name.len;
+        const n = field_name.len;
         if (n > up.len - 1) return error.NameTooLong;
         var i: usize = 0;
-        while (i < n) : (i += 1) up[i] = std.ascii.toUpper(field.name[i]);
+        while (i < n) : (i += 1) up[i] = std.ascii.toUpper(field_name[i]);
         up[n] = 0; // NUL terminate
 
-        const py_val = python.create(field.value) orelse return error.ValueCreationFailed;
+        const py_val = python.create(field_value) orelse return error.ValueCreationFailed;
         defer c.Py_DecRef(py_val);
         if (c.PyDict_SetItemString(values, @ptrCast(&up[0]), py_val) < 0) return error.DictSetFailed;
     }
@@ -124,10 +124,10 @@ pub fn pyToEnum(comptime E: type, obj: *c.PyObject) !E {
     const EI = getEnumInfo(E);
     var matched = false;
     var out: E = @enumFromInt(0);
-    inline for (EI.fields) |field| {
-        if (v == field.value) {
+    inline for (EI.field_values) |field_value| {
+        if (v == field_value) {
             matched = true;
-            out = @enumFromInt(field.value);
+            out = @enumFromInt(field_value);
         }
     }
     if (!matched) {
@@ -168,9 +168,9 @@ pub fn pyToUnionTag(comptime U: type, obj: *c.PyObject) !TagOf(U) {
     }
 
     const EI = getEnumInfo(U);
-    inline for (EI.fields) |field| {
-        if (v == field.value) {
-            return @enumFromInt(field.value);
+    inline for (EI.field_values) |field_value| {
+        if (v == field_value) {
+            return @enumFromInt(field_value);
         }
     }
     var buf: [128]u8 = undefined;
@@ -192,9 +192,9 @@ fn ResolvedEnum(comptime T: type) type {
 /// Convert a c_long integer to a Zig enum value (or union tag)
 pub fn longToEnum(comptime T: type, value: c_long) !ResolvedEnum(T) {
     const EI = getEnumInfo(T);
-    inline for (EI.fields) |field| {
-        if (value == field.value) {
-            return @enumFromInt(field.value);
+    inline for (EI.field_values) |field_value| {
+        if (value == field_value) {
+            return @enumFromInt(field_value);
         }
     }
     var buf: [128]u8 = undefined;

--- a/bindings/python/src/generate_stubs.zig
+++ b/bindings/python/src/generate_stubs.zig
@@ -139,16 +139,16 @@ fn generateColorClass(stub: *GeneratedStub, comptime ColorType: type) !void {
 
     // Constructor
     try stub.write("    def __init__(self");
-    inline for (type_info.fields) |field| {
-        const python_type = getPythonType(field.type);
-        try stub.writef(", {s}: {s}", .{ field.name, python_type });
+    inline for (type_info.field_names, type_info.field_types) |field_name, field_type| {
+        const python_type = getPythonType(field_type);
+        try stub.writef(", {s}: {s}", .{ field_name, python_type });
     }
     try stub.write(") -> None: ...\n");
 
     // Properties (getters and setters)
-    inline for (type_info.fields) |field| {
-        try generatePropertyGetter(stub, field.name, field.type);
-        try generatePropertySetter(stub, field.name, field.type);
+    inline for (type_info.field_names, type_info.field_types) |field_name, field_type| {
+        try generatePropertyGetter(stub, field_name, field_type);
+        try generatePropertySetter(stub, field_name, field_type);
     }
 
     // to(self, space) accepting a color class
@@ -325,19 +325,19 @@ fn generateEnumFromMetadata(stub: *GeneratedStub, enum_info: stub_metadata.EnumI
     try stub.writef("    \"\"\"{s}\"\"\"\n", .{enum_info.doc});
 
     // Generate enum values
-    inline for (enum_type_info.fields) |field| {
+    inline for (enum_type_info.field_names, enum_type_info.field_values) |field_name, field_value| {
         // Convert field name to uppercase for Python convention
         var uppercase_name: [128]u8 = undefined;
-        const name_len = field.name.len;
+        const name_len = field_name.len;
         if (name_len > uppercase_name.len) {
             return error.NameTooLong;
         }
-        for (field.name, 0..) |c, i| {
+        for (field_name, 0..) |c, i| {
             uppercase_name[i] = std.ascii.toUpper(c);
         }
 
         // Write enum value with optional inline documentation
-        try stub.writef("    {s} = {d}\n", .{ uppercase_name[0..name_len], field.value });
+        try stub.writef("    {s} = {d}\n", .{ uppercase_name[0..name_len], field_value });
 
         // Add inline comment if documentation is provided
         if (enum_info.value_docs) |docs| {

--- a/bindings/python/src/pixel_proxy.zig
+++ b/bindings/python/src/pixel_proxy.zig
@@ -28,7 +28,7 @@ const RgbaPixelProxy = extern struct {
 };
 
 fn PixelProxyBinding(comptime ColorType: type, comptime ProxyObjectType: type) type {
-    const fields = @typeInfo(ColorType).@"struct".fields;
+    const fields = zignal.meta.structFields(ColorType);
 
     return struct {
         const Self = @This();

--- a/bindings/python/src/python.zig
+++ b/bindings/python/src/python.zig
@@ -341,7 +341,7 @@ pub fn getterOptionalPtr(
 ) *const anyopaque {
     const field_index = std.meta.fieldIndex(Obj, field_name) orelse
         @compileError("Field '" ++ field_name ++ "' not found on type " ++ @typeName(Obj));
-    const FieldType = std.meta.fields(Obj)[field_index].type;
+    const FieldType = std.meta.fieldTypes(Obj)[field_index];
     const opt_info = @typeInfo(FieldType);
     if (opt_info != .optional) {
         @compileError("Field '" ++ field_name ++ "' on type " ++ @typeName(Obj) ++ " must be optional");
@@ -1021,8 +1021,8 @@ pub fn kw(comptime names: []const []const u8) [names.len + 1]?[*:0]const u8 {
 /// ```
 pub fn parseArgs(comptime T: type, args: ?*c.PyObject, kwds: ?*c.PyObject, out: *T) !void {
     const type_info = @typeInfo(T);
-    const fields = switch (type_info) {
-        .@"struct" => |s| s.fields,
+    const fields = comptime switch (type_info) {
+        .@"struct" => zignal.meta.structFields(T),
         else => @compileError("parseArgs expects a struct type, got: " ++ @typeName(T)),
     };
 
@@ -1287,7 +1287,7 @@ pub fn genericNew(comptime T: type) fn (?*c.PyTypeObject, ?*c.PyObject, ?*c.PyOb
             const self: ?*T = @ptrCast(c.PyType_GenericAlloc(type_obj, 0));
             if (self) |obj| {
                 // Initialize all pointer fields to null
-                inline for (@typeInfo(T).@"struct".fields) |field| {
+                inline for (comptime zignal.meta.structFields(T)) |field| {
                     if (@typeInfo(field.type) == .optional) {
                         @field(obj, field.name) = null;
                     }

--- a/build.zig
+++ b/build.zig
@@ -57,9 +57,7 @@ pub fn build(b: *Build) void {
     const run_cmd = b.addRunArtifact(exe);
     run_step.dependOn(&run_cmd.step);
     run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
+    run_cmd.addPassthruArgs();
     // Version info step
     const version_info_step = b.step("version", "Print the resolved version information");
     const version_info_run = b.addRunArtifact(exe);
@@ -113,7 +111,7 @@ pub fn build(b: *Build) void {
     // Format check
     const fmt_step = b.step("fmt", "Check code formatting");
     const fmt = b.addFmt(.{
-        .paths = &.{ "src", "build.zig", "build.zig.zon" },
+        .paths = b.pathList(&.{ "src", "build.zig", "build.zig.zon" }),
         .check = true,
     });
     fmt_step.dependOn(&fmt.step);
@@ -183,7 +181,7 @@ pub fn build(b: *Build) void {
     py_bindings_step.dependOn(&install_py_module.step);
 
     // Also copy the built extension into the source package directory for local development
-    const pkg_dir = b.pathJoin(&.{ b.build_root.path.?, "bindings/python/zignal" });
+    const pkg_dir = b.pathJoin(&.{ b.root.root_dir.path.?, "bindings/python/zignal" });
     const wf = b.addWriteFiles();
     _ = wf.addCopyFile(py_module.getEmittedBin(), b.fmt("{s}/_zignal{s}", .{ pkg_dir, extension }));
 
@@ -254,7 +252,7 @@ fn resolveVersion(b: *std.Build) std.SemanticVersion {
 /// Helper function to run git commands and return stdout
 fn runGit(b: *std.Build, args: []const []const u8) ![]const u8 {
     var code: u8 = undefined;
-    const dir = b.pathFromRoot(".");
+    const dir = b.root.root_dir.path orelse ".";
     var full_args: std.ArrayList([]const u8) = .empty;
     defer full_args.deinit(b.allocator);
     try full_args.appendSlice(b.allocator, &.{ "git", "-C", dir });

--- a/build.zig
+++ b/build.zig
@@ -135,7 +135,7 @@ pub fn build(b: *Build) void {
             .imports = &.{.{ .name = "zignal", .module = zignal }},
         }),
     });
-    linkPython(b, py_module, target, optimize, "python3");
+    linkPython(b, py_module, target, "python3");
 
     const extension = switch (os_tag) {
         .windows => ".pyd",
@@ -161,7 +161,7 @@ pub fn build(b: *Build) void {
             .imports = &.{.{ .name = "zignal", .module = zignal }},
         }),
     });
-    linkPython(b, stub_generator, target, .Debug, "python3-embed");
+    linkPython(b, stub_generator, target, "python3-embed");
 
     // Run stub generator in the python bindings directory
     const run_stub_generator = b.addRunArtifact(stub_generator);
@@ -268,7 +268,6 @@ fn linkPython(
     b: *Build,
     artifact: *Build.Step.Compile,
     target: Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
     python_lib: []const u8,
 ) void {
     const root = artifact.root_module;
@@ -277,7 +276,10 @@ fn linkPython(
     const tc = b.addTranslateC(.{
         .root_source_file = b.path("bindings/python/src/c.h"),
         .target = target,
-        .optimize = optimize,
+        // Pin to Debug: translate-c in zig 0.17.0-dev.690 rejects the `-O<mode>`
+        // flag it emits for Release modes ("unrecognized optimization mode").
+        // TODO: revert to `optimize` once a newer zig fixes this.
+        .optimize = .Debug,
     });
     if (b.graph.environ_map.get("PYTHON_INCLUDE_DIR")) |python_include| {
         validatePath(python_include, "PYTHON_INCLUDE_DIR");

--- a/build.zig
+++ b/build.zig
@@ -249,6 +249,17 @@ fn resolveVersion(b: *std.Build) std.SemanticVersion {
     return zignal_version;
 }
 
+/// Run `python -c <snippet>` and return its trimmed stdout, or null on any
+/// failure (interpreter missing, non-zero exit, empty output). Used to discover
+/// Python paths on Windows, where there is no pkg-config fallback.
+fn pythonValue(b: *std.Build, snippet: []const u8) ?[]const u8 {
+    const exe = b.graph.environ_map.get("PYTHON") orelse "python";
+    var code: u8 = undefined;
+    const out = b.runAllowFail(&.{ exe, "-c", snippet }, &code, .ignore) catch return null;
+    const trimmed = std.mem.trim(u8, out, " \r\n");
+    return if (trimmed.len == 0) null else trimmed;
+}
+
 /// Helper function to run git commands and return stdout
 fn runGit(b: *std.Build, args: []const []const u8) ![]const u8 {
     var code: u8 = undefined;
@@ -272,6 +283,7 @@ fn linkPython(
 ) void {
     const root = artifact.root_module;
     const os_tag = target.result.os.tag;
+    const is_windows = os_tag == .windows;
 
     const tc = b.addTranslateC(.{
         .root_source_file = b.path("bindings/python/src/c.h"),
@@ -285,6 +297,13 @@ fn linkPython(
     if (b.graph.environ_map.get("PYTHON_INCLUDE_DIR")) |python_include| {
         validatePath(python_include, "PYTHON_INCLUDE_DIR");
         tc.addIncludePath(.{ .cwd_relative = python_include });
+    } else if (is_windows) {
+        // Windows has no pkg-config, so ask the interpreter for the include
+        // path directly. translate-c only needs `-I`; it never links libpython.
+        const python_include = pythonValue(b, "import sysconfig;print(sysconfig.get_path('include'),end='')") orelse
+            @panic("Could not determine the Python include directory; set PYTHON_INCLUDE_DIR.");
+        validatePath(python_include, "PYTHON_INCLUDE_DIR");
+        tc.addIncludePath(.{ .cwd_relative = python_include });
     } else {
         // Let pkg-config discover the Python include path. This also emits
         // link flags, but linkSystemLibrary below is the source of truth for
@@ -294,14 +313,26 @@ fn linkPython(
     root.addImport("c", tc.createModule());
 
     root.link_libc = true;
-    if (b.graph.environ_map.get("PYTHON_LIBS_DIR")) |libs_dir| {
-        validatePath(libs_dir, "PYTHON_LIBS_DIR");
-        root.addLibraryPath(.{ .cwd_relative = libs_dir });
+
+    // On Windows the env vars below are normally set by setup.py / CI; fall back
+    // to the interpreter so `zig build python-stubs` also works standalone.
+    const libs_dir = b.graph.environ_map.get("PYTHON_LIBS_DIR") orelse if (is_windows)
+        pythonValue(b, "import sysconfig;from pathlib import Path;p=Path(sysconfig.get_path('stdlib')).parent/'libs';print(p if p.exists() else '',end='')")
+    else
+        null;
+    if (libs_dir) |dir| {
+        validatePath(dir, "PYTHON_LIBS_DIR");
+        root.addLibraryPath(.{ .cwd_relative = dir });
     }
-    const lib_name = if (b.graph.environ_map.get("PYTHON_LIB_NAME")) |name| blk: {
+
+    const env_lib_name = b.graph.environ_map.get("PYTHON_LIB_NAME") orelse if (is_windows)
+        pythonValue(b, "import sys;print(f'python{sys.version_info.major}{sys.version_info.minor}.lib',end='')")
+    else
+        null;
+    const lib_name = if (env_lib_name) |name| blk: {
         validateLibName(name, "PYTHON_LIB_NAME");
         // On Windows, strip the .lib extension
-        if (os_tag == .windows and std.mem.endsWith(u8, name, ".lib")) {
+        if (is_windows and std.mem.endsWith(u8, name, ".lib")) {
             break :blk name[0 .. name.len - ".lib".len];
         }
         break :blk name;

--- a/build.zig
+++ b/build.zig
@@ -278,7 +278,8 @@ fn linkPython(
         .target = target,
         // Pin to Debug: translate-c in zig 0.17.0-dev.690 rejects the `-O<mode>`
         // flag it emits for Release modes ("unrecognized optimization mode").
-        // TODO: revert to `optimize` once a newer zig fixes this.
+        // Fixed upstream by ziglang/translate-c#375 (commit 57924d2, zig-dev.772+).
+        // TODO: revert to `optimize` once the pinned zig includes that fix.
         .optimize = .Debug,
     });
     if (b.graph.environ_map.get("PYTHON_INCLUDE_DIR")) |python_include| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal,
     .version = "0.11.0-dev",
     .fingerprint = 0x5303c43db377b63a,
-    .minimum_zig_version = "0.17.0-dev.304+9787df942",
+    .minimum_zig_version = "0.17.0-dev.633+9c5655093",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal,
     .version = "0.11.0-dev",
     .fingerprint = 0x5303c43db377b63a,
-    .minimum_zig_version = "0.17.0-dev.633+9c5655093",
+    .minimum_zig_version = "0.17.0-dev.690+c5a61e899",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -62,7 +62,7 @@ pub fn build(b: *std.Build) void {
 
             // Create individual run step
             const run_exe = b.addRunArtifact(exe);
-            if (b.args) |args| run_exe.addArgs(args);
+            run_exe.addPassthruArgs();
 
             // Replace underscores with hyphens for step name
             const run_name = blk: {
@@ -85,7 +85,7 @@ pub fn build(b: *std.Build) void {
 
     const fmt_step = b.step("fmt", "Run zig fmt");
     const fmt = b.addFmt(.{
-        .paths = &.{ "src", "build.zig", "build.zig.zon" },
+        .paths = b.pathList(&.{ "src", "build.zig", "build.zig.zon" }),
         .check = true,
     });
     fmt_step.dependOn(&fmt.step);

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal_examples,
     .version = "0.0.0",
     .fingerprint = 0xcf70e6a9b7002db6,
-    .minimum_zig_version = "0.17.0-dev.633+9c5655093",
+    .minimum_zig_version = "0.17.0-dev.690+c5a61e899",
     .dependencies = .{
         .zignal = .{
             .path = "../",

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal_examples,
     .version = "0.0.0",
     .fingerprint = 0xcf70e6a9b7002db6,
-    .minimum_zig_version = "0.17.0-dev.304+9787df942",
+    .minimum_zig_version = "0.17.0-dev.633+9c5655093",
     .dependencies = .{
         .zignal = .{
             .path = "../",

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Io = std.Io;
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
+const meta = @import("zignal").meta;
 
 pub var runtime_log_level: std.log.Level = if (builtin.mode == .Debug) .debug else .err;
 
@@ -84,7 +85,7 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
             const flag_name = arg[2..];
             var found = false;
 
-            inline for (std.meta.fields(T)) |field| {
+            inline for (comptime meta.structFields(T)) |field| {
                 const matches = blk: {
                     if (flag_name.len != field.name.len) break :blk false;
                     for (flag_name, field.name) |c_flag, c_field| {
@@ -152,7 +153,7 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
 pub fn generateHelp(comptime T: type, comptime usage_line: []const u8, comptime description: []const u8) []const u8 {
     var text: []const u8 = "Usage: " ++ usage_line ++ "\n\n" ++ description ++ "\n\n";
 
-    const fields = std.meta.fields(T);
+    const fields = comptime meta.structFields(T);
     if (fields.len > 0) {
         text = text ++ "Options:\n";
     }

--- a/src/cli/common.zig
+++ b/src/cli/common.zig
@@ -106,8 +106,8 @@ pub fn toSnake(name: []const u8, buf: []u8) []const u8 {
 pub fn parseEnum(comptime T: type, name: []const u8) ?T {
     const max_len = comptime blk: {
         var m: usize = 0;
-        for (std.meta.fields(T)) |field| {
-            if (field.name.len > m) m = field.name.len;
+        for (std.meta.fieldNames(T)) |field_name| {
+            if (field_name.len > m) m = field_name.len;
         }
         break :blk m;
     };
@@ -121,13 +121,13 @@ pub fn parseEnum(comptime T: type, name: []const u8) ?T {
 /// tagged union so help text cannot drift from the type. Tags without
 /// underscores pass through unchanged.
 pub fn joinFieldNames(comptime T: type) []const u8 {
-    const fields = std.meta.fields(T);
+    const names = std.meta.fieldNames(T);
     var result: []const u8 = "";
-    inline for (fields, 0..) |field, i| {
-        inline for (field.name) |c| {
+    inline for (names, 0..) |name, i| {
+        inline for (name) |c| {
             result = result ++ &[_]u8{if (c == '_') '-' else c};
         }
-        if (i < fields.len - 1) result = result ++ ", ";
+        if (i < names.len - 1) result = result ++ ", ";
     }
     return result;
 }

--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -1038,8 +1038,8 @@ pub const Marker = enum(u16) {
 
     pub fn fromBytes(bytes: [2]u8) ?Marker {
         const value = (@as(u16, bytes[0]) << 8) | bytes[1];
-        return inline for (std.meta.fields(Marker)) |f| {
-            if (value == f.value) break @enumFromInt(value);
+        return inline for (@typeInfo(Marker).@"enum".field_values) |field_value| {
+            if (value == field_value) break @enumFromInt(value);
         } else null;
     }
 };

--- a/src/color.zig
+++ b/src/color.zig
@@ -58,6 +58,7 @@ const blending = @import("blending.zig");
 pub const Blending = blending.Blending;
 pub const blendColors = blending.blendColors;
 const getSimpleTypeName = @import("meta.zig").getSimpleTypeName;
+const structFields = @import("meta.zig").structFields;
 
 // Rec.709 Luma coefficients (used for Grayscale/Luma)
 const luma_r = 0.2126;
@@ -120,7 +121,7 @@ pub fn convertColor(comptime DestType: type, source: anytype) DestType {
     // Scalar -> Color
     if (SrcType == u8 or @typeInfo(SrcType) == .float) {
         const DestT = switch (@typeInfo(DestType)) {
-            .@"struct" => |info| info.fields[0].type,
+            .@"struct" => |info| info.field_types[0],
             else => @compileError("Destination type must be a color struct"),
         };
         // Interpret scalar as grayscale
@@ -136,7 +137,7 @@ pub fn convertColor(comptime DestType: type, source: anytype) DestType {
 
     // Color -> Color
     const DestT = switch (@typeInfo(DestType)) {
-        .@"struct" => |info| info.fields[0].type,
+        .@"struct" => |info| info.field_types[0],
         else => @compileError("Destination type must be a color struct"),
     };
 
@@ -167,7 +168,7 @@ fn formatColor(comptime T: type, self: T, writer: *Io.Writer) !void {
     );
 
     // Print each field
-    const fields = std.meta.fields(T);
+    const fields = comptime structFields(T);
     inline for (fields, 0..) |field, i| {
         try writer.print(".{s} = ", .{field.name});
 
@@ -1531,7 +1532,7 @@ fn xybToRgb(comptime T: type, xyb: Xyb(T)) Rgb(T) {
 fn testRoundTripConversion(from: Rgb(u8), to: anytype) !void {
     const Dest = @TypeOf(to);
     const T = switch (@typeInfo(Dest)) {
-        .@"struct" => |info| info.fields[0].type, // Assumes first field is component type, consistent with rest of file
+        .@"struct" => |info| info.field_types[0], // Assumes first field is component type, consistent with rest of file
         else => @compileError("Invalid test destination type"),
     };
     const target_space = comptime ColorSpace.tag(Dest);
@@ -1541,7 +1542,7 @@ fn testRoundTripConversion(from: Rgb(u8), to: anytype) !void {
 
     const Source = @TypeOf(from);
     const U = switch (@typeInfo(Source)) {
-        .@"struct" => |info| info.fields[0].type,
+        .@"struct" => |info| info.field_types[0],
         else => @compileError("Invalid test source type"),
     };
 

--- a/src/geometry/Point.zig
+++ b/src/geometry/Point.zig
@@ -63,9 +63,9 @@ pub fn Point(comptime dim: usize, comptime T: type) type {
             return switch (info) {
                 .@"struct" => |s| blk: {
                     if (s.is_tuple) {
-                        comptime assert(s.fields.len == dim);
+                        comptime assert(s.field_names.len == dim);
                         var items: @Vector(dim, T) = undefined;
-                        inline for (s.fields, 0..) |_, i| {
+                        inline for (s.field_names, 0..) |_, i| {
                             items[i] = @as(T, components[i]);
                         }
                         break :blk .{ .items = items };

--- a/src/image.zig
+++ b/src/image.zig
@@ -294,7 +294,7 @@ pub fn Image(comptime T: type) type {
         pub fn channels() u32 {
             return comptime switch (@typeInfo(T)) {
                 .int, .float => 1,
-                .@"struct" => std.meta.fields(T).len,
+                .@"struct" => |info| info.field_names.len,
                 .array => |info| info.len,
                 else => @compileError("Image(" ++ @typeName(T) ++ ") is unsupported."),
             };

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -40,7 +40,7 @@ pub fn findUniformValue(comptime T: type, data: []const T) ?T {
 
 /// Get the common type of all fields in a struct, or compile error if not uniform
 fn FieldTypeOf(comptime T: type) type {
-    const fields = std.meta.fields(T);
+    const fields = comptime meta.structFields(T);
     if (fields.len == 0) @compileError("Type " ++ @typeName(T) ++ " has no fields");
 
     const first_type = fields[0].type;
@@ -58,7 +58,7 @@ pub fn splitChannelsWithUniform(comptime T: type, image: Image(T), allocator: st
     uniforms: [Image(T).channels()]?FieldTypeOf(T),
 } {
     const num_channels = comptime Image(T).channels();
-    const fields = std.meta.fields(T);
+    const fields = comptime meta.structFields(T);
     const FieldType = FieldTypeOf(T);
     const plane_size = image.rows * image.cols;
 
@@ -120,7 +120,7 @@ pub fn splitChannels(comptime T: type, image: Image(T), allocator: std.mem.Alloc
 
 /// Combine channels back into struct image.
 pub fn mergeChannels(comptime T: type, channels: [Image(T).channels()][]const FieldTypeOf(T), out: Image(T)) void {
-    const fields = std.meta.fields(T);
+    const fields = comptime meta.structFields(T);
 
     var idx: u32 = 0;
     for (0..out.rows) |r| {

--- a/src/image/diff.zig
+++ b/src/image/diff.zig
@@ -80,7 +80,7 @@ pub fn compute(
                 .@"struct" => {
                     var is_pixel_diff = false;
                     var pixel_max_val: f64 = 0;
-                    const fields = std.meta.fields(T);
+                    const fields = comptime meta.structFields(T);
                     var diffs: [fields.len]f32 = undefined;
 
                     // 1. Calculate raw differences and check threshold

--- a/src/image/integral.zig
+++ b/src/image/integral.zig
@@ -110,7 +110,7 @@ pub fn Integral(comptime T: type) type {
                     plane(image, planes.planes[0]);
                 },
                 .@"struct" => {
-                    const fields = std.meta.fields(T);
+                    const fields = comptime meta.structFields(T);
                     const plane_len = try std.math.mul(usize, image.rows, image.cols);
                     const src_plane = try allocator.alloc(f32, plane_len);
                     defer allocator.free(src_plane);
@@ -169,7 +169,7 @@ pub fn Integral(comptime T: type) type {
                     var scratch = try Image(f32).init(allocator, dst.rows, dst.cols);
                     defer scratch.deinit(allocator);
 
-                    const fields = std.meta.fields(T);
+                    const fields = comptime meta.structFields(T);
                     inline for (fields, 0..) |field, ch| {
                         boxBlurPlane(f32, sat.planes[ch], scratch, radius);
 
@@ -292,7 +292,7 @@ pub fn Integral(comptime T: type) type {
                 },
                 .@"struct" => {
                     // Multi-channel sharpen
-                    const fields = std.meta.fields(T);
+                    const fields = comptime meta.structFields(T);
                     for (0..src.rows) |r| {
                         for (0..src.cols) |c| {
                             const r1 = r -| radius;

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -387,7 +387,7 @@ fn interpolateBilinear(comptime T: type, self: Image(T), x: f32, y: f32, border:
         },
         .float => temp = lerpFloat(T, tl, tr, bl, br, lr_frac, tb_frac),
         .@"struct" => {
-            inline for (std.meta.fields(T)) |f| {
+            inline for (comptime meta.structFields(T)) |f| {
                 const f_tl = @field(tl, f.name);
                 const f_tr = @field(tr, f.name);
                 const f_bl = @field(bl, f.name);
@@ -486,7 +486,7 @@ fn interpolateWithKernel(
             result = clamp(T, val);
         },
         .@"struct" => {
-            const fields = std.meta.fields(T);
+            const fields = comptime meta.structFields(T);
             var sums: [fields.len]f32 = @splat(0);
             var weight_sum: f32 = 0;
 

--- a/src/image/metrics.zig
+++ b/src/image/metrics.zig
@@ -27,7 +27,7 @@ pub fn psnr(comptime T: type, image_a: Image(T), image_b: Image(T)) !f64 {
                     component_count += 1;
                 },
                 .@"struct" => {
-                    inline for (std.meta.fields(T)) |field| {
+                    inline for (comptime meta.structFields(T)) |field| {
                         const diff = getScalarValue(field.type, @field(image_a.data[idx_a], field.name)) - getScalarValue(field.type, @field(image_b.data[idx_b], field.name));
                         mse += diff * diff;
                         component_count += 1;
@@ -132,7 +132,7 @@ pub fn meanPixelError(comptime T: type, image_a: Image(T), image_b: Image(T)) !f
                     component_count += 1;
                 },
                 .@"struct" => {
-                    inline for (std.meta.fields(T)) |field| {
+                    inline for (comptime meta.structFields(T)) |field| {
                         const diff = @abs(
                             getScalarValue(field.type, @field(image_a.data[idx_a], field.name)) -
                                 getScalarValue(field.type, @field(image_b.data[idx_b], field.name)),
@@ -168,7 +168,7 @@ pub fn meanPixelError(comptime T: type, image_a: Image(T), image_b: Image(T)) !f
 inline fn componentType(comptime T: type) type {
     return switch (@typeInfo(T)) {
         .int, .float => T,
-        .@"struct" => std.meta.fields(T)[0].type,
+        .@"struct" => |info| info.field_types[0],
         .array => |info| info.child,
         else => T,
     };
@@ -203,7 +203,7 @@ inline fn getPixelScalar(comptime PixelType: type, pixel: PixelType) f64 {
             }
             var sum: f64 = 0.0;
             var count: usize = 0;
-            inline for (std.meta.fields(PixelType)) |field| {
+            inline for (comptime meta.structFields(PixelType)) |field| {
                 sum += getScalarValue(field.type, @field(pixel, field.name));
                 count += 1;
             }

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -171,7 +171,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                     },
                     .@"struct" => {
                         // Process struct types (RGB, RGBA, etc.)
-                        const fields = std.meta.fields(T);
+                        const fields = comptime meta.structFields(T);
                         for (0..image.rows) |r| {
                             for (0..image.cols) |c| {
                                 var result_pixel: T = undefined;
@@ -345,7 +345,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                 },
                 .@"struct" => {
                     // Process struct types (RGB, RGBA, etc.)
-                    const fields = std.meta.fields(T);
+                    const fields = comptime meta.structFields(T);
                     for (0..image.rows) |r| {
                         for (0..image.cols) |c| {
                             const fx = @as(f32, @floatFromInt(c));

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,7 +71,7 @@ pub const Cli = struct {
             for (std.meta.declarations(root)) |decl| {
                 if (getCommandModule(decl)) |val| {
                     array[i] = .{
-                        .name = decl.name,
+                        .name = decl,
                         .run = val.run,
                         .description = val.description,
                         .help = val.help,
@@ -92,7 +92,7 @@ pub const Cli = struct {
     }
 
     fn getCommandModule(comptime decl: anytype) ?type {
-        const val = @field(root, decl.name);
+        const val = @field(root, decl);
         return if (@TypeOf(val) == type and
             @hasDecl(val, "run") and
             @hasDecl(val, "description") and

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -73,9 +73,26 @@ pub fn comptimeLowercase(comptime input: []const u8) []const u8 {
     return &result;
 }
 
+/// A struct field's name, type and default value, mirroring the old `std.builtin.Type.StructField`.
+pub const FieldDesc = struct { name: [:0]const u8, type: type, default_value_ptr: ?*const anyopaque };
+
+/// Replacement for the removed `std.meta.fields` (struct kind). Comptime-only;
+/// call in a comptime context, e.g. `inline for (comptime meta.structFields(T))`.
+pub fn structFields(comptime T: type) []const FieldDesc {
+    return comptime blk: {
+        const info = @typeInfo(T).@"struct";
+        var result: [info.field_names.len]FieldDesc = undefined;
+        for (info.field_names, info.field_types, info.field_attrs, 0..) |field_name, field_type, attrs, i| {
+            result[i] = .{ .name = field_name, .type = field_type, .default_value_ptr = attrs.default_value_ptr };
+        }
+        const final = result;
+        break :blk &final;
+    };
+}
+
 /// Returns true if and only if all fields of T are of type u8
 pub fn allFieldsAreU8(comptime T: type) bool {
-    return for (std.meta.fields(T)) |field| {
+    return for (comptime structFields(T)) |field| {
         if (field.type != u8) break false;
     } else true;
 }
@@ -130,7 +147,7 @@ pub fn isRgb(comptime T: type) bool {
     const type_info = @typeInfo(T);
     if (type_info != .@"struct") return false;
 
-    const fields = std.meta.fields(T);
+    const fields = comptime structFields(T);
     if (fields.len < 3 or fields.len > 4) return false;
 
     // Check first three fields are u8 and named appropriately
@@ -161,7 +178,7 @@ pub fn isRgb(comptime T: type) bool {
 /// const no_alpha = meta.hasAlphaChannel(Rgb);   // false
 /// ```
 pub fn hasAlphaChannel(comptime T: type) bool {
-    const fields = std.meta.fields(T);
+    const fields = comptime structFields(T);
     if (fields.len != 4) return false;
     const last_field = fields[3];
     return std.mem.eql(u8, last_field.name, "a") or std.mem.eql(u8, last_field.name, "alpha");

--- a/src/pca.zig
+++ b/src/pca.zig
@@ -135,7 +135,7 @@ pub fn Pca(comptime T: type) type {
                     self.mean[j] += data_matrix.at(i, j).*;
                 }
             }
-            const n_samples_f = @as(T, @floatFromInt(n_samples));
+            const n_samples_f: T = @floatFromInt(n_samples);
             for (0..self.dim) |j| {
                 self.mean[j] /= n_samples_f;
             }
@@ -192,16 +192,15 @@ pub fn Pca(comptime T: type) type {
                     var j: u32 = 0;
                     // Vectorized loop
                     while (j + VecSize <= self.dim) : (j += VecSize) {
-                        var centered_arr: [VecSize]T = undefined;
+                        const vec_chunk: @Vector(VecSize, T) = vector[j..][0..VecSize].*;
+                        const mean_chunk: @Vector(VecSize, T) = self.mean[j..][0..VecSize].*;
+                        // components are column-strided in row-major storage, so gather them
                         var comp_arr: [VecSize]T = undefined;
                         inline for (0..VecSize) |k| {
-                            centered_arr[k] = vector[j + k] - self.mean[j + k];
                             comp_arr[k] = self.components.at(j + k, i).*;
                         }
-                        const centered_vec: @Vector(VecSize, T) = centered_arr;
                         const comp_vec: @Vector(VecSize, T) = comp_arr;
-                        const prod = centered_vec * comp_vec;
-                        sum += @reduce(.Add, prod);
+                        sum += @reduce(.Add, (vec_chunk - mean_chunk) * comp_vec);
                     }
                     // Handle remainder
                     while (j < self.dim) : (j += 1) {
@@ -242,24 +241,18 @@ pub fn Pca(comptime T: type) type {
                 const VecSize = std.simd.suggestVectorLength(T) orelse 1;
                 for (0..self.num_components) |i| {
                     const weight = coefficients[i];
+                    const weight_vec: @Vector(VecSize, T) = @splat(weight);
                     var j: u32 = 0;
                     // Vectorized loop
                     while (j + VecSize <= self.dim) : (j += VecSize) {
+                        // components are column-strided in row-major storage, so gather them
                         var comp_arr: [VecSize]T = undefined;
-                        var res_arr: [VecSize]T = undefined;
                         inline for (0..VecSize) |k| {
                             comp_arr[k] = self.components.at(j + k, i).*;
-                            res_arr[k] = result[j + k];
                         }
                         const comp_vec: @Vector(VecSize, T) = comp_arr;
-                        const res_vec: @Vector(VecSize, T) = res_arr;
-                        const weight_vec = @as(@Vector(VecSize, T), @splat(weight));
-                        const weighted = weight_vec * comp_vec;
-                        const new_vec = res_vec + weighted;
-                        const new_arr = @as([VecSize]T, new_vec);
-                        inline for (0..VecSize) |k| {
-                            result[j + k] = new_arr[k];
-                        }
+                        const res_vec: @Vector(VecSize, T) = result[j..][0..VecSize].*;
+                        result[j..][0..VecSize].* = res_vec + weight_vec * comp_vec;
                     }
                     // Handle remainder
                     while (j < self.dim) : (j += 1) {
@@ -328,8 +321,6 @@ pub fn Pca(comptime T: type) type {
             var cov_matrix = try data_matrix.gemm(true, data_matrix.*, false, scale, 0.0, null);
             defer cov_matrix.deinit();
 
-            const n = cov_matrix.rows;
-
             // Prepare outputs
             self.num_components = num_components;
             self.eigenvalues = try self.allocator.realloc(self.eigenvalues, num_components);
@@ -343,16 +334,12 @@ pub fn Pca(comptime T: type) type {
             defer result.deinit();
             if (result.converged != 0) return error.SvdFailed;
 
-            // Extract eigenvalues and components
+            // Extract eigenvalues and components. The covariance matrix is dim × dim and
+            // `fit` clamps num_components to at most dim, so every index is in range.
             for (0..num_components) |i| {
-                if (i < n) {
-                    self.eigenvalues[i] = result.s.at(i, 0).*;
-                    for (0..self.dim) |j| {
-                        self.components.at(j, i).* = if (j < n) result.u.at(j, i).* else 0;
-                    }
-                } else {
-                    self.eigenvalues[i] = 0;
-                    for (0..self.dim) |j| self.components.at(j, i).* = 0;
+                self.eigenvalues[i] = result.s.at(i, 0).*;
+                for (0..self.dim) |j| {
+                    self.components.at(j, i).* = result.u.at(j, i).*;
                 }
             }
         }
@@ -398,9 +385,10 @@ pub fn Pca(comptime T: type) type {
             defer result.deinit();
             if (result.converged != 0) return error.SvdFailed;
 
-            // Project eigenvectors back to feature space
-            const actual_components = @min(num_components, n);
-            for (0..actual_components) |i| {
+            // Project eigenvectors back to feature space. The Gram matrix is
+            // n_samples × n_samples and `fit` clamps num_components to at most
+            // n_samples - 1, so every requested component has a backing eigenvector.
+            for (0..num_components) |i| {
                 const eigenval = result.s.at(i, 0).*;
                 self.eigenvalues[i] = eigenval;
 
@@ -416,10 +404,6 @@ pub fn Pca(comptime T: type) type {
                 } else {
                     for (0..self.dim) |j| self.components.at(j, i).* = 0;
                 }
-            }
-            for (actual_components..num_components) |i| {
-                self.eigenvalues[i] = 0;
-                for (0..self.dim) |j| self.components.at(j, i).* = 0;
             }
         }
     };

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -240,6 +240,20 @@ const State = struct {
         }
     }
 
+    /// Index of a control character in `termios.cc`. `std.posix.V` fails to
+    /// compile on Linux in Zig `0.17.0-dev.690` (std bug: `arch_bits == .alpha`),
+    /// so compute the index directly there and defer to `std.posix.V` elsewhere.
+    fn ccIndex(comptime field: enum { MIN, TIME }) usize {
+        if (builtin.os.tag == .linux) {
+            const arch = builtin.cpu.arch;
+            return switch (field) {
+                .MIN => if (arch.isMIPS()) 4 else if (arch.isPowerPC()) 5 else if (arch == .alpha) 16 else 6,
+                .TIME => if (arch.isMIPS()) 5 else if (arch.isPowerPC()) 7 else if (arch == .alpha) 17 else 5,
+            };
+        }
+        return @intFromEnum(@field(std.posix.V, @tagName(field)));
+    }
+
     /// Enter raw mode for reading terminal responses
     ///
     /// Disables canonical mode and echo to allow reading individual characters
@@ -259,8 +273,8 @@ const State = struct {
                     raw.lflag.ECHO = false;
 
                     // Set minimum characters and timeout
-                    raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
-                    raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
+                    raw.cc[ccIndex(.MIN)] = 0;
+                    raw.cc[ccIndex(.TIME)] = 1; // 0.1 second timeout
 
                     try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
                 }


### PR DESCRIPTION
Use direct slice-to-vector loads and stores in SIMD loops instead of manual array copying. Remove redundant bounds checks during fitting since components are already clamped to valid ranges.