### PR TITLE
refactor(matrix): extract cholesky factorization

### DIFF
--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -6,6 +6,7 @@
 pub const SMatrix = @import("matrix/SMatrix.zig").SMatrix;
 pub const Matrix = @import("matrix/Matrix.zig").Matrix;
 pub const MatrixError = @import("matrix/Matrix.zig").MatrixError;
+pub const cholesky = @import("matrix/Matrix.zig").cholesky;
 pub const Chain = @import("matrix/Chain.zig").Chain;
 
 test {

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -64,6 +64,26 @@ pub const MatrixError = error{
 /// Recommended alignment for SIMD operations (64 bytes covers AVX-512)
 const simd_alignment = 64;
 
+/// In-place Cholesky factorization of an n*n row-major symmetric matrix stored in a flat slice.
+/// Reads only the lower triangle of `a`; on success overwrites it with L such that A = L*L^T (the
+/// strict upper triangle is left untouched). Returns false if A is not positive definite (the
+/// partial result is then meaningless).
+pub fn cholesky(comptime T: type, a: []T, n: usize) bool {
+    for (0..n) |j| {
+        var sum = a[j * n + j];
+        for (0..j) |k| sum -= a[j * n + k] * a[j * n + k];
+        if (sum <= 0) return false;
+        const ljj = @sqrt(sum);
+        a[j * n + j] = ljj;
+        for (j + 1..n) |i| {
+            var s = a[i * n + j];
+            for (0..j) |k| s -= a[i * n + k] * a[j * n + k];
+            a[i * n + j] = s / ljj;
+        }
+    }
+    return true;
+}
+
 /// Matrix with runtime dimensions using flat array storage
 pub fn Matrix(comptime T: type) type {
     return struct {
@@ -1238,22 +1258,12 @@ pub fn Matrix(comptime T: type) type {
             ensureFloat("chol");
             if (self.rows != self.cols) return error.NotSquare;
             const n = self.rows;
-            var l: Matrix(T) = try .init(self.allocator, n, n);
+            var l = try self.dupe(self.allocator);
             errdefer l.deinit();
-            @memset(l.items, 0);
+            if (!cholesky(T, l.items, n)) return error.NotPositiveDefinite;
+            // The kernel leaves A's values in the strict upper triangle; L must be clean.
             for (0..n) |i| {
-                for (0..i + 1) |j| {
-                    var accum: T = 0;
-                    for (0..j) |k| accum += l.at(i, k).* * l.at(j, k).*;
-                    if (i == j) {
-                        const val = self.at(i, i).* - accum;
-                        if (val <= 0) return error.NotPositiveDefinite;
-                        l.at(i, i).* = @sqrt(val);
-                    } else {
-                        const val = self.at(i, j).* - accum;
-                        l.at(i, j).* = val / l.at(j, j).*;
-                    }
-                }
+                for (i + 1..n) |j| l.at(i, j).* = 0;
             }
             return l;
         }
@@ -1292,11 +1302,16 @@ pub fn Matrix(comptime T: type) type {
         }
 
         pub const QrResult = struct {
-            q: Matrix(T), // Orthogonal matrix (m×n)
-            r: Matrix(T), // Upper triangular matrix (n×n)
-            perm: Permutation, // Permutation P such that AP = QR
-            rank: u32, // Numerical rank of the matrix
-            col_norms: []T, // Final column norms after pivoting (diagnostic)
+            /// Orthogonal matrix (m×n)
+            q: Matrix(T),
+            /// Upper triangular matrix (n×n)
+            r: Matrix(T),
+            /// Permutation P such that AP = QR
+            perm: Permutation,
+            /// Numerical rank of the matrix
+            rank: u32,
+            /// Final column norms after pivoting (diagnostic)
+            col_norms: []T,
             allocator: std.mem.Allocator,
 
             pub fn deinit(self: *@This()) void {

--- a/src/optimization/trust_region.zig
+++ b/src/optimization/trust_region.zig
@@ -4,40 +4,23 @@
 //! Nocedal & Wright Algorithm 4.3) and `global_function_search.cpp` (`fit_quadratic_to_points`).
 //!
 //! Everything operates on f64 with small, dense, row-major matrices stored as flat slices, which
-//! suits the low-dimensional sub-problems that arise here. Heavy decompositions reuse zignal's
-//! `Matrix` (pseudo-inverse for the quadratic fit, `eigh` for the trust-region hard case);
-//! the rest is self-contained.
+//! suits the low-dimensional sub-problems that arise here. Decompositions reuse zignal's matrix
+//! module (the in-place Cholesky kernel, pseudo-inverse for the quadratic fit, `eigh` for the
+//! trust-region hard case); the rest is self-contained.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const expectApproxEqAbs = std.testing.expectApproxEqAbs;
 
-const Matrix = @import("../matrix.zig").Matrix;
+const matrix = @import("../matrix.zig");
+const Matrix = matrix.Matrix;
+const cholesky = matrix.cholesky;
 const vec = @import("vec.zig");
 const norm = vec.norm;
 
 // ---------------------------------------------------------------------------------------
 // Dense linear-algebra helpers (row-major n*n in []f64)
 // ---------------------------------------------------------------------------------------
-
-/// In-place Cholesky factorization. `a` is an n*n row-major symmetric matrix; on success its
-/// lower triangle is overwritten with L such that A = L*L^T. Returns false if A is not positive
-/// definite (the partial result is then meaningless).
-fn cholInPlace(a: []f64, n: usize) bool {
-    for (0..n) |j| {
-        var sum = a[j * n + j];
-        for (0..j) |k| sum -= a[j * n + k] * a[j * n + k];
-        if (sum <= 0) return false;
-        const ljj = @sqrt(sum);
-        a[j * n + j] = ljj;
-        for (j + 1..n) |i| {
-            var s = a[i * n + j];
-            for (0..j) |k| s -= a[i * n + k] * a[j * n + k];
-            a[i * n + j] = s / ljj;
-        }
-    }
-    return true;
-}
 
 /// Solve L*y = b (forward substitution), L lower-triangular (only lower triangle of `l` read).
 fn solveLower(l: []const f64, b: []const f64, y: []f64) void {
@@ -128,7 +111,7 @@ pub fn solveTrustRegionSubproblem(
         @memcpy(m, b[0 .. n * n]);
         for (0..n) |d| m[d * n + d] += lambda;
 
-        if (!cholInPlace(m, n)) {
+        if (!cholesky(f64, m, n)) {
             // Cholesky doesn't exist: B + lambda*I not positive definite.
             if (g_norm <= numeric_eps) break; // go to eigen-decomposition path
             lambda_min = lambda;
@@ -412,7 +395,7 @@ fn fitQuadraticMse(
     const w = try allocator.alloc(f64, k);
     defer allocator.free(w);
 
-    // Only the lower triangle of A = WᵀW is accumulated — cholInPlace reads nothing else.
+    // Only the lower triangle of A = WᵀW is accumulated — cholesky reads nothing else.
     for (0..m) |j| {
         quadFeatures(x, m, dims, j, w);
         for (0..k) |r1| {
@@ -426,7 +409,7 @@ fn fitQuadraticMse(
     // Cholesky on the normal equations is fast but squares the condition number, so take it only when
     // WᵀW is positive definite and well-conditioned. The pivots left on L's diagonal give
     // cond(WᵀW) ≈ (max/min)²; a ratio past max_cond_ratio (cond ≳ 1e8) loses too much precision.
-    if (cholInPlace(a, k)) {
+    if (cholesky(f64, a, k)) {
         const max_cond_ratio = 1e4;
         var min_piv: f64 = std.math.floatMax(f64);
         var max_piv: f64 = 0;
@@ -545,10 +528,10 @@ pub fn evalQuad(h: []const f64, g: []const f64, c: f64, dims: usize, x: []const 
 // Tests
 // ---------------------------------------------------------------------------------------
 
-test "cholInPlace + solve" {
+test "cholesky + solve" {
     // A = [[4,2],[2,3]] (SPD), solve A x = b with b = [10, 8] -> x = [...]
     var a = [_]f64{ 4, 2, 2, 3 };
-    try std.testing.expect(cholInPlace(&a, 2));
+    try std.testing.expect(cholesky(f64, &a, 2));
     const b = [_]f64{ 10, 8 };
     var y: [2]f64 = undefined;
     var x: [2]f64 = undefined;


### PR DESCRIPTION
Move the in-place Cholesky factorization from `trust_region.zig` and `Matrix.zig` into a single, reusable function.