### PR TITLE
feat(image): add color support to braille display

### DIFF
--- a/src/image.zig
+++ b/src/image.zig
@@ -444,7 +444,7 @@ pub fn Image(comptime T: type) type {
         ///
         /// Display modes:
         /// - `.sgr`: Uses SGR (Select Graphic Rendition) with Unicode half-block characters (requires monospace font with U+2580 support)
-        /// - `.braille`: Uses Braille patterns for 2x4 monochrome resolution (requires Unicode Braille support U+2800-U+28FF, converts to grayscale)
+        /// - `.braille`: Uses Braille patterns for 2x4 resolution (requires Unicode Braille support U+2800-U+28FF; dots binarized by `threshold`, optionally tinted with truecolor or a quantized palette)
         /// - `.sixel`: Uses the sixel graphics protocol if supported
         /// - `.kitty`: Uses the kitty graphics protocol if supported
         /// - `.auto`: Automatically selects best available format: kitty -> sixel -> sgr
@@ -453,7 +453,7 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// const img = try Image(Rgb).load(io, allocator, "test.png");
         /// std.debug.print("{f}", .{img.display(io, .sgr)});           // SGR with unicode half blocks
-        /// std.debug.print("{f}", .{img.display(io, .{ .braille = .{ .threshold = 0.5 } })}); // 2x4 monochrome
+        /// std.debug.print("{f}", .{img.display(io, .{ .braille = .{ .threshold = 0.5 } })}); // 2x4 braille, truecolor tint
         /// std.debug.print("{f}", .{img.display(io, .{ .sixel = .{ .palette_mode = .adaptive } })});
         /// std.debug.print("{f}", .{img.display(io, .{ .kitty = .default })});  // Kitty graphics protocol
         /// ```

--- a/src/image/display.zig
+++ b/src/image/display.zig
@@ -7,6 +7,7 @@ const color = @import("../color.zig");
 const Image = @import("../image.zig").Image;
 const Interpolation = @import("interpolation.zig").Interpolation;
 const kitty = @import("../kitty.zig");
+const quantize = @import("quantize.zig");
 const sixel = @import("../sixel.zig");
 const terminal = @import("../terminal.zig");
 
@@ -35,12 +36,18 @@ pub const DisplayFormat = union(enum) {
         height: ?u32 = null,
         pub const default: @This() = .{};
     },
-    /// Braille patterns for 2x4 monochrome resolution
+    /// Braille patterns for 2x4 resolution
     /// Requires Unicode Braille pattern support (U+2800-U+28FF)
-    /// Color images are binarized with threshold
+    /// Dot on/off is binarized with `threshold`; when `color` is set each cell
+    /// is tinted with the average color of its lit dots. An optional `palette`
+    /// snaps that tint to a fixed/adaptive palette (see `quantize.PaletteMode`).
     braille: struct {
         /// Brightness threshold for on/off (0.0-1.0)
-        threshold: f32 = 0.5,
+        threshold: f32 = 0.39,
+        /// Tint each cell with the average color of its lit dots
+        color: bool = true,
+        /// Snap each cell's tint to a quantized palette (null = 24-bit truecolor)
+        palette: ?quantize.PaletteMode = .{ .adaptive = .{ .max_colors = 256 } },
         /// Optional target width in pixels
         width: ?u32 = null,
         /// Optional target height in pixels
@@ -151,6 +158,9 @@ pub fn DisplayFormatter(comptime T: type) type {
                     const row_pairs = (image_to_display.rows + 1) / 2;
 
                     for (0..row_pairs) |pair_idx| {
+                        // Re-emit the fg/bg escape only when the pair changes.
+                        var last_upper: ?Rgb = null;
+                        var last_lower: ?Rgb = null;
                         for (0..image_to_display.cols) |col| {
                             const row1 = pair_idx * 2;
                             // Odd-row image: duplicate the last row so the final half-block renders as a solid cell.
@@ -159,10 +169,18 @@ pub fn DisplayFormatter(comptime T: type) type {
                             const rgb_upper = color.convertColor(Rgb, image_to_display.at(row1, col).*);
                             const rgb_lower = color.convertColor(Rgb, image_to_display.at(row2, col).*);
 
-                            try writer.print("\x1b[38;2;{d};{d};{d};48;2;{d};{d};{d}m▀", .{
-                                rgb_upper.r, rgb_upper.g, rgb_upper.b,
-                                rgb_lower.r, rgb_lower.g, rgb_lower.b,
-                            });
+                            if (last_upper == null or
+                                !std.meta.eql(rgb_upper, last_upper.?) or
+                                !std.meta.eql(rgb_lower, last_lower.?))
+                            {
+                                try writer.print("\x1b[38;2;{d};{d};{d};48;2;{d};{d};{d}m", .{
+                                    rgb_upper.r, rgb_upper.g, rgb_upper.b,
+                                    rgb_lower.r, rgb_lower.g, rgb_lower.b,
+                                });
+                                last_upper = rgb_upper;
+                                last_lower = rgb_lower;
+                            }
+                            try writer.writeAll("▀");
                         }
                         try writer.writeAll("\x1b[0m");
                         if (pair_idx < row_pairs - 1) try writer.writeByte('\n');
@@ -180,12 +198,28 @@ pub fn DisplayFormatter(comptime T: type) type {
                         .{ 2, 5 },
                         .{ 6, 7 },
                     };
+                    const Rgb = color.Rgb(u8);
                     const block_rows = (image_to_display.rows + 3) / 4;
                     const block_cols = (image_to_display.cols + 1) / 2;
 
+                    // Optional quantization: snap each cell's tint to a palette.
+                    var palette_buf: [256]quantize.Rgb = undefined;
+                    const color_lut: ?quantize.ColorLookupTable = if (config.color) blk: {
+                        const mode = config.palette orelse break :blk null;
+                        const size = quantize.buildPalette(T, allocator, image_to_display.*, mode, &palette_buf);
+                        break :blk quantize.getPaletteLut(mode, palette_buf[0..size]);
+                    } else null;
+
                     for (0..block_rows) |block_row| {
+                        // Re-emit the fg escape only when the cell color changes.
+                        var last_color: ?Rgb = null;
                         for (0..block_cols) |block_col| {
                             var pattern: u8 = 0;
+                            // Accumulate lit-dot colors for the cell tint.
+                            var sum_r: u32 = 0;
+                            var sum_g: u32 = 0;
+                            var sum_b: u32 = 0;
+                            var lit: u32 = 0;
 
                             for (0..4) |dy| {
                                 for (0..2) |dx| {
@@ -193,11 +227,32 @@ pub fn DisplayFormatter(comptime T: type) type {
                                     const x = block_col * 2 + dx;
 
                                     if (y < image_to_display.rows and x < image_to_display.cols) {
-                                        const brightness = color.convertColor(f32, image_to_display.at(y, x).*);
+                                        const pixel = image_to_display.at(y, x).*;
+                                        const brightness = color.convertColor(f32, pixel);
                                         if (brightness > config.threshold) {
                                             pattern |= @as(u8, 1) << braille_bits[dy][dx];
+                                            if (config.color) {
+                                                const rgb = color.convertColor(Rgb, pixel);
+                                                sum_r += rgb.r;
+                                                sum_g += rgb.g;
+                                                sum_b += rgb.b;
+                                                lit += 1;
+                                            }
                                         }
                                     }
+                                }
+                            }
+
+                            if (config.color and lit > 0) {
+                                var rgb: Rgb = .{
+                                    .r = @intCast(sum_r / lit),
+                                    .g = @intCast(sum_g / lit),
+                                    .b = @intCast(sum_b / lit),
+                                };
+                                if (color_lut) |lut| rgb = palette_buf[lut.lookup(rgb)];
+                                if (last_color == null or !std.meta.eql(rgb, last_color.?)) {
+                                    try writer.print("\x1b[38;2;{d};{d};{d}m", .{ rgb.r, rgb.g, rgb.b });
+                                    last_color = rgb;
                                 }
                             }
 
@@ -208,6 +263,7 @@ pub fn DisplayFormatter(comptime T: type) type {
                                 0x80 | (pattern & 0x3F),
                             });
                         }
+                        if (config.color) try writer.writeAll("\x1b[0m");
                         if (block_row < block_rows - 1) try writer.writeByte('\n');
                     }
                 },

--- a/src/image/quantize.zig
+++ b/src/image/quantize.zig
@@ -7,6 +7,7 @@
 //! - Fixed palette generators: 6x7x6 (252 colors), web-safe 216, VGA-16.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
 const convertColor = @import("../color.zig").convertColor;
@@ -470,3 +471,93 @@ pub const vga16_palette = [16]Rgb{
     Rgb{ .r = 0, .g = 255, .b = 255 }, // Cyan
     Rgb{ .r = 255, .g = 255, .b = 255 }, // White
 };
+
+/// Palette generation strategy shared by sixel, braille, and other renderers.
+pub const PaletteMode = union(enum) {
+    /// Fixed 252-color palette with 6x7x6 RGB distribution
+    fixed_6x7x6,
+    /// Fixed 16-color VGA palette
+    fixed_vga16,
+    /// Fixed 216-color web-safe palette (6x6x6 RGB cube)
+    fixed_web216,
+    /// Adaptive palette using median cut algorithm
+    adaptive: struct {
+        /// Maximum colors for adaptive palette (1-256)
+        max_colors: u16 = 256,
+    },
+
+    /// Get the palette size for this mode
+    pub fn size(self: PaletteMode) usize {
+        return switch (self) {
+            .fixed_6x7x6 => 252, // 6*7*6 = 252 colors
+            .fixed_vga16 => 16, // Standard VGA palette
+            .fixed_web216 => 216, // 6*6*6 = 216 web-safe colors
+            .adaptive => |opts| @min(opts.max_colors, 256),
+        };
+    }
+};
+
+/// Fills `palette` according to `mode` and returns the number of colors written.
+/// Adaptive generation falls back to the fixed 6x7x6 palette if allocation fails.
+pub fn buildPalette(
+    comptime T: type,
+    gpa: Allocator,
+    image: Image(T),
+    mode: PaletteMode,
+    palette: *[256]Rgb,
+) usize {
+    return switch (mode) {
+        .fixed_6x7x6 => blk: {
+            fixed6x7x6Palette(palette);
+            break :blk 252;
+        },
+        .fixed_vga16 => blk: {
+            @memcpy(palette[0..16], &vga16_palette);
+            break :blk 16;
+        },
+        .fixed_web216 => blk: {
+            web216Palette(palette);
+            break :blk 216;
+        },
+        .adaptive => |opts| medianCut(T, gpa, image, palette, opts.max_colors) catch blk: {
+            fixed6x7x6Palette(palette);
+            break :blk 252;
+        },
+    };
+}
+
+/// Cache of `ColorLookupTable`s for the fixed palettes — avoids rebuilding the
+/// 32x32x32 LUT on every render. Adaptive palettes get a fresh LUT each call.
+const PaletteLutCache = struct {
+    var lock_val = std.atomic.Value(u32).init(0);
+    var fixed_6x7x6: ?ColorLookupTable = null;
+    var fixed_vga16: ?ColorLookupTable = null;
+    var fixed_web216: ?ColorLookupTable = null;
+
+    fn getOrInit(cache_field: *?ColorLookupTable, palette: []const Rgb) ColorLookupTable {
+        if (!builtin.single_threaded) {
+            while (lock_val.swap(1, .acquire) != 0) {
+                std.Thread.yield() catch |err| std.debug.panic("Thread.yield failed: {s}", .{@errorName(err)});
+            }
+        }
+        defer if (!builtin.single_threaded) lock_val.store(0, .release);
+
+        if (cache_field.*) |cached| {
+            return cached;
+        }
+        const lut: ColorLookupTable = .init(palette);
+        cache_field.* = lut;
+        return lut;
+    }
+};
+
+/// Returns a nearest-color lookup table for `palette`, caching the result for
+/// fixed palettes and building a fresh one for adaptive palettes.
+pub fn getPaletteLut(mode: PaletteMode, palette: []const Rgb) ColorLookupTable {
+    return switch (mode) {
+        .fixed_6x7x6 => PaletteLutCache.getOrInit(&PaletteLutCache.fixed_6x7x6, palette),
+        .fixed_vga16 => PaletteLutCache.getOrInit(&PaletteLutCache.fixed_vga16, palette),
+        .fixed_web216 => PaletteLutCache.getOrInit(&PaletteLutCache.fixed_web216, palette),
+        .adaptive => .init(palette),
+    };
+}

--- a/src/image/tests/display.zig
+++ b/src/image/tests/display.zig
@@ -37,6 +37,27 @@ test "image format sgr" {
     try expectEqualStrings(expected, result);
 }
 
+test "image format sgr coalesces repeated colors" {
+    const Rgb = color.Rgb(u8);
+
+    // 2x2 solid red: both cells share the same fg/bg pair, so the escape is emitted once.
+    var image = try Image(Rgb).init(std.testing.allocator, 2, 2);
+    defer image.deinit(std.testing.allocator);
+    for (0..2) |r| {
+        for (0..2) |c| image.at(r, c).* = Rgb.red;
+    }
+
+    var buffer: [256]u8 = undefined;
+    var stream = Io.Writer.fixed(&buffer);
+
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .sgr = .default })});
+    const result = buffer[0..stream.end];
+
+    const expected = "\x1b[38;2;255;0;0;48;2;255;0;0m▀▀\x1b[0m";
+
+    try expectEqualStrings(expected, result);
+}
+
 test "image format sgr odd rows" {
     const Rgb = color.Rgb(u8);
 
@@ -93,7 +114,7 @@ test "image format braille" {
     var buffer: [256]u8 = undefined;
     var stream = Io.Writer.fixed(&buffer);
 
-    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .default })});
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{ .color = false } })});
     const result = buffer[0..stream.end];
 
     // Expected pattern: dots 2, 4, 6, 8 are on (white pixels)
@@ -126,7 +147,7 @@ test "image format braille custom threshold" {
     var buffer: [256]u8 = undefined;
     var stream = Io.Writer.fixed(&buffer);
 
-    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{ .threshold = 0.3 } })});
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{ .threshold = 0.3, .color = false } })});
     const result = buffer[0..stream.end];
 
     // Expected: pixels with >30% brightness are on
@@ -161,7 +182,7 @@ test "image format braille large image" {
     var buffer: [256]u8 = undefined;
     var stream = Io.Writer.fixed(&buffer);
 
-    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .default })});
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{ .color = false } })});
     const result = buffer[0..stream.end];
 
     // Expected: checkerboard pattern creates same pattern in all blocks
@@ -172,6 +193,85 @@ test "image format braille large image" {
     // B W
     // All blocks have the same pattern because checkerboard is regular
     const expected = "⢕⢕\n⢕⢕";
+
+    try expectEqualStrings(expected, result);
+}
+
+test "image format braille color" {
+    const Rgb = color.Rgb(u8);
+
+    // 4x2 image: lit (bright) pixels are colored, dark pixels stay off.
+    var image = try Image(Rgb).init(std.testing.allocator, 4, 2);
+    defer image.deinit(std.testing.allocator);
+
+    // Same diagonal as the monochrome test, but the white dots are red instead.
+    image.at(0, 0).* = Rgb.black;
+    image.at(0, 1).* = Rgb.red;
+    image.at(1, 0).* = Rgb.red;
+    image.at(1, 1).* = Rgb.black;
+    image.at(2, 0).* = Rgb.black;
+    image.at(2, 1).* = Rgb.red;
+    image.at(3, 0).* = Rgb.red;
+    image.at(3, 1).* = Rgb.black;
+
+    var buffer: [256]u8 = undefined;
+    var stream = Io.Writer.fixed(&buffer);
+
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{ .threshold = 0.2 } })});
+    const result = buffer[0..stream.end];
+
+    // Lit dots are all pure red, so the cell is tinted red, then reset at line end.
+    // Pattern is the same ⡪ as the monochrome diagonal test.
+    const expected = "\x1b[38;2;255;0;0m⡪\x1b[0m";
+
+    try expectEqualStrings(expected, result);
+}
+
+test "image format braille palette snaps tint" {
+    const Rgb = color.Rgb(u8);
+
+    var image = try Image(Rgb).init(std.testing.allocator, 4, 2);
+    defer image.deinit(std.testing.allocator);
+
+    // A single off-primary red dot; the VGA-16 palette should snap it to pure red.
+    for (0..4) |r| {
+        for (0..2) |c| image.at(r, c).* = Rgb.black;
+    }
+    image.at(0, 0).* = Rgb{ .r = 200, .g = 20, .b = 10 };
+
+    var buffer: [256]u8 = undefined;
+    var stream = Io.Writer.fixed(&buffer);
+
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .{
+        .threshold = 0.1,
+        .palette = .fixed_vga16,
+    } })});
+    const result = buffer[0..stream.end];
+
+    // Only dot 1 (bit 0) is lit -> 0x2801 = ⠁, tinted with the nearest VGA color (red).
+    const expected = "\x1b[38;2;255;0;0m⠁\x1b[0m";
+
+    try expectEqualStrings(expected, result);
+}
+
+test "image format braille coalesces repeated colors" {
+    const Rgb = color.Rgb(u8);
+
+    // 4x4 solid white: two full cells in the row share one color, so one escape is emitted.
+    var image = try Image(Rgb).init(std.testing.allocator, 4, 4);
+    defer image.deinit(std.testing.allocator);
+    for (0..4) |r| {
+        for (0..4) |c| image.at(r, c).* = Rgb.white;
+    }
+
+    var buffer: [256]u8 = undefined;
+    var stream = Io.Writer.fixed(&buffer);
+
+    try stream.print("{f}", .{image.display(std.testing.io, .{ .braille = .default })});
+    const result = buffer[0..stream.end];
+
+    // Both 4x2 blocks are fully lit -> 0x28FF = ⣿; color escape emitted once, reset at row end.
+    const expected = "\x1b[38;2;255;255;255m⣿⣿\x1b[0m";
 
     try expectEqualStrings(expected, result);
 }

--- a/src/sixel.zig
+++ b/src/sixel.zig
@@ -18,34 +18,8 @@ const rle = @import("rle.zig");
 const terminal = @import("terminal.zig");
 
 const Rgb = quantize.Rgb;
-const ColorLookupTable = quantize.ColorLookupTable;
 const sixel_char_offset: u8 = '?'; // ASCII 63 - base for sixel characters
 const max_supported_width: usize = 2048;
-
-/// Available palette modes for sixel encoding
-pub const PaletteMode = union(enum) {
-    /// Fixed 252-color palette with 6x7x6 RGB distribution
-    fixed_6x7x6,
-    /// Fixed 16-color VGA palette
-    fixed_vga16,
-    /// Fixed 216-color web-safe palette (6x6x6 RGB cube)
-    fixed_web216,
-    /// Adaptive palette using median cut algorithm
-    adaptive: struct {
-        /// Maximum colors for adaptive palette (1-256)
-        max_colors: u16 = 256,
-    },
-
-    /// Get the palette size for this mode
-    pub fn size(self: PaletteMode) usize {
-        return switch (self) {
-            .fixed_6x7x6 => 252, // 6*7*6 = 252 colors
-            .fixed_vga16 => 16, // Standard VGA palette
-            .fixed_web216 => 216, // 6*6*6 = 216 web-safe colors
-            .adaptive => |opts| @min(opts.max_colors, 256),
-        };
-    }
-};
 
 /// Dithering modes for color quantization (alias for the shared `dither.Mode`).
 pub const DitherMode = dither.Mode;
@@ -53,7 +27,7 @@ pub const DitherMode = dither.Mode;
 /// Options for sixel encoding
 pub const Options = struct {
     /// Palette generation mode
-    palette: PaletteMode = .{ .adaptive = .{ .max_colors = 256 } },
+    palette: quantize.PaletteMode = .{ .adaptive = .{ .max_colors = 256 } },
     /// Dithering algorithm to use
     dither: DitherMode = .auto,
     /// Target width (null = original width preserved, scaling fits aspect ratio)
@@ -162,28 +136,11 @@ pub fn fromImageProfiled(
     }
 
     var palette: [256]Rgb = undefined;
-    var palette_size: usize = options.palette.size();
 
     var palette_start: u64 = 0;
     if (profiler != null) palette_start = monotonicNs();
 
-    switch (options.palette) {
-        .fixed_6x7x6 => {
-            quantize.fixed6x7x6Palette(&palette);
-        },
-        .fixed_vga16 => {
-            @memcpy(palette[0..16], &quantize.vga16_palette);
-        },
-        .fixed_web216 => {
-            quantize.web216Palette(&palette);
-        },
-        .adaptive => |adaptive_opts| {
-            palette_size = quantize.medianCut(T, gpa, image, &palette, adaptive_opts.max_colors) catch blk: {
-                quantize.fixed6x7x6Palette(&palette);
-                break :blk 252;
-            };
-        },
-    }
+    const palette_size = quantize.buildPalette(T, gpa, image, options.palette, &palette);
 
     if (profiler) |p| {
         p.palette_ns += monotonicNs() - palette_start;
@@ -191,7 +148,7 @@ pub fn fromImageProfiled(
 
     var lut_start: u64 = 0;
     if (profiler != null) lut_start = monotonicNs();
-    const color_lut = PaletteLutCache.get(options.palette, palette[0..palette_size]);
+    const color_lut = quantize.getPaletteLut(options.palette, palette[0..palette_size]);
     if (profiler) |p| {
         p.lut_ns += monotonicNs() - lut_start;
     }
@@ -466,40 +423,6 @@ pub fn fromImageProfiled(
 
     return output.toOwnedSlice(gpa);
 }
-
-/// Cache of `ColorLookupTable`s for sixel's fixed palettes — avoids rebuilding the
-/// 32x32x32 LUT for every sixel render. Adaptive palettes get a fresh LUT.
-const PaletteLutCache = struct {
-    var lock_val = std.atomic.Value(u32).init(0);
-    var fixed_6x7x6: ?ColorLookupTable = null;
-    var fixed_vga16: ?ColorLookupTable = null;
-    var fixed_web216: ?ColorLookupTable = null;
-
-    fn getOrInit(cache_field: *?ColorLookupTable, palette: []const Rgb) ColorLookupTable {
-        if (!builtin.single_threaded) {
-            while (lock_val.swap(1, .acquire) != 0) {
-                std.Thread.yield() catch |err| std.debug.panic("Thread.yield failed: {s}", .{@errorName(err)});
-            }
-        }
-        defer if (!builtin.single_threaded) lock_val.store(0, .release);
-
-        if (cache_field.*) |cached| {
-            return cached;
-        }
-        const lut: ColorLookupTable = .init(palette);
-        cache_field.* = lut;
-        return lut;
-    }
-
-    fn get(mode: PaletteMode, palette: []const Rgb) ColorLookupTable {
-        return switch (mode) {
-            .fixed_6x7x6 => getOrInit(&PaletteLutCache.fixed_6x7x6, palette),
-            .fixed_vga16 => getOrInit(&PaletteLutCache.fixed_vga16, palette),
-            .fixed_web216 => getOrInit(&PaletteLutCache.fixed_web216, palette),
-            .adaptive => .init(palette),
-        };
-    }
-};
 
 /// Checks if the terminal supports sixel graphics
 pub fn isSupported(io: std.Io) bool {


### PR DESCRIPTION
Moves palette generation and LUT caching to `quantize.zig` to share between Sixel and Braille renderers. Adds color tinting and palette quantization to Braille display mode. Optimizes SGR and Braille rendering by coalescing repeated ANSI color escapes.