### PR TITLE
refactor(optimization): clean up and simplify codebase

### DIFF
--- a/examples/src/optimization_example.zig
+++ b/examples/src/optimization_example.zig
@@ -89,7 +89,7 @@ pub fn main() !void {
     std.debug.print("== Rosenbrock (global minimum at (1, 1)) ==\n", .{});
     {
         const variables = [_]Variable{ .{ .lower = -5, .upper = 5 }, .{ .lower = -5, .upper = 5 } };
-        var res = try findGlobalOptimum(io, gpa, rosen, &variables, 150, .min_default);
+        var res = try findGlobalOptimum(io, gpa, rosen, &variables, .{ .max_evals = 150 }, .min_default);
         defer res.deinit(gpa);
         printVec("  solution x = ", res.x);
         std.debug.print("  solution y = {d:.6}\n\n", .{res.y});
@@ -110,7 +110,7 @@ pub fn main() !void {
         // `max_concurrency > 1` evaluates several candidates at once on the thread pool above. These
         // toy objectives are too cheap to show a wall-clock win, but a costly thread-safe objective
         // would scale across cores.
-        var res = try findGlobalOptimum(io, gpa, beLikeTarget, &variables, 200, .{ .policy = .min, .max_concurrency = 4 });
+        var res = try findGlobalOptimum(io, gpa, beLikeTarget, &variables, .{ .max_evals = 200 }, .{ .policy = .min, .max_concurrency = 4 });
         defer res.deinit(gpa);
         printVec("  solution x = ", res.x);
         std.debug.print("  solution y = {d:.6}\n\n", .{res.y});

--- a/src/optimization/assignment.zig
+++ b/src/optimization/assignment.zig
@@ -64,10 +64,10 @@ pub fn solveAssignmentProblem(
             // so accumulated u/v potentials and padding_value can't overflow. `+ 1` guards num_elements == 0.
             const precision_range = 1e12;
             const max_total = 4e18;
-            const num_elements: f64 = @floatFromInt(n_rows * n_cols);
+            const num_elements: f64 = n_rows * n_cols;
             scale_factor = @min(precision_range, max_total / (num_elements + 1.0)) / max_abs;
         }
-        padding_value = @as(i64, @intFromFloat(@ceil(sum_abs * scale_factor))) + 1;
+        padding_value = @as(i64, @ceil(sum_abs * scale_factor)) + 1;
     } else {
         var sum_abs: u64 = 0;
         for (cost_matrix.items) |val_raw| {
@@ -90,15 +90,13 @@ pub fn solveAssignmentProblem(
     const row_covered = try aa.alloc(bool, n);
     const col_covered = try aa.alloc(bool, n);
 
+    const sign: f64 = @floatFromInt(multiplier);
     for (0..n) |i| {
         for (0..n) |j| {
             if (i < n_rows and j < n_cols) {
                 const base_val = cost_matrix.at(i, j).*;
                 work[i * n + j] = switch (@typeInfo(T)) {
-                    .float => blk: {
-                        const scaled = as(f64, base_val) * @as(f64, @floatFromInt(multiplier)) * scale_factor;
-                        break :blk @round(scaled);
-                    },
+                    .float => @round(as(f64, base_val) * sign * scale_factor),
                     .int => @as(i64, base_val) * multiplier,
                     else => @compileError("Unsupported type for cost matrix"),
                 };
@@ -108,10 +106,7 @@ pub fn solveAssignmentProblem(
         }
     }
     for (0..n) |i| {
-        var min_val = work[i * n];
-        for (0..n) |j| {
-            min_val = @min(min_val, work[i * n + j]);
-        }
+        const min_val = std.mem.min(i64, work[i * n ..][0..n]);
         if (min_val != 0) {
             for (0..n) |j| {
                 work[i * n + j] -= min_val;
@@ -187,21 +182,15 @@ pub fn solveAssignmentProblem(
     var total_cost: f64 = 0;
     var result_assignments = try allocator.alloc(?u32, n_rows);
     for (0..n_rows) |i| {
-        if (row_assignment[i]) |col| {
-            if (col < n_cols) {
-                result_assignments[i] = col;
-                // Use original cost matrix values (not the multiplied work matrix)
-                const cost_val = cost_matrix.at(i, col).*;
-                total_cost += as(f64, cost_val);
-            } else {
-                result_assignments[i] = null;
-            }
-        } else {
-            result_assignments[i] = null;
-        }
+        result_assignments[i] = null;
+        if (row_assignment[i]) |col| if (col < n_cols) {
+            result_assignments[i] = col;
+            // Use original cost matrix values (not the multiplied work matrix)
+            total_cost += as(f64, cost_matrix.at(i, col).*);
+        };
     }
 
-    return Assignment{
+    return .{
         .assignments = result_assignments,
         .total_cost = total_cost,
         .allocator = allocator,

--- a/src/optimization/global_search.zig
+++ b/src/optimization/global_search.zig
@@ -22,6 +22,7 @@ const Io = std.Io;
 const expectApproxEqAbs = std.testing.expectApproxEqAbs;
 
 const tr = @import("trust_region.zig");
+const vec = @import("vec.zig");
 const UpperBound = @import("lipschitz.zig").UpperBound;
 const OptimizationPolicy = @import("../optimization.zig").OptimizationPolicy;
 
@@ -72,22 +73,18 @@ pub const GlobalOptimizer = struct {
     pool: ?WorkerPool,
     arena: std.heap.ArenaAllocator,
 
-    pub const WorkerPool = struct {
+    const WorkerPool = struct {
         outstanding_x: []f64,
         outstanding_y: []f64,
-        outstanding_predicted: []f64,
-        outstanding_anchor: []f64,
-        outstanding_move: []Move,
+        outstanding_ask: []Ask,
         outstanding_active: []bool,
         scratch_pending_x: []f64,
         scratch_pending_y: []f64,
 
-        pub fn deinit(self: *WorkerPool, allocator: Allocator) void {
+        fn deinit(self: *WorkerPool, allocator: Allocator) void {
             allocator.free(self.outstanding_x);
             allocator.free(self.outstanding_y);
-            allocator.free(self.outstanding_predicted);
-            allocator.free(self.outstanding_anchor);
-            allocator.free(self.outstanding_move);
+            allocator.free(self.outstanding_ask);
             allocator.free(self.outstanding_active);
             allocator.free(self.scratch_pending_x);
             allocator.free(self.scratch_pending_y);
@@ -183,19 +180,15 @@ pub const GlobalOptimizer = struct {
         const scratch = try allocator.alloc(f64, dims);
         errdefer allocator.free(scratch);
 
-        const mc = @max(@as(usize, 1), options.max_concurrency);
+        const mc = @max(1, options.max_concurrency);
         var pool: ?WorkerPool = null;
         if (mc > 1) {
             const outstanding_x = try allocator.alloc(f64, mc * dims);
             errdefer allocator.free(outstanding_x);
             const outstanding_y = try allocator.alloc(f64, mc);
             errdefer allocator.free(outstanding_y);
-            const outstanding_predicted = try allocator.alloc(f64, mc);
-            errdefer allocator.free(outstanding_predicted);
-            const outstanding_anchor = try allocator.alloc(f64, mc);
-            errdefer allocator.free(outstanding_anchor);
-            const outstanding_move = try allocator.alloc(Move, mc);
-            errdefer allocator.free(outstanding_move);
+            const outstanding_ask = try allocator.alloc(Ask, mc);
+            errdefer allocator.free(outstanding_ask);
             const outstanding_active = try allocator.alloc(bool, mc);
             errdefer allocator.free(outstanding_active);
             @memset(outstanding_active, false);
@@ -207,9 +200,7 @@ pub const GlobalOptimizer = struct {
             pool = .{
                 .outstanding_x = outstanding_x,
                 .outstanding_y = outstanding_y,
-                .outstanding_predicted = outstanding_predicted,
-                .outstanding_anchor = outstanding_anchor,
-                .outstanding_move = outstanding_move,
+                .outstanding_ask = outstanding_ask,
                 .outstanding_active = outstanding_active,
                 .scratch_pending_x = pending_x,
                 .scratch_pending_y = pending_y,
@@ -259,15 +250,14 @@ pub const GlobalOptimizer = struct {
     pub fn addEvaluation(self: *GlobalOptimizer, eval: Evaluation) !void {
         if (eval.x.len != self.variables.len) return GlobalError.DimensionMismatch;
         // A warm-start point is a seed, not a trust-region step → treat it like an `.init` move.
-        try self.record(eval.x, self.sign * eval.y, .init, 0, 0);
+        try self.record(eval.x, self.sign * eval.y, .{ .move = .init });
     }
 
     /// Perform one ask+evaluate+tell iteration and return what happened.
     pub fn step(self: *GlobalOptimizer, objective: anytype) !Step {
         const a = try self.ask(self.last_x);
         const y_raw = callObjective(objective, self.last_x);
-        try self.record(self.last_x, self.sign * y_raw, a.move, a.predicted, a.anchor);
-        self.evals += 1;
+        try self.tell(self.last_x, y_raw, a);
         return .{
             .point = .{ .x = self.last_x, .y = y_raw },
             .move = a.move,
@@ -325,9 +315,7 @@ pub const GlobalOptimizer = struct {
                         return;
                     };
                     pool.outstanding_y[slot] = opt.upper_bound.nearestY(xslot);
-                    pool.outstanding_move[slot] = a.move;
-                    pool.outstanding_predicted[slot] = a.predicted;
-                    pool.outstanding_anchor[slot] = a.anchor;
+                    pool.outstanding_ask[slot] = a;
                     pool.outstanding_active[slot] = true;
                     sh.dispatched += 1;
                     sh.mutex.unlock(w_io);
@@ -336,12 +324,11 @@ pub const GlobalOptimizer = struct {
 
                     sh.mutex.lockUncancelable(w_io);
                     pool.outstanding_active[slot] = false;
-                    opt.record(xslot, opt.sign * y_raw, pool.outstanding_move[slot], pool.outstanding_predicted[slot], pool.outstanding_anchor[slot]) catch |e| {
+                    opt.tell(xslot, y_raw, pool.outstanding_ask[slot]) catch |e| {
                         sh.err = e;
                         sh.mutex.unlock(w_io);
                         return;
                     };
-                    opt.evals += 1;
                     if (opt.shouldStop(st, opt.best_y.?, &sh.state)) sh.stopped = true;
                     sh.mutex.unlock(w_io);
                 }
@@ -400,18 +387,22 @@ pub const GlobalOptimizer = struct {
 
         var npending: usize = 0;
         var tr_outstanding = false;
+        var pending_x: []const f64 = &.{};
+        var pending_y: []const f64 = &.{};
         if (self.pool) |*pool| {
-            for (0..pool.outstanding_active.len) |j| {
-                if (!pool.outstanding_active[j]) continue;
+            for (pool.outstanding_active, 0..) |is_active, j| {
+                if (!is_active) continue;
                 @memcpy(pool.scratch_pending_x[npending * dims ..][0..dims], pool.outstanding_x[j * dims ..][0..dims]);
                 pool.scratch_pending_y[npending] = pool.outstanding_y[j];
-                if (pool.outstanding_move[j] == .exploit) tr_outstanding = true;
+                if (pool.outstanding_ask[j].move == .exploit) tr_outstanding = true;
                 npending += 1;
             }
+            pending_x = pool.scratch_pending_x[0 .. npending * dims];
+            pending_y = pool.scratch_pending_y[0..npending];
         }
 
         const real_n = self.upper_bound.numPoints();
-        const init_budget = @max(@as(usize, 3), dims);
+        const init_budget = @max(3, dims);
 
         if (real_n + npending < init_budget) {
             if (real_n + npending == 0) self.centerVector(x_out) else self.randomVector(x_out);
@@ -433,8 +424,6 @@ pub const GlobalOptimizer = struct {
 
         self.do_trust_region_step = true;
         if (self.prng.random().float(f64) >= self.pure_random_probability) {
-            const pending_x: []const f64 = if (self.pool) |*pool| pool.scratch_pending_x[0 .. npending * dims] else &.{};
-            const pending_y: []const f64 = if (self.pool) |*pool| pool.scratch_pending_y[0..npending] else &.{};
             if (self.pickMaxUpperBound(pending_x, pending_y, x_out)) {
                 return .{ .move = .explore };
             }
@@ -443,20 +432,20 @@ pub const GlobalOptimizer = struct {
         return .{ .move = .random };
     }
 
-    /// Tell: incorporate an evaluated point produced by `move`, adapt the trust-region radius,
+    /// Complete one ask-tell transaction: incorporate the raw (caller-sign) objective value for a
+    /// point produced by `ask` and count the evaluation. Shared by `step()` and the pooled workers.
+    fn tell(self: *GlobalOptimizer, x: []const f64, y_raw: f64, a: Ask) !void {
+        try self.record(x, self.sign * y_raw, a);
+        self.evals += 1;
+    }
+
+    /// Tell: incorporate an evaluated point produced by `a.move`, adapt the trust-region radius,
     /// update the best. Only `.exploit` evaluations drive the radius adaptation.
-    fn record(
-        self: *GlobalOptimizer,
-        x: []const f64,
-        y_internal: f64,
-        move: Move,
-        predicted: f64,
-        anchor: f64,
-    ) !void {
+    fn record(self: *GlobalOptimizer, x: []const f64, y_internal: f64, a: Ask) !void {
         try self.upper_bound.add(x, y_internal);
 
-        if (move == .exploit and predicted != 0) {
-            const rho = (y_internal - anchor) / @abs(predicted);
+        if (a.move == .exploit and a.predicted != 0) {
+            const rho = (y_internal - a.anchor) / @abs(a.predicted);
             if (rho < 0.25) {
                 self.radius *= 0.5;
             } else if (rho > 0.75) {
@@ -465,7 +454,7 @@ pub const GlobalOptimizer = struct {
         }
 
         if (self.best_y == null or y_internal > self.best_y.?) {
-            if (move != .exploit and self.best_y != null and tr.dist(x, self.best_x) > self.radius * 1.001) {
+            if (a.move != .exploit and self.best_y != null and vec.dist(x, self.best_x) > self.radius * 1.001) {
                 self.radius = 0;
             }
             @memcpy(self.best_x, x);
@@ -508,26 +497,19 @@ pub const GlobalOptimizer = struct {
         const is_integer = vars.items(.is_integer);
         @memcpy(x_out, self.best_x);
 
-        // Active (continuous) dimensions only — integer variables are held at the best value.
-        var da: usize = 0;
-        for (0..dims) |k| {
-            if (!is_integer[k]) da += 1;
-        }
-        if (da == 0) return 0;
-
         defer _ = self.arena.reset(.retain_capacity);
         const a = self.arena.allocator();
 
-        const active = try a.alloc(usize, da);
-        {
-            var j: usize = 0;
-            for (0..dims) |k| {
-                if (!is_integer[k]) {
-                    active[j] = k;
-                    j += 1;
-                }
+        // Active (continuous) dimensions only — integer variables are held at the best value.
+        const active = try a.alloc(usize, dims);
+        var da: usize = 0;
+        for (0..dims) |k| {
+            if (!is_integer[k]) {
+                active[da] = k;
+                da += 1;
             }
         }
+        if (da == 0) return 0;
 
         const n = self.upper_bound.numPoints();
         const k_full = (da + 1) * (da + 2) / 2;
@@ -536,7 +518,7 @@ pub const GlobalOptimizer = struct {
         // N nearest neighbors of best_x (full-space distance squared).
         const DistIdx = struct { d: f64, idx: usize };
         const dists = try a.alloc(DistIdx, n);
-        for (0..n) |i| dists[i] = .{ .d = tr.distSq(self.best_x, self.upper_bound.pointX(i)), .idx = i };
+        for (0..n) |i| dists[i] = .{ .d = vec.distSq(self.best_x, self.upper_bound.pointX(i)), .idx = i };
         std.mem.sort(DistIdx, dists, {}, struct {
             fn lt(_: void, p: DistIdx, q: DistIdx) bool {
                 return p.d < q.d;
@@ -589,18 +571,14 @@ pub const GlobalOptimizer = struct {
         try tr.solveTrustRegionSubproblemBounded(a, bneg, gneg, self.radius, lo_rel, hi_rel, p, .{});
 
         // Never move more than the radius (guards against inaccurate sub-problem solves).
-        const pn = tr.norm(p);
-        if (pn >= self.radius and pn > 0) {
+        const pn = vec.norm(p);
+        if (pn >= self.radius) {
             const scale = self.radius / pn;
             for (0..da) |i| p[i] *= scale;
         }
 
         // predicted improvement of the model = Q(p) - Q(0).
-        var predicted: f64 = 0;
-        for (0..da) |i| {
-            predicted += g[i] * p[i];
-            for (0..da) |jj| predicted += 0.5 * p[i] * h[i * da + jj] * p[jj];
-        }
+        const predicted = tr.evalQuad(h, g, 0, da, p);
 
         // Reinsert active dims into the full candidate (integer dims keep best_x's value).
         for (0..da) |i| {
@@ -638,22 +616,22 @@ fn sampleInBox(buf: []f64, lower: []const f64, upper: []const f64, is_integer: [
 // One-shot convenience wrapper
 // ---------------------------------------------------------------------------------------
 
-/// Optimize `objective` over the given `variables` (one `Variable` per dimension) using up to `max_evals`
-/// function evaluations. `io` runs the evaluations (single-threaded inline, or parallel on a pooled
-/// `Io` when `options.max_concurrency > 1`). `options` is the same `GlobalOptimizer.Options` the struct
-/// API takes — pass `.min_default` or `.max_default` (or a full literal). The returned `Evaluation`
-/// owns its `x`; free it via `result.deinit(allocator)`.
+/// Optimize `objective` over the given `variables` (one `Variable` per dimension) until `stop` is
+/// hit (e.g. `.{ .max_evals = 100 }`). `io` runs the evaluations (single-threaded inline, or parallel
+/// on a pooled `Io` when `options.max_concurrency > 1`). `options` is the same `GlobalOptimizer.Options`
+/// the struct API takes — pass `.min_default` or `.max_default` (or a full literal). The returned
+/// `Evaluation` owns its `x`; free it via `result.deinit(allocator)`.
 pub fn findGlobalOptimum(
     io: Io,
     allocator: Allocator,
     objective: anytype,
     variables: []const GlobalOptimizer.Variable,
-    max_evals: usize,
+    stop: GlobalOptimizer.StopOptions,
     options: GlobalOptimizer.Options,
 ) !GlobalOptimizer.Evaluation {
     var opt = try GlobalOptimizer.init(allocator, variables, options);
     defer opt.deinit();
-    const b = try opt.optimize(io, objective, .{ .max_evals = max_evals });
+    const b = try opt.optimize(io, objective, stop);
     const x = try allocator.dupe(f64, b.x);
     return .{ .x = x, .y = b.y };
 }
@@ -685,7 +663,7 @@ test "findGlobalOptimum: shifted bowl (maximize)" {
     const allocator = std.testing.allocator;
     const io = Io.Threaded.global_single_threaded.io();
     const variables = box2(-2, 2);
-    var res = try findGlobalOptimum(io, allocator, negShiftedBowl, &variables, 80, .max_default);
+    var res = try findGlobalOptimum(io, allocator, negShiftedBowl, &variables, .{ .max_evals = 80 }, .max_default);
     defer res.deinit(allocator);
     try expectApproxEqAbs(@as(f64, 0.3), res.x[0], 1e-2);
     try expectApproxEqAbs(@as(f64, -0.4), res.x[1], 1e-2);
@@ -696,7 +674,7 @@ test "findGlobalOptimum: shifted bowl (minimize)" {
     const allocator = std.testing.allocator;
     const io = Io.Threaded.global_single_threaded.io();
     const variables = box2(-2, 2);
-    var res = try findGlobalOptimum(io, allocator, shiftedBowl, &variables, 80, .min_default);
+    var res = try findGlobalOptimum(io, allocator, shiftedBowl, &variables, .{ .max_evals = 80 }, .min_default);
     defer res.deinit(allocator);
     try expectApproxEqAbs(@as(f64, 0.3), res.x[0], 1e-2);
     try expectApproxEqAbs(@as(f64, -0.4), res.x[1], 1e-2);

--- a/src/optimization/lipschitz.zig
+++ b/src/optimization/lipschitz.zig
@@ -17,7 +17,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const VarStats = @import("../stats.zig").RunningStats(f64, .variance);
-const tr = @import("trust_region.zig");
+const vec = @import("vec.zig");
 
 pub const UpperBound = struct {
     allocator: Allocator,
@@ -25,13 +25,11 @@ pub const UpperBound = struct {
     relative_noise_magnitude: f64,
     solver_eps: f64,
 
-    npoints: usize = 0,
-    capacity: usize = 0,
-    xs: []f64 = &.{}, // flat capacity*dims, row-major (point i at xs[i*dims ..][0..dims])
-    ys: []f64 = &.{},
+    xs: std.ArrayList(f64) = .empty, // flat n*dims, row-major (point i at xs.items[i*dims ..][0..dims])
+    ys: std.ArrayList(f64) = .empty,
 
     slopes: []f64, // length dims (>= 0)
-    offsets: []f64 = &.{}, // length capacity (>= 0)
+    offsets: std.ArrayList(f64) = .empty, // length n (>= 0)
 
     x_stats: []VarStats = &.{},
     x_stats_prev: []VarStats = &.{}, // scratch for the add() rollback snapshot
@@ -42,7 +40,7 @@ pub const UpperBound = struct {
     // QP dual variables, persisted across refits to warm-start the dual coordinate descent. Indexed
     // by the n-independent pair index j*(j-1)/2 + i, so an entry keeps referring to the same pair as
     // points accumulate (new pairs only ever append at the tail).
-    alpha: []f64 = &.{},
+    alpha: std.ArrayList(f64) = .empty,
     /// DCD sweeps the last refit needed (diagnostic; stays small thanks to warm-starting).
     last_sweeps: usize = 0,
 
@@ -69,51 +67,45 @@ pub const UpperBound = struct {
             .slopes = slopes,
             .x_stats = x_stats,
             .x_stats_prev = x_stats_prev,
-            .y_stats = .init(),
             .arena = std.heap.ArenaAllocator.init(allocator),
         };
     }
 
     pub fn deinit(self: *UpperBound) void {
-        self.allocator.free(self.xs);
-        self.allocator.free(self.ys);
+        self.xs.deinit(self.allocator);
+        self.ys.deinit(self.allocator);
         self.allocator.free(self.slopes);
-        self.allocator.free(self.offsets);
-        self.allocator.free(self.alpha);
+        self.offsets.deinit(self.allocator);
+        self.alpha.deinit(self.allocator);
         self.allocator.free(self.x_stats);
         self.allocator.free(self.x_stats_prev);
         self.arena.deinit();
     }
 
     pub fn numPoints(self: *const UpperBound) usize {
-        return self.npoints;
+        return self.ys.items.len;
     }
 
     pub fn pointX(self: *const UpperBound, i: usize) []const f64 {
-        return self.xs[i * self.dims ..][0..self.dims];
+        return self.xs.items[i * self.dims ..][0..self.dims];
     }
 
     pub fn pointY(self: *const UpperBound, i: usize) f64 {
-        return self.ys[i];
+        return self.ys.items[i];
     }
 
     /// Append an observed point and refit the surrogate (once there are >= 2 points).
     pub fn add(self: *UpperBound, x: []const f64, y: f64) !void {
         std.debug.assert(x.len == self.dims);
-        const n = self.npoints;
-        if (n >= self.capacity) {
-            const new_cap = if (self.capacity == 0) 8 else self.capacity * 2;
-            self.xs = try self.allocator.realloc(self.xs, new_cap * self.dims);
-            self.ys = try self.allocator.realloc(self.ys, new_cap);
-            self.offsets = try self.allocator.realloc(self.offsets, new_cap);
-            self.capacity = new_cap;
-        }
-        @memcpy(self.xs[n * self.dims ..][0..self.dims], x);
-        self.ys[n] = y;
-        self.offsets[n] = 0;
-        self.npoints = n + 1;
-        // A failed refit must not leave npoints or the running stats ahead of the fitted parameters.
-        errdefer self.npoints = n;
+        const n = self.numPoints();
+        try self.xs.appendSlice(self.allocator, x);
+        // A failed append or refit must not leave the point set or the running stats ahead of the
+        // fitted parameters.
+        errdefer self.xs.shrinkRetainingCapacity(n * self.dims);
+        try self.ys.append(self.allocator, y);
+        errdefer self.ys.shrinkRetainingCapacity(n);
+        try self.offsets.append(self.allocator, 0);
+        errdefer self.offsets.shrinkRetainingCapacity(n);
 
         const y_stats_prev = self.y_stats;
         @memcpy(self.x_stats_prev, self.x_stats);
@@ -125,33 +117,31 @@ pub const UpperBound = struct {
         for (0..self.dims) |k| self.x_stats[k].add(x[k]);
         self.y_stats.add(y);
 
-        if (self.npoints >= 2) try self.learnParams();
+        if (self.numPoints() >= 2) try self.learnParams();
     }
 
-    /// The bound a single point `(xi, y)` contributes at `x`: `y + sqrt(max(0, base + Σ slopes·d²))`.
+    /// The bound a single point `(xi, y)` contributes at `x`: `y + sqrt(base + Σ slopes·d²)`.
     /// `base` is the point's noise offset for stored points, or 0 for imputed in-flight ones.
     fn pointBound(self: *const UpperBound, x: []const f64, xi: []const f64, y: f64, base: f64, current_best: f64) f64 {
-        var s = base;
         if (y >= current_best) return y;
         const diff_limit = current_best - y;
         const s_limit = diff_limit * diff_limit;
 
+        var s = base;
         for (0..self.dims) |k| {
             const d = x[k] - xi[k];
             s += self.slopes[k] * d * d;
             if (s >= s_limit) return current_best;
         }
-        return y + @sqrt(@max(0.0, s));
+        return y + @sqrt(s);
     }
 
     /// Evaluate the upper bound at x. Requires at least one point (with a single point the bound is
     /// simply that point's value, since the slopes are still zero).
     pub fn evaluate(self: *const UpperBound, x: []const f64) f64 {
         var ub: f64 = std.math.inf(f64);
-        const dims = self.dims;
-        for (0..self.npoints) |i| {
-            const xi = self.xs[i * dims ..][0..dims];
-            ub = @min(ub, self.pointBound(x, xi, self.ys[i], self.offsets[i], ub));
+        for (0..self.numPoints()) |i| {
+            ub = @min(ub, self.pointBound(x, self.pointX(i), self.pointY(i), self.offsets.items[i], ub));
         }
         return ub;
     }
@@ -160,15 +150,13 @@ pub const UpperBound = struct {
     /// value for an in-flight ("pending") point so concurrent asks don't collapse onto it. Returns 0
     /// when there are no points yet.
     pub fn nearestY(self: *const UpperBound, x: []const f64) f64 {
-        const dims = self.dims;
         var best_d: f64 = std.math.inf(f64);
         var best_y: f64 = 0;
-        for (0..self.npoints) |i| {
-            const xi = self.xs[i * dims ..][0..dims];
-            const s = tr.distSq(x, xi);
+        for (0..self.numPoints()) |i| {
+            const s = vec.distSq(x, self.pointX(i));
             if (s < best_d) {
                 best_d = s;
-                best_y = self.ys[i];
+                best_y = self.pointY(i);
             }
         }
         return best_y;
@@ -195,7 +183,9 @@ pub const UpperBound = struct {
     }
 
     fn learnParams(self: *UpperBound) !void {
+        const n = self.numPoints();
         const dims = self.dims;
+        const rnm = self.relative_noise_magnitude;
 
         defer _ = self.arena.reset(.retain_capacity);
         const a = self.arena.allocator();
@@ -209,14 +199,6 @@ pub const UpperBound = struct {
             const x_std = self.x_stats[k].stdDev();
             xscale[k] = if (x_std > 0) 1.0 / (x_std * yscale) else 0;
         }
-
-        try self.solveAndStore(a, xscale, yscale);
-    }
-
-    fn solveAndStore(self: *UpperBound, a: Allocator, xscale: []const f64, yscale: f64) !void {
-        const n = self.npoints;
-        const dims = self.dims;
-        const rnm = self.relative_noise_magnitude;
 
         const npairs = n * (n - 1) / 2;
         // Sparse constraints: dmat[p][k] = (dx_k * xscale_k * yscale)^2; one noise term at
@@ -233,13 +215,13 @@ pub const UpperBound = struct {
             for (0..j) |i| {
                 var q: f64 = 0;
                 for (0..dims) |k| {
-                    const dx = (self.xs[i * dims + k] - self.xs[j * dims + k]) * xscale[k] * yscale;
+                    const dx = (self.xs.items[i * dims + k] - self.xs.items[j * dims + k]) * xscale[k] * yscale;
                     const dk = dx * dx;
                     dmat[p * dims + k] = dk;
                     q += dk * dk;
                 }
-                noise_idx[p] = if (self.ys[i] > self.ys[j]) j else i;
-                const diff = (self.ys[i] - self.ys[j]) * yscale;
+                noise_idx[p] = if (self.ys.items[i] > self.ys.items[j]) j else i;
+                const diff = (self.ys.items[i] - self.ys.items[j]) * yscale;
                 cvec[p] = diff * diff;
                 qnn[p] = q + rnm * rnm;
                 p += 1;
@@ -247,10 +229,10 @@ pub const UpperBound = struct {
         }
 
         // Warm-start: keep dual variables for pre-existing pairs, zero only the newly appended tail.
-        const old_len = self.alpha.len;
-        self.alpha = try self.allocator.realloc(self.alpha, npairs);
-        if (npairs > old_len) @memset(self.alpha[old_len..], 0);
-        const alpha = self.alpha;
+        const old_len = self.alpha.items.len;
+        try self.alpha.resize(self.allocator, npairs);
+        @memset(self.alpha.items[old_len..], 0);
+        const alpha = self.alpha.items;
 
         // --- dual coordinate descent: max_{alpha>=0} sum alpha*c - 0.5||u||^2, u = sum alpha*a ---
         // Rebuild u under the current normalization from the (warm) dual variables.
@@ -293,7 +275,7 @@ pub const UpperBound = struct {
 
         // --- recover slopes/offsets in original space (offsets already sized to n by add) ---
         for (0..dims) |k| self.slopes[k] = u[k] * xscale[k] * xscale[k];
-        for (0..n) |i| self.offsets[i] = u[dims + i] * rnm;
+        for (0..n) |i| self.offsets.items[i] = u[dims + i] * rnm;
     }
 };
 

--- a/src/optimization/trust_region.zig
+++ b/src/optimization/trust_region.zig
@@ -13,33 +13,8 @@ const Allocator = std.mem.Allocator;
 const expectApproxEqAbs = std.testing.expectApproxEqAbs;
 
 const Matrix = @import("../matrix.zig").Matrix;
-
-// ---------------------------------------------------------------------------------------
-// Small vector helpers (on []f64)
-// ---------------------------------------------------------------------------------------
-
-pub fn dot(a: []const f64, b: []const f64) f64 {
-    var s: f64 = 0;
-    for (a, b) |x, y| s += x * y;
-    return s;
-}
-
-pub fn norm(a: []const f64) f64 {
-    return @sqrt(dot(a, a));
-}
-
-pub fn distSq(a: []const f64, b: []const f64) f64 {
-    var s: f64 = 0;
-    for (a, b) |x, y| {
-        const d = x - y;
-        s += d * d;
-    }
-    return s;
-}
-
-pub fn dist(a: []const f64, b: []const f64) f64 {
-    return @sqrt(distSq(a, b));
-}
+const vec = @import("vec.zig");
+const norm = vec.norm;
 
 // ---------------------------------------------------------------------------------------
 // Dense linear-algebra helpers (row-major n*n in []f64)
@@ -65,7 +40,7 @@ fn cholInPlace(a: []f64, n: usize) bool {
 }
 
 /// Solve L*y = b (forward substitution), L lower-triangular (only lower triangle of `l` read).
-pub fn solveLower(l: []const f64, b: []const f64, y: []f64) void {
+fn solveLower(l: []const f64, b: []const f64, y: []f64) void {
     const n = y.len;
     for (0..n) |i| {
         var s = b[i];
@@ -74,8 +49,8 @@ pub fn solveLower(l: []const f64, b: []const f64, y: []f64) void {
     }
 }
 
-/// Solve L^T*x = y (back substitution), L lower-triangular (L^T is upper).
-pub fn solveLowerT(l: []const f64, y: []const f64, x: []f64) void {
+/// Solve L^T*x = y (back substitution), L lower-triangular (L^T is upper). Safe in place (x = y).
+fn solveLowerT(l: []const f64, y: []const f64, x: []f64) void {
     const n = x.len;
     var i: usize = n;
     while (i > 0) {
@@ -98,7 +73,7 @@ pub const TrustRegionOptions = struct {
     /// Max Newton iterations before falling back to the eigenvalue "hard case".
     max_iter: usize = 500,
 
-    pub const default: TrustRegionOptions = .{ .eps = 1e-3, .max_iter = 500 };
+    pub const default: TrustRegionOptions = .{};
 };
 
 /// Solve   minimize  0.5*p^T B p + g^T p   subject to ||p|| <= radius.
@@ -135,7 +110,7 @@ pub fn solveTrustRegionSubproblem(
     const g_norm = norm(g);
 
     var lambda_min: f64 = 0;
-    var lambda_max: f64 = std.math.clamp(g_norm / radius - bb_min_eig, 0, std.math.floatMax(f64));
+    var lambda_max: f64 = @max(g_norm / radius - bb_min_eig, 0);
 
     // Minimum is at 0.
     if (g_norm < numeric_eps and bb_min_eig > numeric_eps) return;
@@ -167,9 +142,7 @@ pub fn solveTrustRegionSubproblem(
         for (0..n) |k| neg_g[k] = -g[k];
         solveLower(m, neg_g, p); // p = q = L^-1 (-g)
         const q_norm = norm(p);
-        // copy q out, then back-solve in place
-        @memcpy(tmp, p);
-        solveLowerT(m, tmp, p);
+        solveLowerT(m, p, p);
         const p_norm = norm(p);
 
         const target_met = if (lambda == 0) p_norm < radius else @abs(p_norm - radius) / radius < eps;
@@ -439,11 +412,12 @@ fn fitQuadraticMse(
     const w = try allocator.alloc(f64, k);
     defer allocator.free(w);
 
+    // Only the lower triangle of A = WᵀW is accumulated — cholInPlace reads nothing else.
     for (0..m) |j| {
         quadFeatures(x, m, dims, j, w);
         for (0..k) |r1| {
             b[r1] += w[r1] * y[j];
-            for (0..k) |r2| {
+            for (0..r1 + 1) |r2| {
                 a[r1 * k + r2] += w[r1] * w[r2];
             }
         }
@@ -464,19 +438,7 @@ fn fitQuadraticMse(
         if (max_piv <= max_cond_ratio * min_piv) {
             solveLower(a, b, z);
             solveLowerT(a, z, z);
-
-            const c = z[dims];
-            for (0..dims) |r| g[r] = z[r];
-            var wr: usize = dims + 1;
-            for (0..dims) |r| {
-                for (r..dims) |r2| {
-                    const val = z[wr];
-                    h[r * dims + r2] = val;
-                    h[r2 * dims + r] = val;
-                    wr += 1;
-                }
-            }
-            return c;
+            return unpackQuadratic(z, dims, h, g);
         }
     }
 
@@ -485,7 +447,7 @@ fn fitQuadraticMse(
     defer wt.deinit();
     for (0..m) |j| {
         quadFeatures(x, m, dims, j, w);
-        for (0..k) |col| wt.at(j, @intCast(col)).* = w[col];
+        for (0..k) |col| wt.at(j, col).* = w[col];
     }
 
     var ycol: Matrix(f64) = try .init(allocator, @intCast(m), 1);
@@ -497,7 +459,7 @@ fn fitQuadraticMse(
     var z_mat = try pinv.dot(ycol);
     defer z_mat.deinit();
 
-    return unpackQuadratic(z_mat, dims, h, g);
+    return unpackQuadratic(z_mat.items, dims, h, g);
 }
 
 fn fitQuadraticInterp(
@@ -521,13 +483,13 @@ fn fitQuadraticInterp(
         }
     }
     for (0..m) |i| {
-        w.at(i, @intCast(m)).* = 1;
-        w.at(@intCast(m), i).* = 1;
+        w.at(i, m).* = 1;
+        w.at(m, i).* = 1;
     }
     for (0..m) |i| {
         for (0..dims) |d| {
-            w.at(i, @intCast(m + 1 + d)).* = x[d * m + i];
-            w.at(@intCast(m + 1 + d), i).* = x[d * m + i];
+            w.at(i, m + 1 + d).* = x[d * m + i];
+            w.at(m + 1 + d, i).* = x[d * m + i];
         }
     }
 
@@ -541,7 +503,7 @@ fn fitQuadraticInterp(
     defer z.deinit();
 
     const c = z.at(m, 0).*;
-    for (0..dims) |d| g[d] = z.at(@intCast(m + 1 + d), 0).*;
+    for (0..dims) |d| g[d] = z.at(m + 1 + d, 0).*;
     for (0..dims) |a| {
         for (0..dims) |bcol| {
             var s: f64 = 0;
@@ -554,13 +516,13 @@ fn fitQuadraticInterp(
 
 /// Extract c, g, and symmetric H from the MSE solution vector z (layout: g[0..dims], c at dims,
 /// then upper-triangular H entries row-major).
-fn unpackQuadratic(z: Matrix(f64), dims: usize, h: []f64, g: []f64) f64 {
-    const c = z.at(dims, 0).*;
-    for (0..dims) |r| g[r] = z.at(r, 0).*;
+fn unpackQuadratic(z: []const f64, dims: usize, h: []f64, g: []f64) f64 {
+    const c = z[dims];
+    for (0..dims) |r| g[r] = z[r];
     var wr: usize = dims + 1;
     for (0..dims) |r| {
         for (r..dims) |r2| {
-            const v = z.at(@intCast(wr), 0).*;
+            const v = z[wr];
             h[r * dims + r2] = v;
             h[r2 * dims + r] = v;
             wr += 1;
@@ -569,11 +531,8 @@ fn unpackQuadratic(z: Matrix(f64), dims: usize, h: []f64, g: []f64) f64 {
     return c;
 }
 
-// ---------------------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------------------
-
-fn evalQuad(h: []const f64, g: []const f64, c: f64, dims: usize, x: []const f64) f64 {
+/// Evaluate Q(x) = 0.5*x^T H x + g^T x + c (the model form fit by `fitQuadratic`).
+pub fn evalQuad(h: []const f64, g: []const f64, c: f64, dims: usize, x: []const f64) f64 {
     var q: f64 = c;
     for (0..dims) |i| {
         q += g[i] * x[i];
@@ -581,6 +540,10 @@ fn evalQuad(h: []const f64, g: []const f64, c: f64, dims: usize, x: []const f64)
     }
     return q;
 }
+
+// ---------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------
 
 test "cholInPlace + solve" {
     // A = [[4,2],[2,3]] (SPD), solve A x = b with b = [10, 8] -> x = [...]

--- a/src/optimization/vec.zig
+++ b/src/optimization/vec.zig
@@ -1,0 +1,24 @@
+//! Small vector helpers on []f64 shared by the optimization modules.
+
+pub fn dot(a: []const f64, b: []const f64) f64 {
+    var s: f64 = 0;
+    for (a, b) |x, y| s += x * y;
+    return s;
+}
+
+pub fn norm(a: []const f64) f64 {
+    return @sqrt(dot(a, a));
+}
+
+pub fn distSq(a: []const f64, b: []const f64) f64 {
+    var s: f64 = 0;
+    for (a, b) |x, y| {
+        const d = x - y;
+        s += d * d;
+    }
+    return s;
+}
+
+pub fn dist(a: []const f64, b: []const f64) f64 {
+    return @sqrt(distSq(a, b));
+}


### PR DESCRIPTION
- Move vector helpers from `trust_region.zig` to a new `vec.zig` module.
- Use `std.ArrayList` in `lipschitz.zig` to simplify memory management.
- Consolidate worker pool tracking in `global_search.zig` using `Ask`.
- Update `findGlobalOptimum` to accept `StopOptions` instead of `max_evals`.
- Simplify assignment solver loops and allocations.