### PR TITLE
refactor(python): simplify color object creation

### DIFF
--- a/bindings/python/src/matrix.zig
+++ b/bindings/python/src/matrix.zig
@@ -418,8 +418,7 @@ fn matrix_from_numpy(type_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     }
 
     // Get buffer interface from the array
-    var buffer: c.Py_buffer = undefined;
-    buffer = std.mem.zeroes(c.Py_buffer);
+    var buffer: c.Py_buffer = std.mem.zeroes(c.Py_buffer);
 
     // Request buffer with format and strides info
     const flags: c_int = c.PyBUF_FORMAT | c.PyBUF_ND | c.PyBUF_STRIDES;
@@ -447,7 +446,7 @@ fn matrix_from_numpy(type_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     const expected_stride_col = @sizeOf(f64);
 
     if (buffer.strides[0] != @as(c.Py_ssize_t, @intCast(expected_stride_row)) or
-        buffer.strides[1] != @as(c.Py_ssize_t, @intCast(expected_stride_col)))
+        buffer.strides[1] != expected_stride_col)
     {
         python.setValueError("Array must be C-contiguous. Use np.ascontiguousarray() to convert.", .{});
         return null;

--- a/bindings/python/src/pixel_iterator.zig
+++ b/bindings/python/src/pixel_iterator.zig
@@ -1,3 +1,4 @@
+const color = @import("color.zig");
 const ImageObject = @import("image.zig").ImageObject;
 const python = @import("python.zig");
 const c = python.c;
@@ -49,51 +50,25 @@ fn pixel_iterator_next(self_obj: ?*c.PyObject) callconv(.c) ?*c.PyObject {
     }
 
     const img_py: *ImageObject = @ptrCast(self.image_ref.?);
-    const total = if (img_py.py_image) |pimg| pimg.rows() * pimg.cols() else 0;
-    if (self.index >= total) {
+    const pimg = img_py.py_image orelse {
+        c.PyErr_SetNone(c.PyExc_StopIteration);
+        return null;
+    };
+
+    const cols = pimg.cols();
+    if (self.index >= pimg.rows() * cols) {
         c.PyErr_SetNone(c.PyExc_StopIteration);
         return null;
     }
 
     // Compute row/col and get pixel in native format
-    var row: usize = undefined;
-    var col: usize = undefined;
-    var pixel_obj: ?*c.PyObject = null;
-
-    if (img_py.py_image == null) {
-        c.PyErr_SetNone(c.PyExc_StopIteration);
-        return null;
-    }
-    const pimg = img_py.py_image.?;
-    row = self.index / pimg.cols();
-    col = self.index % pimg.cols();
-    switch (pimg.data) {
-        .gray => |img| {
-            const v = img.at(row, col).*;
-            pixel_obj = python.create(v);
-        },
-        .rgb => |img| {
-            const p = img.at(row, col).*;
-            const color_module = @import("color.zig");
-            const rgb_obj = c.PyType_GenericAlloc(@ptrCast(&color_module.rgb), 0) orelse return null;
-            const rgb: *color_module.RgbBinding.PyObjectType = @ptrCast(rgb_obj);
-            rgb.field0 = p.r;
-            rgb.field1 = p.g;
-            rgb.field2 = p.b;
-            pixel_obj = rgb_obj;
-        },
-        .rgba => |img| {
-            const p = img.at(row, col).*;
-            const color_module = @import("color.zig");
-            const rgba_obj = c.PyType_GenericAlloc(@ptrCast(&color_module.rgba), 0) orelse return null;
-            const rgba: *color_module.RgbaBinding.PyObjectType = @ptrCast(rgba_obj);
-            rgba.field0 = p.r;
-            rgba.field1 = p.g;
-            rgba.field2 = p.b;
-            rgba.field3 = p.a;
-            pixel_obj = rgba_obj;
-        },
-    }
+    const row = self.index / cols;
+    const col = self.index % cols;
+    const pixel_obj: ?*c.PyObject = switch (pimg.data) {
+        .gray => |img| python.create(img.at(row, col).*),
+        .rgb => |img| color.createColorPyObject(img.at(row, col).*),
+        .rgba => |img| color.createColorPyObject(img.at(row, col).*),
+    };
 
     if (pixel_obj == null) return null;
 

--- a/bindings/python/src/pixel_proxy.zig
+++ b/bindings/python/src/pixel_proxy.zig
@@ -199,24 +199,10 @@ fn PixelProxyBinding(comptime ColorType: type, comptime ProxyObjectType: type) t
                 const rgba = pimg.getPixelRgba(@intCast(proxy.row), @intCast(proxy.col));
 
                 // Return the color as the appropriate type
-                if (ColorType == Rgb) {
-                    const obj = c.PyType_GenericNew(&color.rgb, null, null);
-                    if (obj == null) return null;
-                    const py_obj: *color.RgbBinding.PyObjectType = @ptrCast(obj);
-                    py_obj.field0 = rgba.r;
-                    py_obj.field1 = rgba.g;
-                    py_obj.field2 = rgba.b;
-                    return obj;
-                } else {
-                    const obj = c.PyType_GenericNew(&color.rgba, null, null);
-                    if (obj == null) return null;
-                    const py_obj: *color.RgbaBinding.PyObjectType = @ptrCast(obj);
-                    py_obj.field0 = rgba.r;
-                    py_obj.field1 = rgba.g;
-                    py_obj.field2 = rgba.b;
-                    py_obj.field3 = rgba.a;
-                    return obj;
-                }
+                return if (ColorType == Rgb)
+                    color.createColorPyObject(Rgb{ .r = rgba.r, .g = rgba.g, .b = rgba.b })
+                else
+                    color.createColorPyObject(rgba);
             }
 
             c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");
@@ -269,24 +255,10 @@ fn PixelProxyBinding(comptime ColorType: type, comptime ProxyObjectType: type) t
                 pimg.setPixelRgba(@intCast(proxy.row), @intCast(proxy.col), blended);
 
                 // Return the new blended color as an Rgb or Rgba object
-                if (ColorType == Rgb) {
-                    const obj = c.PyType_GenericNew(&color.rgb, null, null);
-                    if (obj == null) return null;
-                    const py_obj: *color.RgbBinding.PyObjectType = @ptrCast(obj);
-                    py_obj.field0 = blended.r;
-                    py_obj.field1 = blended.g;
-                    py_obj.field2 = blended.b;
-                    return obj;
-                } else {
-                    const obj = c.PyType_GenericNew(&color.rgba, null, null);
-                    if (obj == null) return null;
-                    const py_obj: *color.RgbaBinding.PyObjectType = @ptrCast(obj);
-                    py_obj.field0 = blended.r;
-                    py_obj.field1 = blended.g;
-                    py_obj.field2 = blended.b;
-                    py_obj.field3 = blended.a;
-                    return obj;
-                }
+                return if (ColorType == Rgb)
+                    color.createColorPyObject(Rgb{ .r = blended.r, .g = blended.g, .b = blended.b })
+                else
+                    color.createColorPyObject(blended);
             }
 
             c.PyErr_SetString(c.PyExc_RuntimeError, "Invalid pixel proxy");


### PR DESCRIPTION
Uses `color.createColorPyObject` in pixel iterator and proxy. Also cleans up matrix buffer initialization and type casts.