### PR TITLE
build: bump minimum zig version to 0.17.0-dev.813

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -135,7 +135,7 @@ pub fn build(b: *Build) void {
             .imports = &.{.{ .name = "zignal", .module = zignal }},
         }),
     });
-    linkPython(b, py_module, target, "python3");
+    linkPython(b, py_module, target, optimize, "python3");
 
     const extension = switch (os_tag) {
         .windows => ".pyd",
@@ -157,11 +157,11 @@ pub fn build(b: *Build) void {
         .root_module = b.createModule(.{
             .root_source_file = b.path("bindings/python/src/generate_stubs.zig"),
             .target = target,
-            .optimize = .Debug,
+            .optimize = optimize,
             .imports = &.{.{ .name = "zignal", .module = zignal }},
         }),
     });
-    linkPython(b, stub_generator, target, "python3-embed");
+    linkPython(b, stub_generator, target, optimize, "python3-embed");
 
     // Run stub generator in the python bindings directory
     const run_stub_generator = b.addRunArtifact(stub_generator);
@@ -280,6 +280,7 @@ fn linkPython(
     b: *Build,
     artifact: *Build.Step.Compile,
     target: Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
     python_lib: []const u8,
 ) void {
     const root = artifact.root_module;
@@ -289,11 +290,7 @@ fn linkPython(
     const tc = b.addTranslateC(.{
         .root_source_file = b.path("bindings/python/src/c.h"),
         .target = target,
-        // Pin to Debug: translate-c in zig 0.17.0-dev.690 rejects the `-O<mode>`
-        // flag it emits for Release modes ("unrecognized optimization mode").
-        // Fixed upstream by ziglang/translate-c#375 (commit 57924d2, zig-dev.772+).
-        // TODO: revert to `optimize` once the pinned zig includes that fix.
-        .optimize = .Debug,
+        .optimize = optimize,
     });
     // On Windows the interpreter supplies the include path (no pkg-config);
     // translate-c only needs `-I`, it never links libpython.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal,
     .version = "0.11.0-dev",
     .fingerprint = 0x5303c43db377b63a,
-    .minimum_zig_version = "0.17.0-dev.690+c5a61e899",
+    .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zignal_examples,
     .version = "0.0.0",
     .fingerprint = 0xcf70e6a9b7002db6,
-    .minimum_zig_version = "0.17.0-dev.690+c5a61e899",
+    .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .zignal = .{
             .path = "../",

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -240,20 +240,6 @@ const State = struct {
         }
     }
 
-    /// Index of a control character in `termios.cc`. `std.posix.V` fails to
-    /// compile on Linux in Zig `0.17.0-dev.690` (std bug: `arch_bits == .alpha`),
-    /// so compute the index directly there and defer to `std.posix.V` elsewhere.
-    fn ccIndex(comptime field: enum { MIN, TIME }) usize {
-        if (builtin.os.tag == .linux) {
-            const arch = builtin.cpu.arch;
-            return switch (field) {
-                .MIN => if (arch.isMIPS()) 4 else if (arch.isPowerPC()) 5 else if (arch == .alpha) 16 else 6,
-                .TIME => if (arch.isMIPS()) 5 else if (arch.isPowerPC()) 7 else if (arch == .alpha) 17 else 5,
-            };
-        }
-        return @intFromEnum(@field(std.posix.V, @tagName(field)));
-    }
-
     /// Enter raw mode for reading terminal responses
     ///
     /// Disables canonical mode and echo to allow reading individual characters
@@ -273,8 +259,8 @@ const State = struct {
                     raw.lflag.ECHO = false;
 
                     // Set minimum characters and timeout
-                    raw.cc[ccIndex(.MIN)] = 0;
-                    raw.cc[ccIndex(.TIME)] = 1; // 0.1 second timeout
+                    raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
+                    raw.cc[@intFromEnum(std.posix.V.TIME)] = 1; // 0.1 second timeout
 
                     try std.posix.tcsetattr(self.stdin.handle, .FLUSH, raw);
                 }


### PR DESCRIPTION
Removes workarounds for translate-c and std.posix.V bugs.