### PR TITLE
feat(python): add Matrix.solve method

### DIFF
--- a/bindings/python/src/matrix.zig
+++ b/bindings/python/src/matrix.zig
@@ -1009,6 +1009,48 @@ fn matrix_dot_method(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
     return matrix_matmul(self_obj, params.other);
 }
 
+const matrix_solve_doc =
+    \\Solve the linear system ``A @ x = b`` for ``x``.
+    \\
+    \\Uses LU factorization with partial pivoting, which is faster and more
+    \\numerically stable than forming ``A.inv() @ b``. The right-hand side may
+    \\carry several columns, each solved independently.
+    \\
+    \\## Parameters
+    \\- `b` (Matrix): Right-hand side with as many rows as this matrix and one or more columns.
+    \\
+    \\## Returns
+    \\Matrix: The solution ``x``, with the same shape as ``b``.
+    \\
+    \\## Raises
+    \\ValueError: If this matrix is not square, ``b``'s rows do not match, or the matrix is singular.
+    \\
+    \\## Examples
+    \\```python
+    \\a = Matrix([[2, 1], [1, 3]])
+    \\b = Matrix([[3], [5]])
+    \\x = a.solve(b)  # a @ x ≈ b
+    \\```
+;
+
+fn matrix_solve_method(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const ptr = python.unwrap(MatrixObject, "matrix_ptr", self_obj, "Matrix") orelse return null;
+
+    const Params = struct {
+        b: ?*c.PyObject,
+    };
+    var params: Params = undefined;
+    python.parseArgs(Params, args, kwds, &params) catch return null;
+
+    if (c.PyObject_IsInstance(params.b, @ptrCast(&MatrixType)) != 1) {
+        python.setTypeError("Matrix", params.b);
+        return null;
+    }
+
+    const b_ptr = python.unwrap(MatrixObject, "matrix_ptr", params.b, "Matrix") orelse return null;
+    return matrixToObject(ptr.solve(b_ptr.*));
+}
+
 const matrix_sum_doc =
     \\Sum of all matrix elements.
     \\
@@ -2091,6 +2133,14 @@ pub const matrix_methods_metadata = [_]python.MethodWithMetadata{
         .flags = c.METH_VARARGS | c.METH_KEYWORDS,
         .doc = matrix_dot_doc,
         .params = "self, other: Matrix",
+        .returns = "Matrix",
+    },
+    .{
+        .name = "solve",
+        .meth = @ptrCast(&matrix_solve_method),
+        .flags = c.METH_VARARGS | c.METH_KEYWORDS,
+        .doc = matrix_solve_doc,
+        .params = "self, b: Matrix",
         .returns = "Matrix",
     },
     .{

--- a/bindings/python/tests/test_matrix.py
+++ b/bindings/python/tests/test_matrix.py
@@ -302,3 +302,38 @@ def test_sum_rows_cols():
     assert cols_sum.shape == (2, 1)
     assert cols_sum[0, 0] == pytest.approx(6.0)
     assert cols_sum[1, 0] == pytest.approx(15.0)
+
+
+def test_solve():
+    """Solve A @ x = b, single and multiple right-hand sides."""
+    a = zignal.Matrix([[2, 1, 1], [4, 3, 3], [8, 7, 9]])
+    b = zignal.Matrix([[7], [19], [49]])
+
+    x = a.solve(b)
+    assert x.shape == (3, 1)
+    expected = np.linalg.solve(a.to_numpy(), b.to_numpy())
+    np.testing.assert_allclose(x.to_numpy(), expected, atol=1e-10)
+
+    # Multiple right-hand sides: RHS = I recovers the inverse.
+    identity = zignal.Matrix.identity(3, 3)
+    inv = a.solve(identity)
+    np.testing.assert_allclose(inv.to_numpy(), np.linalg.inv(a.to_numpy()), atol=1e-10)
+
+
+def test_solve_errors():
+    """solve() rejects non-square, singular, and mismatched systems."""
+    singular = zignal.Matrix([[1, 2], [2, 4]])
+    b = zignal.Matrix([[1], [2]])
+    with pytest.raises(ValueError):
+        singular.solve(b)
+
+    non_square = zignal.Matrix([[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(ValueError):
+        non_square.solve(zignal.Matrix([[1], [2]]))
+
+    good = zignal.Matrix([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        good.solve(zignal.Matrix([[1], [2], [3]]))
+
+    with pytest.raises(TypeError):
+        good.solve([[1], [2]])


### PR DESCRIPTION
Exposes the `solve` method to solve linear systems of equations. Includes comprehensive unit tests for correctness and error cases.