### PR TITLE
feat(matrix): add linear system solver using LU factorization

### DIFF
--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -426,6 +426,20 @@ pub fn Matrix(comptime T: type) type {
             }
         }
 
+        /// Solves the linear system A*x = b for x, where A is this square matrix
+        /// and b is an n-row right-hand side with one or more columns. Uses LU
+        /// factorization with partial pivoting; prefer this over `inv().dot(b)`,
+        /// which is both slower and less numerically stable. To solve against
+        /// several right-hand sides, factor once with `lu()` and reuse
+        /// `LuResult.solve`. Returns error.Singular when A is singular.
+        pub fn solve(self: Self, b: Self) MatrixError!Self {
+            if (self.rows != self.cols) return error.NotSquare;
+            if (b.rows != self.rows) return error.DimensionMismatch;
+            var lu_result = try self.lu();
+            defer lu_result.deinit();
+            return lu_result.solve(b);
+        }
+
         /// Computes the Moore-Penrose pseudoinverse using an SVD-based algorithm.
         /// Works for rectangular matrices and gracefully handles rank deficiency
         /// by discarding singular values below the provided tolerance. The optional
@@ -1155,6 +1169,46 @@ pub fn Matrix(comptime T: type) type {
             /// Returns the permutation as a matrix P such that PA = LU.
             pub fn permutationMatrix(self: *const @This()) !Matrix(T) {
                 return self.p.toMatrix(.row);
+            }
+
+            /// Solves A*x = b for x, reusing this factorization. `b` may have
+            /// several columns, each solved independently. Returns error.Singular
+            /// when U has a (near-)zero pivot on its diagonal.
+            pub fn solve(self: *const @This(), b: Matrix(T)) MatrixError!Matrix(T) {
+                const n = self.u.rows;
+                if (b.rows != n) return error.DimensionMismatch;
+                const k = b.cols;
+
+                // x holds P*b, then y, then the solution, each overwriting the last.
+                var x: Matrix(T) = try .init(self.l.allocator, n, k);
+                errdefer x.deinit();
+                for (0..n) |i| {
+                    const src = self.p.indices[i];
+                    for (0..k) |c| x.at(i, c).* = b.at(src, c).*;
+                }
+
+                // Forward substitution: L*y = P*b (L is unit lower triangular).
+                for (0..n) |i| {
+                    for (0..i) |j| {
+                        const l_ij = self.l.at(i, j).*;
+                        for (0..k) |c| x.at(i, c).* -= l_ij * x.at(j, c).*;
+                    }
+                }
+
+                // Back substitution: U*x = y.
+                var i = n;
+                while (i > 0) {
+                    i -= 1;
+                    const pivot = self.u.at(i, i).*;
+                    if (@abs(pivot) < std.math.floatEps(T)) return error.Singular;
+                    for (i + 1..n) |j| {
+                        const u_ij = self.u.at(i, j).*;
+                        for (0..k) |c| x.at(i, c).* -= u_ij * x.at(j, c).*;
+                    }
+                    for (0..k) |c| x.at(i, c).* /= pivot;
+                }
+
+                return x;
             }
         };
 

--- a/src/matrix/test_ops_decomposition.zig
+++ b/src/matrix/test_ops_decomposition.zig
@@ -557,3 +557,73 @@ test "Matrix Cholesky decomposition" {
 
     try std.testing.expectError(MatrixError.NotPositiveDefinite, non_spd.chol());
 }
+
+test "Matrix solve single right-hand side" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const eps = 1e-12;
+
+    // Solution is x = [1, 2, 3].
+    const a: Matrix(f64) = try .fromSlice(alloc, 3, 3, &[_]f64{
+        2, 1, 1,
+        4, 3, 3,
+        8, 7, 9,
+    });
+    const b: Matrix(f64) = try .fromSlice(alloc, 3, 1, &[_]f64{ 7, 19, 49 });
+
+    const x = try a.solve(b);
+    try std.testing.expectApproxEqAbs(@as(f64, 1), x.at(0, 0).*, eps);
+    try std.testing.expectApproxEqAbs(@as(f64, 2), x.at(1, 0).*, eps);
+    try std.testing.expectApproxEqAbs(@as(f64, 3), x.at(2, 0).*, eps);
+
+    const recon = try a.dot(x);
+    for (0..3) |i| try std.testing.expectApproxEqAbs(b.at(i, 0).*, recon.at(i, 0).*, eps);
+}
+
+test "Matrix solve multiple right-hand sides via reused factorization" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const eps = 1e-12;
+
+    const a: Matrix(f64) = try .fromSlice(alloc, 2, 2, &[_]f64{
+        3, 2,
+        1, 4,
+    });
+    // RHS = I, so the solution is A^-1 and A*x == I.
+    const b: Matrix(f64) = try .fromSlice(alloc, 2, 2, &[_]f64{
+        1, 0,
+        0, 1,
+    });
+
+    var lu_result = try a.lu();
+    defer lu_result.deinit();
+    const x = try lu_result.solve(b);
+
+    const recon = try a.dot(x);
+    for (0..2) |i| {
+        for (0..2) |j| {
+            const expected: f64 = if (i == j) 1 else 0;
+            try std.testing.expectApproxEqAbs(expected, recon.at(i, j).*, eps);
+        }
+    }
+}
+
+test "Matrix solve reports singular systems" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const MatrixError = @import("Matrix.zig").MatrixError;
+
+    // Second row is twice the first: singular.
+    const a: Matrix(f64) = try .fromSlice(alloc, 2, 2, &[_]f64{
+        1, 2,
+        2, 4,
+    });
+    const b: Matrix(f64) = try .fromSlice(alloc, 2, 1, &[_]f64{ 1, 2 });
+    try std.testing.expectError(MatrixError.Singular, a.solve(b));
+
+    const b_bad: Matrix(f64) = try .fromSlice(alloc, 3, 1, &[_]f64{ 1, 2, 3 });
+    try std.testing.expectError(MatrixError.DimensionMismatch, a.solve(b_bad));
+}


### PR DESCRIPTION
Adds `Matrix.solve` and `LuResult.solve` to solve A*x = b using LU factorization with partial pivoting. Supports multiple right-hand sides and detects singular matrices.