### PR TITLE
QR follow-ups: generic decode and SMatrix.solve

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Zignal is a zero-dependency image processing library inspired by [dlib](https://
 ## Features
 
 - **Core Math:** Matrices (`SMatrix`, `Matrix`, SVD), PCA, ND Geometry (SIMD Points, affine/projective transforms, convex hull), Statistics, Optimization.
-- **Computer Vision:** Feature detection and matching (FAST, ORB), Edge detection (Shen-Castan), Hough Transform, Feature Distribution Matching (style transfer).
+- **Computer Vision:** Feature detection and matching (FAST, ORB), Edge detection (Shen-Castan), Hough Transform, QR code encoding and decoding, Feature Distribution Matching (style transfer).
 - **Image Processing:** Spatial transforms (resize, crop, rotate), morphology, convolution filters (blur, sharpen), thresholding, advanced Color Spaces (Lab, Oklab, Oklch, Xyb, Lms, etc.), Perlin noise generation.
 - **I/O & Graphics:** Pure-Zig PNG/JPEG codecs, Canvas API (antialiasing, Bézier curves), Bitmap/PCF Fonts, Colormaps, Terminal graphics (Kitty/Sixel).
 - **Platform Support:** Native Zig, first-class Python bindings, and WASM compilation for the web.
@@ -68,6 +68,7 @@ zig-out/bin/zignal <command> [options]
 - `resize` - Resize images with various filters
 - `tile` - Combine multiple images into a grid
 - `fdm` - Apply style transfer (Feature Distribution Matching)
+- `qr` - Encode text as QR codes or decode them from images
 - `info` - Show image metadata
 
 ## Examples
@@ -85,6 +86,7 @@ zig-out/bin/zignal <command> [options]
 - [Hough transform animation](https://arrufat.github.io/zignal/examples/hough-animation.html) - Real-time visualization of line detection
 - [Metrics analyzer](https://arrufat.github.io/zignal/examples/metrics.html) - PSNR and SSIM comparison for reference vs. distorted images
 - [Global optimization](https://arrufat.github.io/zignal/examples/global-optimization.html) - Type a JavaScript function and watch the MaxLIPO+TR optimizer search for its optimum
+- [QR code](https://arrufat.github.io/zignal/examples/qrcode.html) - Encode text into QR codes and decode them from your camera or images
 
 
 ## Sponsors

--- a/bindings/python/src/qrcode.zig
+++ b/bindings/python/src/qrcode.zig
@@ -245,21 +245,9 @@ fn qrcode_decode(self: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) cal
         return null;
     };
 
-    // Decode on grayscale; color variants are converted into a temporary.
-    var converted: ?zignal.Image(u8) = null;
-    defer if (converted) |*gray| gray.deinit(allocator);
-    const gray: zignal.Image(u8) = switch (pimg.data) {
-        .gray => |gray| gray,
-        inline .rgb, .rgba => |color_img| blk: {
-            converted = color_img.convert(allocator, u8) catch {
-                _ = c.PyErr_NoMemory();
-                return null;
-            };
-            break :blk converted.?;
-        },
-    };
-
-    var result = (qrcode.decode(allocator, gray) catch |err| {
+    var result = (switch (pimg.data) {
+        inline else => |img| qrcode.decode(allocator, img),
+    } catch |err| {
         python.setZigError(err);
         return null;
     }) orelse return python.none();

--- a/bindings/python/src/qrcode.zig
+++ b/bindings/python/src/qrcode.zig
@@ -191,7 +191,7 @@ fn qrcode_encode(self: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) cal
     const module_size = python.validatePositive(u32, params.module_size, "module_size") catch return null;
     const quiet_zone = python.validateNonNegative(u32, params.quiet_zone, "quiet_zone") catch return null;
 
-    const img = qrcode.encodeImage(allocator, payload, .{
+    const img = qrcode.encode(allocator, payload, .{
         .ec_level = ec_level,
         .version = version,
         .module_size = module_size,

--- a/examples/src/qrcode.zig
+++ b/examples/src/qrcode.zig
@@ -74,10 +74,8 @@ pub export fn qr_decode(
 ) i32 {
     const size = @as(usize, rows) * cols;
     const rgba: Image(Rgba) = .initFromSlice(rows, cols, rgba_ptr[0..size]);
-    var gray = rgba.convert(allocator, u8) catch return -1;
-    defer gray.deinit(allocator);
 
-    var result = (qrcode.decode(allocator, gray) catch |err| {
+    var result = (qrcode.decode(allocator, rgba) catch |err| {
         std.log.err("qr_decode: {s}", .{@errorName(err)});
         return -1;
     }) orelse return 0;

--- a/examples/src/qrcode.zig
+++ b/examples/src/qrcode.zig
@@ -42,7 +42,7 @@ pub export fn qr_encode(
     out_ptr: [*]Rgba,
     out_capacity: usize,
 ) i32 {
-    var image = qrcode.encodeImage(allocator, text_ptr[0..text_len], .{
+    var image = qrcode.encode(allocator, text_ptr[0..text_len], .{
         .ec_level = @enumFromInt(@min(ec_level, 3)),
         .module_size = 1,
     }) catch |err| switch (err) {

--- a/src/cli/qr.zig
+++ b/src/cli/qr.zig
@@ -77,7 +77,7 @@ fn encode(io: Io, writer: *Io.Writer, gpa: Allocator, positionals: []const []con
     }
     const to_file = options.output != null;
     const defaults = qrcode.EncodeOptions.default;
-    var image = try qrcode.encodeImage(gpa, positionals[0], .{
+    var image = try qrcode.encode(gpa, positionals[0], .{
         .ec_level = try parseEcLevel(options.ec_level),
         .version = options.symbol_version,
         // In the terminal, one pixel per module maps to one character cell.

--- a/src/cli/qr.zig
+++ b/src/cli/qr.zig
@@ -115,10 +115,8 @@ fn decode(io: Io, writer: *Io.Writer, gpa: Allocator, positionals: []const []con
 fn decodeImage(io: Io, writer: *Io.Writer, gpa: Allocator, path: []const u8, is_batch: bool) !void {
     var image: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, path);
     defer image.deinit(gpa);
-    var gray = try image.convert(gpa, u8);
-    defer gray.deinit(gpa);
 
-    var result = (try qrcode.decode(gpa, gray)) orelse return error.NoQrCodeFound;
+    var result = (try qrcode.decode(gpa, image)) orelse return error.NoQrCodeFound;
     defer result.deinit(gpa);
     std.log.info("{s}: version {d}, level {t}, {d} corrected codewords", .{
         path, result.version, result.ec_level, result.corrected_errors,

--- a/src/geometry/transforms.zig
+++ b/src/geometry/transforms.zig
@@ -254,14 +254,10 @@ pub fn ProjectiveTransform(comptime T: type) type {
                 var a: SMatrix(T, 8, 8) = undefined;
                 var b: SMatrix(T, 8, 1) = undefined;
                 for (from_points, to_points, 0..) |f, t, i| {
-                    const x = f.x();
-                    const y = f.y();
-                    const u = t.x();
-                    const v = t.y();
-                    a.items[2 * i] = .{ x, y, 1, 0, 0, 0, -u * x, -u * y };
-                    a.items[2 * i + 1] = .{ 0, 0, 0, x, y, 1, -v * x, -v * y };
-                    b.items[2 * i][0] = u;
-                    b.items[2 * i + 1][0] = v;
+                    a.items[2 * i] = .{ f.x(), f.y(), 1, 0, 0, 0, -t.x() * f.x(), -t.x() * f.y() };
+                    a.items[2 * i + 1] = .{ 0, 0, 0, f.x(), f.y(), 1, -t.y() * f.x(), -t.y() * f.y() };
+                    b.items[2 * i][0] = t.x();
+                    b.items[2 * i + 1][0] = t.y();
                 }
                 const h = a.solve(b) orelse return error.RankDeficient;
                 self.matrix = .init(.{

--- a/src/geometry/transforms.zig
+++ b/src/geometry/transforms.zig
@@ -235,53 +235,6 @@ pub fn ProjectiveTransform(comptime T: type) type {
             return if (self.matrix.inv()) |m| .{ .matrix = m } else null;
         }
 
-        /// The exact four-correspondence solve backing `find`; null when the
-        /// correspondences are degenerate. Solving by Gauss-Jordan keeps the
-        /// full input precision, which the least-squares path loses to its
-        /// unnormalized normal equations.
-        fn initExact(from_points: [4]Point(2, T), to_points: [4]Point(2, T)) ?Self {
-            // Unknowns h00..h21 with h22 fixed to 1; two equations per
-            // correspondence.
-            var a: [8][9]T = undefined;
-            for (from_points, to_points, 0..) |f, t, i| {
-                const x = f.x();
-                const y = f.y();
-                const u = t.x();
-                const v = t.y();
-                a[2 * i] = .{ x, y, 1, 0, 0, 0, -u * x, -u * y, u };
-                a[2 * i + 1] = .{ 0, 0, 0, x, y, 1, -v * x, -v * y, v };
-            }
-            var max_entry: T = 0;
-            for (a) |row| {
-                for (row[0..8]) |entry| max_entry = @max(max_entry, @abs(entry));
-            }
-            if (max_entry == 0) return null;
-            // Degeneracy threshold relative to the system's scale.
-            const tolerance = max_entry * std.math.floatEps(T) * 100;
-            // Gauss-Jordan with partial pivoting.
-            for (0..8) |col| {
-                var pivot = col;
-                for (col + 1..8) |row| {
-                    if (@abs(a[row][col]) > @abs(a[pivot][col])) pivot = row;
-                }
-                if (@abs(a[pivot][col]) < tolerance) return null;
-                std.mem.swap([9]T, &a[col], &a[pivot]);
-                for (0..8) |row| {
-                    if (row == col) continue;
-                    const factor = a[row][col] / a[col][col];
-                    if (factor == 0) continue;
-                    for (col..9) |k| a[row][k] -= factor * a[col][k];
-                }
-            }
-            var h: [8]T = undefined;
-            for (0..8) |i| h[i] = a[i][8] / a[i][i];
-            return .{ .matrix = .init(.{
-                .{ h[0], h[1], h[2] },
-                .{ h[3], h[4], h[5] },
-                .{ h[6], h[7], 1 },
-            }) };
-        }
-
         /// Finds the best projective transform that maps between the two given sets of points.
         /// Returns `error.NotConverged` when the SVD fails to converge or `error.RankDeficient`
         /// when the system does not have enough rank to define a projective transform.
@@ -293,9 +246,29 @@ pub fn ProjectiveTransform(comptime T: type) type {
                 return error.RankDeficient;
             }
             if (from_points.len == 4) {
-                // Four correspondences determine the transform exactly; the
-                // least-squares path below would only add numerical error.
-                self.* = initExact(from_points[0..4].*, to_points[0..4].*) orelse return error.RankDeficient;
+                // Four correspondences determine the transform exactly
+                // (unknowns h00..h21 with h22 fixed to 1, two equations per
+                // correspondence), keeping the full input precision that the
+                // least-squares path below loses to its unnormalized normal
+                // equations.
+                var a: SMatrix(T, 8, 8) = undefined;
+                var b: SMatrix(T, 8, 1) = undefined;
+                for (from_points, to_points, 0..) |f, t, i| {
+                    const x = f.x();
+                    const y = f.y();
+                    const u = t.x();
+                    const v = t.y();
+                    a.items[2 * i] = .{ x, y, 1, 0, 0, 0, -u * x, -u * y };
+                    a.items[2 * i + 1] = .{ 0, 0, 0, x, y, 1, -v * x, -v * y };
+                    b.items[2 * i][0] = u;
+                    b.items[2 * i + 1][0] = v;
+                }
+                const h = a.solve(b) orelse return error.RankDeficient;
+                self.matrix = .init(.{
+                    .{ h.items[0][0], h.items[1][0], h.items[2][0] },
+                    .{ h.items[3][0], h.items[4][0], h.items[5][0] },
+                    .{ h.items[6][0], h.items[7][0], 1 },
+                });
                 return;
             }
             var accum: SMatrix(T, 9, 9) = .initAll(0);

--- a/src/matrix/SMatrix.zig
+++ b/src/matrix/SMatrix.zig
@@ -722,6 +722,44 @@ pub fn SMatrix(comptime T: type, comptime rows: u32, comptime cols: u32) type {
             return ans;
         }
 
+        /// Solves the linear system self * x = b by Gauss-Jordan elimination
+        /// with partial pivoting. Returns null when the system is singular
+        /// relative to its scale.
+        pub fn solve(self: Self, b: SMatrix(T, rows, 1)) ?SMatrix(T, rows, 1) {
+            comptime assert(@typeInfo(T) == .float);
+            comptime assert(rows == cols);
+            // Augmented [A | b].
+            var a: [rows][cols + 1]T = undefined;
+            var max_entry: T = 0;
+            for (0..rows) |r| {
+                for (0..cols) |c| {
+                    a[r][c] = self.items[r][c];
+                    max_entry = @max(max_entry, @abs(a[r][c]));
+                }
+                a[r][cols] = b.items[r][0];
+            }
+            if (max_entry == 0) return null;
+            // Degeneracy threshold relative to the system's scale.
+            const tolerance = max_entry * std.math.floatEps(T) * 100;
+            for (0..rows) |c| {
+                var pivot = c;
+                for (c + 1..rows) |r| {
+                    if (@abs(a[r][c]) > @abs(a[pivot][c])) pivot = r;
+                }
+                if (@abs(a[pivot][c]) < tolerance) return null;
+                std.mem.swap([cols + 1]T, &a[c], &a[pivot]);
+                for (0..rows) |r| {
+                    if (r == c) continue;
+                    const factor = a[r][c] / a[c][c];
+                    if (factor == 0) continue;
+                    for (c..cols + 1) |k| a[r][k] -= factor * a[c][k];
+                }
+            }
+            var x: SMatrix(T, rows, 1) = undefined;
+            for (0..rows) |i| x.items[i][0] = a[i][cols] / a[i][i];
+            return x;
+        }
+
         /// Computes the Cholesky decomposition of a symmetric positive-definite matrix.
         /// Returns L such that A = L * L^T where L is lower triangular.
         pub fn chol(self: Self) !SMatrix(T, rows, cols) {
@@ -934,6 +972,29 @@ test "SMatrix inverse" {
     b_i.at(2, 1).* = -1.0 / 3.0;
     b_i.at(2, 2).* = 1.0 / 12.0;
     try expectEqualDeep(b.inv().?, b_i);
+}
+
+test "SMatrix solve" {
+    // A well-conditioned 4x4 system with a known solution.
+    const a: SMatrix(f64, 4, 4) = .init(.{
+        .{ 4, 1, 0, 2 },
+        .{ 1, 5, 1, 0 },
+        .{ 0, 1, 6, 1 },
+        .{ 2, 0, 1, 7 },
+    });
+    const expected: SMatrix(f64, 4, 1) = .init(.{ .{1}, .{-2}, .{3}, .{-4} });
+    const b = a.dot(expected);
+    const x = a.solve(b) orelse return error.TestUnexpectedResult;
+    for (0..4) |i| {
+        try expectApproxEqAbs(expected.items[i][0], x.items[i][0], 1e-12);
+    }
+
+    // Singular systems (dependent rows, all zeros) return null.
+    const singular: SMatrix(f64, 2, 2) = .init(.{ .{ 1, 2 }, .{ 2, 4 } });
+    const rhs: SMatrix(f64, 2, 1) = .init(.{ .{1}, .{2} });
+    try expectEqual(@as(?SMatrix(f64, 2, 1), null), singular.solve(rhs));
+    const zero: SMatrix(f64, 2, 2) = .initAll(0);
+    try expectEqual(@as(?SMatrix(f64, 2, 1), null), zero.solve(rhs));
 }
 
 test "SMatrix row and column extraction" {

--- a/src/qrcode.zig
+++ b/src/qrcode.zig
@@ -7,16 +7,12 @@
 //! roughly 2 pixels per module.
 
 pub const EcLevel = @import("qrcode/tables.zig").EcLevel;
-pub const BitMatrix = @import("qrcode/matrix.zig").BitMatrix;
 
 pub const EncodeOptions = @import("qrcode/encoder.zig").EncodeOptions;
 pub const encode = @import("qrcode/encoder.zig").encode;
-pub const encodeImage = @import("qrcode/encoder.zig").encodeImage;
-pub const toImage = @import("qrcode/encoder.zig").toImage;
 
 pub const DecodeResult = @import("qrcode/decoder.zig").DecodeResult;
 pub const decode = @import("qrcode/detector.zig").decode;
-pub const decodeModules = @import("qrcode/decoder.zig").decodeModules;
 
 test {
     _ = @import("qrcode/galois.zig");

--- a/src/qrcode/decoder.zig
+++ b/src/qrcode/decoder.zig
@@ -35,7 +35,7 @@ pub const DecodeResult = struct {
 /// Decodes a sampled module matrix in place (the matrix is unmasked during
 /// decoding). The matrix must have been created with BitMatrix.init so its
 /// function map matches its version.
-pub fn decodeMatrix(allocator: Allocator, m: *BitMatrix) !DecodeResult {
+fn decodeMatrix(allocator: Allocator, m: *BitMatrix) !DecodeResult {
     const format = readFormat(m) orelse return error.InvalidFormat;
     m.applyMask(format.mask);
 
@@ -207,7 +207,7 @@ test "matrix roundtrip across versions, levels, and modes" {
                     };
                 }
 
-                var m = try encoder.encode(allocator, data, .{ .ec_level = level, .version = version });
+                var m = try encoder.encodeMatrix(allocator, data, .{ .ec_level = level, .version = version });
                 defer m.deinit(allocator);
                 var result = try decodeMatrix(allocator, &m);
                 defer result.deinit(allocator);
@@ -228,7 +228,7 @@ test "decoding survives codeword damage up to capacity" {
     // Version 5-Q exercises the two-group block structure. Consecutive
     // interleaved codewords belong to different blocks, so corrupting the
     // first num_blocks * t codewords damages exactly t per block.
-    var m = try encoder.encode(allocator, "DAMAGE RESISTANCE TEST 123", .{
+    var m = try encoder.encodeMatrix(allocator, "DAMAGE RESISTANCE TEST 123", .{
         .ec_level = .quartile,
         .version = 5,
     });
@@ -253,7 +253,7 @@ test "decoding survives codeword damage up to capacity" {
 
 test "format info damage up to 3 bits is corrected" {
     const allocator = std.testing.allocator;
-    var m = try encoder.encode(allocator, "FORMAT DAMAGE", .{ .ec_level = .high });
+    var m = try encoder.encodeMatrix(allocator, "FORMAT DAMAGE", .{ .ec_level = .high });
     defer m.deinit(allocator);
     // Corrupt 3 bits of the first format copy.
     for ([_]matrix_mod.Position{
@@ -270,7 +270,7 @@ test "format info damage up to 3 bits is corrected" {
 
 test "decodeModules recovers every orientation" {
     const allocator = std.testing.allocator;
-    var m = try encoder.encode(allocator, "ORIENTATION", .{});
+    var m = try encoder.encodeMatrix(allocator, "ORIENTATION", .{});
     defer m.deinit(allocator);
 
     var transformed = try BitMatrix.init(allocator, m.version);
@@ -285,7 +285,7 @@ test "decodeModules recovers every orientation" {
 
 test "readVersion through all orientations" {
     const allocator = std.testing.allocator;
-    var m = try encoder.encode(allocator, "VERSION INFO", .{ .version = 9 });
+    var m = try encoder.encodeMatrix(allocator, "VERSION INFO", .{ .version = 9 });
     defer m.deinit(allocator);
     var transformed = try BitMatrix.init(allocator, m.version);
     defer transformed.deinit(allocator);

--- a/src/qrcode/detector.zig
+++ b/src/qrcode/detector.zig
@@ -731,7 +731,7 @@ test "image roundtrip across module sizes and quiet zones" {
         .{ .module_size = 8, .quiet_zone = 0 },
     };
     for (cases) |c| {
-        var image = try encoder.encodeImage(allocator, "https://github.com/arrufat/zignal", .{
+        var image = try encoder.encode(allocator, "https://github.com/arrufat/zignal", .{
             .module_size = c.module_size,
             .quiet_zone = c.quiet_zone,
         });
@@ -751,7 +751,7 @@ test "image roundtrip across module sizes and quiet zones" {
 test "decode accepts color images" {
     const Rgba = @import("../color.zig").Rgba(u8);
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "COLOR INPUT", .{ .module_size = 4 });
+    var clean = try encoder.encode(allocator, "COLOR INPUT", .{ .module_size = 4 });
     defer clean.deinit(allocator);
     var rgba = try clean.convert(allocator, Rgba);
     defer rgba.deinit(allocator);
@@ -778,7 +778,7 @@ test "decode returns null on blank and noise images" {
 
 test "decode rotated 30 degrees" {
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "ROTATED THIRTY", .{ .module_size = 6 });
+    var clean = try encoder.encode(allocator, "ROTATED THIRTY", .{ .module_size = 6 });
     defer clean.deinit(allocator);
 
     // Rotate the source square around the canvas center.
@@ -814,7 +814,7 @@ test "decode under perspective distortion" {
         .{ .data = "PERSPECTIVE VERSION SEVEN WITH LONGER PAYLOAD FOR SIZE", .version = 7 },
     };
     for (payloads) |payload| {
-        var clean = try encoder.encodeImage(allocator, payload.data, .{
+        var clean = try encoder.encode(allocator, payload.data, .{
             .module_size = 8,
             .version = payload.version,
         });
@@ -838,7 +838,7 @@ test "decode under perspective distortion" {
 
 test "decode mirrored perspective" {
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "MIRRORED", .{ .module_size = 8, .version = 2 });
+    var clean = try encoder.encode(allocator, "MIRRORED", .{ .module_size = 8, .version = 2 });
     defer clean.deinit(allocator);
     const side: f32 = @floatFromInt(clean.cols);
     // Swap left and right destination corners to mirror the symbol.
@@ -858,7 +858,7 @@ test "decode mirrored perspective" {
 
 test "decode under uneven lighting" {
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "UNEVEN LIGHTING", .{ .module_size = 6 });
+    var clean = try encoder.encode(allocator, "UNEVEN LIGHTING", .{ .module_size = 6 });
     defer clean.deinit(allocator);
     const side: f32 = @floatFromInt(clean.cols);
     // Straight-on, but with a strong brightness ramp plus perlin shading:
@@ -881,7 +881,7 @@ test "decode under uneven lighting" {
 
 test "decode under blur and noise" {
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "BLUR AND NOISE", .{ .module_size = 6 });
+    var clean = try encoder.encode(allocator, "BLUR AND NOISE", .{ .module_size = 6 });
     defer clean.deinit(allocator);
     const side: f32 = @floatFromInt(clean.cols);
     var photo = try photoSimulate(allocator, clean, .{
@@ -904,7 +904,7 @@ test "decode combined photo distortions" {
     const allocator = std.testing.allocator;
     const versions = [_]?u8{ 1, 4, 10 }; // v1 exercises the parallelogram fallback
     for (versions) |version| {
-        var clean = try encoder.encodeImage(allocator, "COMBINED PHOTO", .{
+        var clean = try encoder.encode(allocator, "COMBINED PHOTO", .{
             .module_size = 8,
             .version = version,
         });
@@ -934,7 +934,7 @@ test "decode combined photo distortions" {
 
 test "decode version 40 at three pixels per module" {
     const allocator = std.testing.allocator;
-    var clean = try encoder.encodeImage(allocator, "V40 SUBPIXEL BUDGET CANARY", .{
+    var clean = try encoder.encode(allocator, "V40 SUBPIXEL BUDGET CANARY", .{
         .module_size = 3,
         .version = 40,
     });
@@ -982,13 +982,13 @@ test "alignment pattern search on a rendered symbol" {
     const allocator = std.testing.allocator;
     const ms = 6;
     const qz = 4;
-    var image = try encoder.encodeImage(allocator, "ALIGNMENT", .{
+    var image = try encoder.encode(allocator, "ALIGNMENT", .{
         .module_size = ms,
         .quiet_zone = qz,
         .version = 2,
     });
     defer image.deinit(allocator);
-    // encodeImage emits 0/255, which is already binarized.
+    // encode emits 0/255, which is already binarized.
     const center = struct {
         fn center(module: f32) f32 {
             return (qz + module) * ms;

--- a/src/qrcode/detector.zig
+++ b/src/qrcode/detector.zig
@@ -43,9 +43,18 @@ const min_side_modules = 10;
 const alignment_run_tolerance = 0.6;
 const alignment_run_limit = 1.6;
 
-/// Locates a QR code in a grayscale image (clean or photographed) and decodes
-/// it. Returns null when no decodable QR code is found. Caller owns result.data.
-pub fn decode(allocator: Allocator, image: Image(u8)) !?DecodeResult {
+/// Locates a QR code in an image (clean or photographed) and decodes it.
+/// Accepts an Image of any pixel type; color images are converted to
+/// grayscale internally. Returns null when no decodable QR code is found.
+/// Caller owns result.data.
+pub fn decode(allocator: Allocator, image: anytype) !?DecodeResult {
+    if (@TypeOf(image) == Image(u8)) return decodeGray(allocator, image);
+    var gray = try image.convert(allocator, u8);
+    defer gray.deinit(allocator);
+    return decodeGray(allocator, gray);
+}
+
+fn decodeGray(allocator: Allocator, image: Image(u8)) !?DecodeResult {
     if (image.rows < 21 or image.cols < 21) return null;
 
     var binary = try Image(u8).initLike(allocator, image);
@@ -737,6 +746,18 @@ test "image roundtrip across module sizes and quiet zones" {
         try std.testing.expectApproxEqAbs(origin, corners[0].x(), tolerance);
         try std.testing.expectApproxEqAbs(origin, corners[0].y(), tolerance);
     }
+}
+
+test "decode accepts color images" {
+    const Rgba = @import("../color.zig").Rgba(u8);
+    const allocator = std.testing.allocator;
+    var clean = try encoder.encodeImage(allocator, "COLOR INPUT", .{ .module_size = 4 });
+    defer clean.deinit(allocator);
+    var rgba = try clean.convert(allocator, Rgba);
+    defer rgba.deinit(allocator);
+    var result = (try decode(allocator, rgba)) orelse return error.TestUnexpectedResult;
+    defer result.deinit(allocator);
+    try std.testing.expectEqualSlices(u8, "COLOR INPUT", result.data);
 }
 
 test "decode returns null on blank and noise images" {

--- a/src/qrcode/encoder.zig
+++ b/src/qrcode/encoder.zig
@@ -17,17 +17,17 @@ pub const EncodeOptions = struct {
     version: ?u8 = null,
     /// Mask pattern; null selects the best-scoring one.
     mask: ?u3 = null,
-    /// Pixels per module; used only when rendering via encodeImage.
+    /// Pixels per module; used only when rendering via encode.
     module_size: u32 = 8,
     /// Light border around the symbol, in modules (the spec requires 4);
-    /// used only when rendering via encodeImage.
+    /// used only when rendering via encode.
     quiet_zone: u32 = 4,
 
     pub const default: EncodeOptions = .{};
 };
 
 /// Encodes data into a QR module matrix. Caller owns the returned matrix.
-pub fn encode(allocator: Allocator, data: []const u8, options: EncodeOptions) !BitMatrix {
+pub fn encodeMatrix(allocator: Allocator, data: []const u8, options: EncodeOptions) !BitMatrix {
     const mode = segment.detectMode(data);
     const level = options.ec_level;
     const version = options.version orelse try segment.fitVersion(mode, level, data.len);
@@ -95,7 +95,7 @@ fn interleave(allocator: Allocator, data: []const u8, blocks: tables.EcBlocks) !
 }
 
 /// Renders a module matrix as a grayscale image (dark modules are 0).
-pub fn toImage(allocator: Allocator, m: BitMatrix, module_size: u32, quiet_zone: u32) !Image(u8) {
+fn toImage(allocator: Allocator, m: BitMatrix, module_size: u32, quiet_zone: u32) !Image(u8) {
     if (module_size == 0) return error.InvalidModuleSize;
     const size = (@as(u32, m.dim) + 2 * quiet_zone) * module_size;
     var image = try Image(u8).init(allocator, size, size);
@@ -115,8 +115,8 @@ pub fn toImage(allocator: Allocator, m: BitMatrix, module_size: u32, quiet_zone:
 }
 
 /// Encodes data straight to a grayscale image. Caller owns the image.
-pub fn encodeImage(allocator: Allocator, data: []const u8, options: EncodeOptions) !Image(u8) {
-    var m = try encode(allocator, data, options);
+pub fn encode(allocator: Allocator, data: []const u8, options: EncodeOptions) !Image(u8) {
+    var m = try encodeMatrix(allocator, data, options);
     defer m.deinit(allocator);
     return toImage(allocator, m, options.module_size, options.quiet_zone);
 }
@@ -148,15 +148,15 @@ test "interleaving order with two groups" {
     try std.testing.expectEqual(@as(u8, 61), data_part[data_len - 1]); // last of block 4
 }
 
-test "encode produces a valid version 1 matrix" {
-    var m = try encode(std.testing.allocator, "HELLO WORLD", .{ .ec_level = .quartile });
+test "encodeMatrix produces a valid version 1 matrix" {
+    var m = try encodeMatrix(std.testing.allocator, "HELLO WORLD", .{ .ec_level = .quartile });
     defer m.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u8, 1), m.version);
     try std.testing.expectEqual(@as(u16, 21), m.dim);
 }
 
-test "encodeImage dimensions" {
-    var image = try encodeImage(std.testing.allocator, "hello", .{ .module_size = 2, .quiet_zone = 4 });
+test "encode dimensions" {
+    var image = try encode(std.testing.allocator, "hello", .{ .module_size = 2, .quiet_zone = 4 });
     defer image.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u32, (21 + 8) * 2), image.rows);
     try std.testing.expectEqual(image.rows, image.cols);

--- a/src/qrcode/galois.zig
+++ b/src/qrcode/galois.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 /// Number of non-zero field elements.
-pub const order = 255;
+const order = 255;
 
 const tables = blk: {
     @setEvalBranchQuota(10_000);

--- a/src/qrcode/matrix.zig
+++ b/src/qrcode/matrix.zig
@@ -43,11 +43,11 @@ pub const BitMatrix = struct {
         return @intCast(self.modules[row * self.dim + col]);
     }
 
-    pub fn set(self: *BitMatrix, row: usize, col: usize, value: u1) void {
+    fn set(self: *BitMatrix, row: usize, col: usize, value: u1) void {
         self.modules[row * self.dim + col] = value;
     }
 
-    pub fn isFunction(self: BitMatrix, row: usize, col: usize) bool {
+    fn isFunction(self: BitMatrix, row: usize, col: usize) bool {
         return self.is_function[row * self.dim + col] != 0;
     }
 
@@ -323,7 +323,7 @@ pub const BitMatrix = struct {
 };
 
 /// The mask predicate: true means the module at (row, col) is inverted.
-pub fn maskBit(mask: u3, row: usize, col: usize) bool {
+fn maskBit(mask: u3, row: usize, col: usize) bool {
     return switch (mask) {
         0 => (row + col) % 2 == 0,
         1 => row % 2 == 0,
@@ -340,7 +340,7 @@ pub fn maskBit(mask: u3, row: usize, col: usize) bool {
 /// column pairs right to left, alternating up and down, skipping column 6.
 /// Shared by placeData and extractCodewords so the encoder and decoder can
 /// never disagree on the traversal.
-pub const DataIterator = struct {
+const DataIterator = struct {
     m: *const BitMatrix,
     col: i32,
     row: i32,

--- a/src/qrcode/matrix.zig
+++ b/src/qrcode/matrix.zig
@@ -347,7 +347,7 @@ const DataIterator = struct {
     upward: bool,
     right: bool,
 
-    pub fn init(matrix: *const BitMatrix) DataIterator {
+    fn init(matrix: *const BitMatrix) DataIterator {
         return .{
             .m = matrix,
             .col = matrix.dim - 1,
@@ -357,7 +357,7 @@ const DataIterator = struct {
         };
     }
 
-    pub fn next(self: *DataIterator) ?Position {
+    fn next(self: *DataIterator) ?Position {
         while (self.col > 0) {
             const row: usize = @intCast(self.row);
             const col: usize = @intCast(if (self.right) self.col else self.col - 1);

--- a/src/qrcode/reed_solomon.zig
+++ b/src/qrcode/reed_solomon.zig
@@ -7,7 +7,7 @@ const assert = std.debug.assert;
 const gf = @import("galois.zig");
 
 /// Maximum number of error correction codewords per block in a QR code.
-pub const max_ecc_len = 30;
+const max_ecc_len = 30;
 
 /// Generator polynomials for every degree up to max_ecc_len, highest-degree
 /// coefficient first (monic, so [degree][0] == 1). Each row multiplies the

--- a/src/qrcode/segment.zig
+++ b/src/qrcode/segment.zig
@@ -40,7 +40,7 @@ pub fn detectMode(data: []const u8) Mode {
 
 /// Number of bits the data occupies in a mode, excluding the mode indicator
 /// and character count field.
-pub fn dataBits(mode: Mode, len: usize) usize {
+fn dataBits(mode: Mode, len: usize) usize {
     const numeric_extra = [3]usize{ 0, 4, 7 };
     return switch (mode) {
         .numeric => 10 * (len / 3) + numeric_extra[len % 3],
@@ -65,7 +65,7 @@ pub fn fitVersion(mode: Mode, level: tables.EcLevel, len: usize) !u8 {
 }
 
 /// Appends bits most significant first to a byte list.
-pub const BitWriter = struct {
+const BitWriter = struct {
     bytes: std.ArrayList(u8) = .empty,
     bit_len: usize = 0,
 
@@ -86,7 +86,7 @@ pub const BitWriter = struct {
 };
 
 /// Reads bits most significant first from a byte slice.
-pub const BitReader = struct {
+const BitReader = struct {
     bytes: []const u8,
     pos: usize = 0,
 

--- a/src/qrcode/segment.zig
+++ b/src/qrcode/segment.zig
@@ -69,11 +69,11 @@ const BitWriter = struct {
     bytes: std.ArrayList(u8) = .empty,
     bit_len: usize = 0,
 
-    pub fn deinit(self: *BitWriter, allocator: Allocator) void {
+    fn deinit(self: *BitWriter, allocator: Allocator) void {
         self.bytes.deinit(allocator);
     }
 
-    pub fn writeBits(self: *BitWriter, allocator: Allocator, value: u32, count: u5) !void {
+    fn writeBits(self: *BitWriter, allocator: Allocator, value: u32, count: u5) !void {
         var i = count;
         while (i > 0) {
             i -= 1;
@@ -90,11 +90,11 @@ const BitReader = struct {
     bytes: []const u8,
     pos: usize = 0,
 
-    pub fn remaining(self: BitReader) usize {
+    fn remaining(self: BitReader) usize {
         return self.bytes.len * 8 - self.pos;
     }
 
-    pub fn readBits(self: *BitReader, count: u5) !u32 {
+    fn readBits(self: *BitReader, count: u5) !u32 {
         if (count > self.remaining()) return error.UnexpectedEndOfData;
         var value: u32 = 0;
         for (0..count) |_| {

--- a/src/qrcode/tables.zig
+++ b/src/qrcode/tables.zig
@@ -12,7 +12,7 @@ pub const EcLevel = enum(u2) {
     high,
 
     /// The two-bit indicator used in the format information.
-    pub fn formatBits(self: EcLevel) u2 {
+    fn formatBits(self: EcLevel) u2 {
         return switch (self) {
             .low => 0b01,
             .medium => 0b00,
@@ -49,7 +49,7 @@ pub const EcBlocks = struct {
     group1_data: u8,
     group2_blocks: u8,
 
-    pub fn group2Data(self: EcBlocks) u8 {
+    fn group2Data(self: EcBlocks) u8 {
         return self.group1_data + 1;
     }
 


### PR DESCRIPTION
Follow-ups from the QR code review (#374):

- **`qrcode.decode` accepts any pixel type**: color images are converted to grayscale internally (any image → u8 → binarize), so the CLI, wasm example, and Python bindings drop their per-frontend conversion glue.
- **`SMatrix.solve`**: general $Ax = b$ Gauss-Jordan solve with partial pivoting and a scale-relative degeneracy tolerance; `ProjectiveTransform`'s exact four-correspondence path now builds the system and calls it (`initExact` is inlined into `find`).
- **Public API trim + symmetry**: the `qrcode` surface is now `EcLevel`, `EncodeOptions`, `encode` (data → `Image(u8)`), `decode` (image → data), and `DecodeResult`. `BitMatrix`, the matrix-level `encodeMatrix`/`decodeMatrix`/`decodeModules`, `toImage`, and file-local helpers (`DataIterator`, `BitWriter`/`BitReader`, etc.) are module internal — easy to re-export later if a need shows up. Raw module grids remain available via `encode` with `module_size = 1, quiet_zone = 0`.
- **README**: QR mentioned under Features and CLI commands, and the interactive example is linked.

Deliberately not included: webcam decode throttling (the demo doubles as a live benchmark), format-info pre-check in `decodeModules` (would duplicate coordinate knowledge `matrix.zig` owns), and per-version `BitMatrix` caching (only pays when multiple fourth candidates survive the timing check for the same version, which is rare).