### PR TITLE
feat(cli): add pipeline command and short option support 

### DIFF
--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -16,6 +16,9 @@ pub const OptionConfig = struct {
     help: []const u8,
     /// The name used for the value placeholder in the help message (e.g., "N" in "--width <N>").
     metavar: ?[]const u8 = null,
+    /// Optional single-character alias, e.g. `.short = 'o'` for `--output`.
+    /// `'h'` is reserved for `--help` and is ignored here.
+    short: ?u8 = null,
 };
 
 /// The result of parsing command-line arguments.
@@ -39,6 +42,61 @@ pub fn ParseResult(comptime T: type) type {
 fn PayloadType(comptime T: type) type {
     const info = @typeInfo(T);
     return if (info == .optional) info.optional.child else T;
+}
+
+/// Returns the single-character alias declared for `field_name` in `T.meta`,
+/// or null if the field has no `meta` entry or no `.short`.
+fn fieldShort(comptime T: type, comptime field_name: []const u8) ?u8 {
+    if (!@hasDecl(T, "meta")) return null;
+    if (!@hasField(@TypeOf(T.meta), field_name)) return null;
+    const info = @field(T.meta, field_name);
+    if (!@hasField(@TypeOf(info), "short")) return null;
+    return info.short;
+}
+
+/// The 4-character help column prefix for a flag: `"-o, "` when a short alias
+/// exists, or four spaces so long-only flags stay aligned under it.
+fn shortPrefix(comptime T: type, comptime field_name: []const u8) [4]u8 {
+    return if (fieldShort(T, field_name)) |s|
+        [4]u8{ '-', s, ',', ' ' }
+    else
+        [4]u8{ ' ', ' ', ' ', ' ' };
+}
+
+/// Assigns the value for a matched option field, consuming a value from `args`
+/// for non-boolean fields. Shared by the long (`--flag`) and short (`-f`) paths.
+fn setOption(comptime T: type, comptime field: anytype, options: *T, args: *std.process.Args.Iterator) !void {
+    const ChildType = PayloadType(field.type);
+
+    if (ChildType == bool) {
+        @field(options.*, field.name) = true;
+        std.log.debug("option --{s} set to true", .{field.name});
+        return;
+    }
+
+    const val_str = args.next() orelse {
+        std.log.err("missing value for --{s}", .{field.name});
+        return error.InvalidArguments;
+    };
+
+    if (ChildType == []const u8) {
+        @field(options.*, field.name) = val_str;
+        std.log.debug("option --{s} set to '{s}'", .{ field.name, val_str });
+    } else if (@typeInfo(ChildType) == .int) {
+        @field(options.*, field.name) = std.fmt.parseInt(ChildType, val_str, 10) catch {
+            std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
+            return error.InvalidArguments;
+        };
+        std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
+    } else if (@typeInfo(ChildType) == .float) {
+        @field(options.*, field.name) = std.fmt.parseFloat(ChildType, val_str) catch {
+            std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
+            return error.InvalidArguments;
+        };
+        std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
+    } else {
+        @compileError("Unsupported type for arg parsing: " ++ @typeName(ChildType));
+    }
 }
 
 /// Checks if the argument is a log level flag and parses it.
@@ -98,36 +156,7 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
 
                 if (matches) {
                     found = true;
-                    const ChildType = PayloadType(field.type);
-
-                    if (ChildType == bool) {
-                        @field(options, field.name) = true;
-                        std.log.debug("option --{s} set to true", .{field.name});
-                    } else {
-                        const val_str = args.next() orelse {
-                            std.log.err("missing value for --{s}", .{field.name});
-                            return error.InvalidArguments;
-                        };
-
-                        if (ChildType == []const u8) {
-                            @field(options, field.name) = val_str;
-                            std.log.debug("option --{s} set to '{s}'", .{ field.name, val_str });
-                        } else if (@typeInfo(ChildType) == .int) {
-                            @field(options, field.name) = std.fmt.parseInt(ChildType, val_str, 10) catch {
-                                std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
-                                return error.InvalidArguments;
-                            };
-                            std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
-                        } else if (@typeInfo(ChildType) == .float) {
-                            @field(options, field.name) = std.fmt.parseFloat(ChildType, val_str) catch {
-                                std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
-                                return error.InvalidArguments;
-                            };
-                            std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
-                        } else {
-                            @compileError("Unsupported type for arg parsing: " ++ @typeName(ChildType));
-                        }
-                    }
+                    try setOption(T, field, &options, args);
                 }
             }
             if (!found) {
@@ -135,8 +164,26 @@ pub fn parse(comptime T: type, allocator: Allocator, args: *std.process.Args.Ite
                 return error.InvalidArguments;
             }
         } else if (std.mem.startsWith(u8, arg, "-")) {
-            std.log.err("unknown option: {s}", .{arg});
-            return error.InvalidArguments;
+            // Short alias, e.g. `-o`. Only single-character shorts are supported.
+            if (arg.len != 2) {
+                std.log.err("unknown option: {s}", .{arg});
+                return error.InvalidArguments;
+            }
+            const short = arg[1];
+            var found = false;
+
+            inline for (comptime meta.structFields(T)) |field| {
+                if (comptime fieldShort(T, field.name)) |s| {
+                    if (s == short) {
+                        found = true;
+                        try setOption(T, field, &options, args);
+                    }
+                }
+            }
+            if (!found) {
+                std.log.err("unknown option: {s}", .{arg});
+                return error.InvalidArguments;
+            }
         } else {
             try positionals.append(allocator, arg);
         }
@@ -182,10 +229,12 @@ pub fn generateHelp(comptime T: type, comptime usage_line: []const u8, comptime 
             break :blk res;
         };
 
+        const short_arr = comptime shortPrefix(T, field.name);
+
         const flag_len = if (is_bool)
-            ("  --" ++ flag_name_fmt).len
+            ("  " ++ short_arr ++ "--" ++ flag_name_fmt).len
         else
-            ("  --" ++ flag_name_fmt ++ " <" ++ metavar ++ ">").len;
+            ("  " ++ short_arr ++ "--" ++ flag_name_fmt ++ " <" ++ metavar ++ ">").len;
 
         if (flag_len > max_len) max_len = flag_len;
     }
@@ -213,10 +262,12 @@ pub fn generateHelp(comptime T: type, comptime usage_line: []const u8, comptime 
             break :blk res;
         };
 
+        const short_arr = comptime shortPrefix(T, field.name);
+
         const flag_str = if (is_bool)
-            "  --" ++ flag_name_fmt
+            "  " ++ short_arr ++ "--" ++ flag_name_fmt
         else
-            "  --" ++ flag_name_fmt ++ " <" ++ metavar ++ ">";
+            "  " ++ short_arr ++ "--" ++ flag_name_fmt ++ " <" ++ metavar ++ ">";
 
         const padding_len = padding_target - flag_str.len;
         const padding: [padding_len]u8 = @splat(' ');

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -3,6 +3,7 @@ const Io = std.Io;
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
 const meta = @import("zignal").meta;
+const common = @import("common.zig");
 
 pub var runtime_log_level: std.log.Level = if (builtin.mode == .Debug) .debug else .err;
 
@@ -90,6 +91,13 @@ fn setOption(comptime T: type, comptime field: anytype, options: *T, args: *std.
         std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
     } else if (@typeInfo(ChildType) == .float) {
         @field(options.*, field.name) = std.fmt.parseFloat(ChildType, val_str) catch {
+            std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
+            return error.InvalidArguments;
+        };
+        std.log.debug("option --{s} set to {s}", .{ field.name, val_str });
+    } else if (@typeInfo(ChildType) == .@"enum") {
+        // Accept either kebab- or snake-case, matching the ZON enum-literal names.
+        @field(options.*, field.name) = common.parseEnum(ChildType, val_str) orelse {
             std.log.err("invalid value for --{s}: {s}", .{ field.name, val_str });
             return error.InvalidArguments;
         };

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -11,7 +11,7 @@ const displayCanvas = display.displayCanvas;
 const resolveDisplayFormat = display.resolveDisplayFormat;
 
 pub const Args = struct {
-    type: ?[]const u8 = null,
+    type: ?BlurType = null,
     output: ?[]const u8 = null,
     display: bool = false,
 
@@ -29,7 +29,7 @@ pub const Args = struct {
     // Display options
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .type = .{ .help = "Blur type: " ++ common.joinFieldNames(BlurType) ++ " (default: gaussian)", .metavar = "name" },
@@ -93,13 +93,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 /// Blur `img` according to `options`, returning a freshly allocated image the
 /// caller owns. Shared by the standalone command and the `pipeline` command.
 pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options: Args) !zignal.Image(zignal.Rgba(u8)) {
-    var blur_type: BlurType = .gaussian;
-    if (options.type) |t| {
-        blur_type = common.parseEnum(BlurType, t) orelse {
-            std.log.err("unknown blur type: {s}", .{t});
-            return error.InvalidArguments;
-        };
-    }
+    const blur_type = options.type orelse .gaussian;
 
     var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, img.rows, img.cols);
     errdefer out.deinit(gpa);
@@ -210,7 +204,7 @@ fn processImage(
     }
 
     if (should_display) {
-        const format = try resolveDisplayFormat(options.protocol, options.width, options.height);
+        const format = resolveDisplayFormat(options.protocol, options.width, options.height);
         try displayCanvas(io, writer, out, format);
     }
 }

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -10,7 +10,7 @@ const display = @import("display.zig");
 const displayCanvas = display.displayCanvas;
 const resolveDisplayFormat = display.resolveDisplayFormat;
 
-const Args = struct {
+pub const Args = struct {
     type: ?[]const u8 = null,
     output: ?[]const u8 = null,
     display: bool = false,
@@ -33,8 +33,8 @@ const Args = struct {
 
     pub const meta = .{
         .type = .{ .help = "Blur type: " ++ common.joinFieldNames(BlurType) ++ " (default: gaussian)", .metavar = "name" },
-        .output = .{ .help = "Output file or directory path", .metavar = "path" },
-        .display = .{ .help = "Display the result in the terminal (default if no output)" },
+        .output = .{ .help = "Output file or directory path", .metavar = "path", .short = 'o' },
+        .display = .{ .help = "Display the result in the terminal (default if no output)", .short = 'd' },
         .radius = .{ .help = "Radius for box/median blur (default: 1)", .metavar = "int" },
         .sigma = .{ .help = "Sigma for Gaussian blur (default: 1.0)", .metavar = "float" },
         .angle = .{ .help = "Angle in degrees for linear motion blur (default: 0)", .metavar = "deg" },
@@ -74,14 +74,6 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    var blur_type: BlurType = .gaussian;
-    if (parsed.options.type) |t| {
-        blur_type = common.parseEnum(BlurType, t) orelse {
-            std.log.err("unknown blur type: {s}", .{t});
-            return error.InvalidArguments;
-        };
-    }
-
     const is_batch = parsed.positionals.len > 1;
     var target: ?common.OutputTarget = null;
     if (parsed.options.output) |out_arg| {
@@ -91,30 +83,26 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const should_display = parsed.options.display or target == null;
 
     for (parsed.positionals) |input_path| {
-        processImage(io, writer, gpa, input_path, target, should_display, blur_type, parsed.options) catch |err| {
+        processImage(io, writer, gpa, input_path, target, should_display, parsed.options) catch |err| {
             std.log.err("failed to blur '{s}': {t}", .{ input_path, err });
             if (!is_batch) return err;
         };
     }
 }
 
-fn processImage(
-    io: Io,
-    writer: *Io.Writer,
-    gpa: Allocator,
-    input_path: []const u8,
-    target: ?common.OutputTarget,
-    should_display: bool,
-    blur_type: BlurType,
-    options: Args,
-) !void {
-    std.log.debug("loading {s}...", .{input_path});
-
-    var img: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
-    defer img.deinit(gpa);
+/// Blur `img` according to `options`, returning a freshly allocated image the
+/// caller owns. Shared by the standalone command and the `pipeline` command.
+pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options: Args) !zignal.Image(zignal.Rgba(u8)) {
+    var blur_type: BlurType = .gaussian;
+    if (options.type) |t| {
+        blur_type = common.parseEnum(BlurType, t) orelse {
+            std.log.err("unknown blur type: {s}", .{t});
+            return error.InvalidArguments;
+        };
+    }
 
     var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, img.rows, img.cols);
-    defer out.deinit(gpa);
+    errdefer out.deinit(gpa);
 
     std.log.info("applying {s} blur...", .{@tagName(blur_type)});
 
@@ -193,6 +181,25 @@ fn processImage(
     }
 
     timer.logElapsed("blur");
+    return out;
+}
+
+fn processImage(
+    io: Io,
+    writer: *Io.Writer,
+    gpa: Allocator,
+    input_path: []const u8,
+    target: ?common.OutputTarget,
+    should_display: bool,
+    options: Args,
+) !void {
+    std.log.debug("loading {s}...", .{input_path});
+
+    var img: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
+    defer img.deinit(gpa);
+
+    var out = try apply(io, gpa, img, options);
+    defer out.deinit(gpa);
 
     if (target) |tgt| {
         const resolved = try tgt.resolveOutputPath(gpa, input_path);

--- a/src/cli/common.zig
+++ b/src/cli/common.zig
@@ -70,24 +70,21 @@ pub fn resolveOutputTarget(
     };
 }
 
-/// Resolves the user's `--filter` string (if any) into an interpolation method.
-/// Defaults to bilinear.
-pub fn resolveFilter(name: ?[]const u8) !zignal.Interpolation {
-    const n = name orelse {
+/// The tag enum of `zignal.Interpolation` — usable directly as a CLI/ZON option
+/// field, since the tag names double as the accepted filter names.
+pub const InterpolationTag = @typeInfo(zignal.Interpolation).@"union".tag_type.?;
+
+/// Expands a selected interpolation tag into a full `Interpolation` value,
+/// defaulting to bilinear when unset. The `mitchell` payload uses `.default`.
+pub fn resolveFilter(tag: ?InterpolationTag) zignal.Interpolation {
+    const t = tag orelse {
         std.log.debug("using default filter: bilinear", .{});
         return .bilinear;
     };
-    std.log.debug("resolving filter: {s}", .{n});
-
-    const Tag = @typeInfo(zignal.Interpolation).@"union".tag_type.?;
-    const tag = parseEnum(Tag, n) orelse {
-        std.log.err("unknown filter type: {s}", .{n});
-        return error.InvalidArguments;
-    };
-    return switch (tag) {
+    return switch (t) {
         // The only variant with a payload — every other variant is bare.
         .mitchell => .{ .mitchell = .default },
-        inline else => |t| @unionInit(zignal.Interpolation, @tagName(t), {}),
+        inline else => |x| @unionInit(zignal.Interpolation, @tagName(x), {}),
     };
 }
 

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -16,7 +16,7 @@ const Args = struct {
     display: bool = false,
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .output = .{ .help = "Path to save the difference image", .metavar = "path", .short = 'o' },
@@ -119,7 +119,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         );
         defer canvas.deinit(gpa);
 
-        const format = try display.resolveDisplayFormat(parsed.options.protocol, null, null);
+        const format = display.resolveDisplayFormat(parsed.options.protocol, null, null);
         try display.displayCanvas(io, writer, &canvas, format);
     }
 }

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -19,11 +19,11 @@ const Args = struct {
     protocol: ?[]const u8 = null,
 
     pub const meta = .{
-        .output = .{ .help = "Path to save the difference image", .metavar = "path" },
+        .output = .{ .help = "Path to save the difference image", .metavar = "path", .short = 'o' },
         .scale = .{ .help = "Scale factor for difference visibility (default: 1.0)", .metavar = "float" },
         .threshold = .{ .help = "Ignore differences smaller than this value (0-255)", .metavar = "int" },
         .binary = .{ .help = "Produce a binary output (white for difference, black for match)" },
-        .display = .{ .help = "Display the result in the terminal (default if no output file)" },
+        .display = .{ .help = "Display the result in the terminal (default if no output file)", .short = 'd' },
         .width = .{ .help = "Width of each sub-image for display", .metavar = "N" },
         .height = .{ .help = "Height of each sub-image for display", .metavar = "N" },
         .protocol = .{ .help = display.protocol_help, .metavar = "p" },

--- a/src/cli/display.zig
+++ b/src/cli/display.zig
@@ -16,10 +16,14 @@ pub const protocol_names: []const u8 = common.joinFieldNames(zignal.DisplayForma
 /// that supports terminal display.
 pub const protocol_help: []const u8 = "Display protocol: " ++ protocol_names;
 
+/// The tag enum of `zignal.DisplayFormat` — usable directly as a CLI/ZON option
+/// field, since the tag names double as the accepted protocol names.
+pub const ProtocolTag = std.meta.Tag(zignal.DisplayFormat);
+
 const Args = struct {
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?ProtocolTag = null,
 
     pub const meta = .{
         .width = .{ .help = "Target width in pixels", .metavar = "N" },
@@ -45,7 +49,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    const display_fmt = try resolveDisplayFormat(
+    const display_fmt = resolveDisplayFormat(
         parsed.options.protocol,
         parsed.options.width,
         parsed.options.height,
@@ -67,27 +71,15 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 }
 
 pub fn resolveDisplayFormat(
-    protocol_name: ?[]const u8,
+    protocol: ?ProtocolTag,
     width: ?u32,
     height: ?u32,
-) !zignal.DisplayFormat {
-    var protocol: zignal.DisplayFormat = .{ .auto = .default };
-    if (protocol_name) |p| {
-        protocol = parseProtocol(p) catch |err| {
-            std.log.err("unknown protocol type: {s}", .{p});
-            return err;
-        };
-    }
-    applyOptions(&protocol, width, height);
-    return protocol;
-}
-
-pub fn parseProtocol(name: []const u8) !zignal.DisplayFormat {
-    const Tag = std.meta.Tag(zignal.DisplayFormat);
-    const tag = std.meta.stringToEnum(Tag, name) orelse return error.InvalidArguments;
-    return switch (tag) {
+) zignal.DisplayFormat {
+    var format: zignal.DisplayFormat = switch (protocol orelse .auto) {
         inline else => |t| @unionInit(zignal.DisplayFormat, @tagName(t), .default),
     };
+    applyOptions(&format, width, height);
+    return format;
 }
 
 pub fn applyOptions(protocol: *zignal.DisplayFormat, width: ?u32, height: ?u32) void {

--- a/src/cli/edges.zig
+++ b/src/cli/edges.zig
@@ -9,7 +9,7 @@ const common = @import("common.zig");
 const display = @import("display.zig");
 
 pub const Args = struct {
-    filter: ?[]const u8 = null,
+    filter: ?Algo = null,
     output: ?[]const u8 = null,
     display: bool = false,
 
@@ -23,7 +23,7 @@ pub const Args = struct {
     // Display options
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .filter = .{ .help = "Filter: " ++ common.joinFieldNames(Algo) ++ " (default: sobel)", .metavar = "name" },
@@ -84,13 +84,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 /// `out`. Shared by the standalone command (which stays on the u8 fast path) and
 /// the `apply` wrapper used by the `pipeline` command.
 pub fn applyGray(io: Io, gpa: Allocator, img: zignal.Image(u8), out: zignal.Image(u8), options: Args) !void {
-    var algo: Algo = .sobel;
-    if (options.filter) |f| {
-        algo = common.parseEnum(Algo, f) orelse {
-            std.log.err("unknown filter: {s}", .{f});
-            return error.InvalidArguments;
-        };
-    }
+    const algo = options.filter orelse .sobel;
 
     std.log.debug("applying {s} edge detection...", .{@tagName(algo)});
     const timer = common.Timer.begin(io);
@@ -165,7 +159,7 @@ fn processImage(
     }
 
     if (should_display) {
-        const format = try display.resolveDisplayFormat(options.protocol, options.width, options.height);
+        const format = display.resolveDisplayFormat(options.protocol, options.width, options.height);
         try display.displayCanvas(io, writer, out_img, format);
     }
 }

--- a/src/cli/edges.zig
+++ b/src/cli/edges.zig
@@ -8,7 +8,7 @@ const args = @import("args.zig");
 const common = @import("common.zig");
 const display = @import("display.zig");
 
-const Args = struct {
+pub const Args = struct {
     filter: ?[]const u8 = null,
     output: ?[]const u8 = null,
     display: bool = false,
@@ -27,8 +27,8 @@ const Args = struct {
 
     pub const meta = .{
         .filter = .{ .help = "Filter: " ++ common.joinFieldNames(Algo) ++ " (default: sobel)", .metavar = "name" },
-        .output = .{ .help = "Output file path (default: display only)", .metavar = "path" },
-        .display = .{ .help = "Display the result in the terminal (default if no output)" },
+        .output = .{ .help = "Output file path (default: display only)", .metavar = "path", .short = 'o' },
+        .display = .{ .help = "Display the result in the terminal (default if no output)", .short = 'd' },
         .sigma = .{ .help = "Canny sigma (def: 1.0) or Shen-Castan smoothing (def: 0.9)", .metavar = "float" },
         .low = .{ .help = "Canny low thresh (def: 50) or Shen-Castan low_rel (def: 0.5)", .metavar = "float" },
         .high = .{ .help = "Canny high thresh (def: 100) or Shen-Castan high_ratio (def: 0.99)", .metavar = "float" },
@@ -63,14 +63,6 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return;
     }
 
-    var algo: Algo = .sobel;
-    if (parsed.options.filter) |f| {
-        algo = common.parseEnum(Algo, f) orelse {
-            std.log.err("unknown filter: {s}", .{f});
-            return error.InvalidArguments;
-        };
-    }
-
     const is_batch = parsed.positionals.len > 1;
     var target: ?common.OutputTarget = null;
 
@@ -81,43 +73,38 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const should_display = parsed.options.display or target == null;
 
     for (parsed.positionals) |input_path| {
-        processImage(io, writer, gpa, input_path, target, should_display, algo, parsed.options) catch |err| {
+        processImage(io, writer, gpa, input_path, target, should_display, parsed.options) catch |err| {
             std.log.err("failed to process image '{s}': {t}", .{ input_path, err });
             if (!is_batch) return err;
         };
     }
 }
 
-fn processImage(
-    io: Io,
-    writer: *Io.Writer,
-    gpa: Allocator,
-    input_path: []const u8,
-    target: ?common.OutputTarget,
-    should_display: bool,
-    algo: Algo,
-    options: Args,
-) !void {
-    std.log.debug("loading image: {s}", .{input_path});
-    var img = try zignal.Image(u8).load(io, gpa, input_path);
-    defer img.deinit(gpa);
-
-    var out_img = try zignal.Image(u8).init(gpa, img.rows, img.cols);
-    defer out_img.deinit(gpa);
+/// Run the selected edge detector on a grayscale image into a caller-allocated
+/// `out`. Shared by the standalone command (which stays on the u8 fast path) and
+/// the `apply` wrapper used by the `pipeline` command.
+pub fn applyGray(io: Io, gpa: Allocator, img: zignal.Image(u8), out: zignal.Image(u8), options: Args) !void {
+    var algo: Algo = .sobel;
+    if (options.filter) |f| {
+        algo = common.parseEnum(Algo, f) orelse {
+            std.log.err("unknown filter: {s}", .{f});
+            return error.InvalidArguments;
+        };
+    }
 
     std.log.debug("applying {s} edge detection...", .{@tagName(algo)});
     const timer = common.Timer.begin(io);
 
     switch (algo) {
         .sobel => {
-            try img.sobel(out_img, gpa);
+            try img.sobel(out, gpa);
         },
         .canny => {
             const sigma = options.sigma orelse 1.0;
             const low = options.low orelse 50.0;
             const high = options.high orelse 100.0;
             std.log.debug("canny params: sigma={d:.2}, low={d:.2}, high={d:.2}", .{ sigma, low, high });
-            try img.canny(out_img, gpa, sigma, low, high);
+            try img.canny(out, gpa, sigma, low, high);
         },
         .shen_castan => {
             const opts = zignal.ShenCastan{
@@ -130,11 +117,44 @@ fn processImage(
             std.log.debug("shen_castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
                 opts.smooth, opts.window_size, opts.high_ratio, opts.low_rel, opts.use_nms,
             });
-            try img.shenCastan(out_img, gpa, opts);
+            try img.shenCastan(out, gpa, opts);
         },
     }
 
     timer.logElapsed("edge detection");
+}
+
+/// Pipeline-facing wrapper: detect edges on an RGBA image by bridging through
+/// grayscale, returning a freshly allocated RGBA image the caller owns.
+pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options: Args) !zignal.Image(zignal.Rgba(u8)) {
+    var gray = try img.convert(gpa, u8);
+    defer gray.deinit(gpa);
+
+    var edges_gray: zignal.Image(u8) = try .init(gpa, gray.rows, gray.cols);
+    defer edges_gray.deinit(gpa);
+
+    try applyGray(io, gpa, gray, edges_gray, options);
+
+    return edges_gray.convert(gpa, zignal.Rgba(u8));
+}
+
+fn processImage(
+    io: Io,
+    writer: *Io.Writer,
+    gpa: Allocator,
+    input_path: []const u8,
+    target: ?common.OutputTarget,
+    should_display: bool,
+    options: Args,
+) !void {
+    std.log.debug("loading image: {s}", .{input_path});
+    var img = try zignal.Image(u8).load(io, gpa, input_path);
+    defer img.deinit(gpa);
+
+    var out_img = try zignal.Image(u8).init(gpa, img.rows, img.cols);
+    defer out_img.deinit(gpa);
+
+    try applyGray(io, gpa, img, out_img, options);
 
     if (target) |tgt| {
         const resolved = try tgt.resolveOutputPath(gpa, input_path);

--- a/src/cli/fdm.zig
+++ b/src/cli/fdm.zig
@@ -12,7 +12,7 @@ const Args = struct {
     display: bool = false,
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .display = .{ .help = "Display the result in the terminal", .short = 'd' },
@@ -88,7 +88,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         );
         defer canvas.deinit(gpa);
 
-        const format = try display.resolveDisplayFormat(parsed.options.protocol, null, null);
+        const format = display.resolveDisplayFormat(parsed.options.protocol, null, null);
         try display.displayCanvas(io, writer, &canvas, format);
     }
 }

--- a/src/cli/fdm.zig
+++ b/src/cli/fdm.zig
@@ -15,7 +15,7 @@ const Args = struct {
     protocol: ?[]const u8 = null,
 
     pub const meta = .{
-        .display = .{ .help = "Display the result in the terminal" },
+        .display = .{ .help = "Display the result in the terminal", .short = 'd' },
         .width = .{ .help = "Width of each sub-image", .metavar = "N" },
         .height = .{ .help = "Height of each sub-image", .metavar = "N" },
         .protocol = .{ .help = display.protocol_help, .metavar = "p" },

--- a/src/cli/pipeline.zig
+++ b/src/cli/pipeline.zig
@@ -1,0 +1,180 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+
+const zignal = @import("zignal");
+
+const args = @import("args.zig");
+const common = @import("common.zig");
+const display = @import("display.zig");
+
+const resize = @import("resize.zig");
+const blur = @import("blur.zig");
+const edges = @import("edges.zig");
+
+/// Recipes are tiny; cap the read to guard against accidentally huge files.
+const max_recipe_bytes = 1 << 20; // 1 MiB
+
+/// One pipeline step. Each variant's payload is the exact `Args` struct of the
+/// matching CLI command, so recipe fields mirror the CLI options one-to-one.
+const Step = union(enum) {
+    resize: resize.Args,
+    blur: blur.Args,
+    edges: edges.Args,
+};
+
+/// A full pipeline as described by a `.zon` recipe file.
+const Recipe = struct {
+    input: ?[]const u8 = null,
+    output: ?[]const u8 = null,
+    steps: []const Step = &.{},
+};
+
+/// CLI-level flags for the `pipeline` command itself. `--output` overrides the
+/// recipe's `.output`; the display flags mirror the other commands.
+const Args = struct {
+    output: ?[]const u8 = null,
+    display: bool = false,
+    width: ?u32 = null,
+    height: ?u32 = null,
+    protocol: ?[]const u8 = null,
+
+    pub const meta = .{
+        .output = .{ .help = "Output file or directory (overrides recipe .output)", .metavar = "path", .short = 'o' },
+        .display = .{ .help = "Display the result in the terminal (default if no output)", .short = 'd' },
+        .width = .{ .help = "Display width", .metavar = "N" },
+        .height = .{ .help = "Display height", .metavar = "N" },
+        .protocol = .{ .help = display.protocol_help, .metavar = "p" },
+    };
+};
+
+pub const description =
+    \\Apply a sequence of operations described by a .zon recipe file.
+    \\
+    \\A recipe lists ordered steps; each step's fields mirror the matching CLI
+    \\command's options (enum values are plain strings, e.g. "gaussian"). The
+    \\recipe may set .input/.output, which a CLI positional/--output override.
+    \\
+    \\Example recipe (recipe.zon):
+    \\  .{
+    \\      .input = "assets/liza.jpg",
+    \\      .output = "out.png",
+    \\      .steps = .{
+    \\          .{ .resize = .{ .width = 800, .filter = "lanczos" } },
+    \\          .{ .blur = .{ .type = "gaussian", .sigma = 2.0 } },
+    \\          .{ .edges = .{ .filter = "sobel" } },
+    \\      },
+    \\  }
+;
+
+pub const help = args.generateHelp(
+    Args,
+    "zignal pipeline <recipe.zon> [images...] [options]",
+    description,
+);
+
+pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Args.Iterator) !void {
+    const parsed = try args.parse(Args, gpa, iterator);
+    defer parsed.deinit(gpa);
+
+    if (parsed.help or parsed.positionals.len == 0) {
+        try args.printHelp(writer, help);
+        return;
+    }
+
+    const recipe_path = parsed.positionals[0];
+    const input_overrides = parsed.positionals[1..];
+
+    // The recipe and every string it references live in this arena for the
+    // duration of processing.
+    var arena_state: std.heap.ArenaAllocator = .init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const bytes = Io.Dir.cwd().readFileAlloc(io, recipe_path, arena, .limited(max_recipe_bytes)) catch |err| {
+        std.log.err("failed to read recipe '{s}': {t}", .{ recipe_path, err });
+        return error.InvalidArguments;
+    };
+    const source = try arena.dupeSentinel(u8, bytes, 0);
+
+    var diag: std.zon.parse.Diagnostics = .{};
+    const recipe = std.zon.parse.fromSliceAlloc(Recipe, arena, source, &diag, .{ .free_on_error = false }) catch |err| switch (err) {
+        error.ParseZon => {
+            std.log.err("invalid recipe '{s}':\n{f}", .{ recipe_path, diag });
+            return error.InvalidArguments;
+        },
+        else => |e| return e,
+    };
+
+    if (recipe.steps.len == 0) {
+        std.log.warn("recipe '{s}' has no steps; output will equal input", .{recipe_path});
+    }
+
+    // Inputs: CLI positionals win, otherwise the recipe's `.input`.
+    var single_input: [1][]const u8 = undefined;
+    const inputs: []const []const u8 = if (input_overrides.len > 0)
+        input_overrides
+    else if (recipe.input) |in| blk: {
+        single_input[0] = in;
+        break :blk &single_input;
+    } else {
+        std.log.err("no input image: recipe has no .input and none given on the command line", .{});
+        return error.InvalidArguments;
+    };
+
+    // Output: CLI --output wins, otherwise the recipe's `.output`.
+    const output_arg = parsed.options.output orelse recipe.output;
+    const is_batch = inputs.len > 1;
+    var target: ?common.OutputTarget = null;
+    if (output_arg) |out| {
+        target = try common.resolveOutputTarget(io, out, is_batch);
+    }
+
+    const should_display = parsed.options.display or target == null;
+
+    for (inputs) |input_path| {
+        processImage(io, writer, gpa, input_path, recipe.steps, target, should_display, parsed.options) catch |err| {
+            std.log.err("failed to process '{s}': {t}", .{ input_path, err });
+            if (!is_batch) return err;
+        };
+    }
+}
+
+fn processImage(
+    io: Io,
+    writer: *Io.Writer,
+    gpa: Allocator,
+    input_path: []const u8,
+    steps: []const Step,
+    target: ?common.OutputTarget,
+    should_display: bool,
+    options: Args,
+) !void {
+    std.log.debug("loading {s}...", .{input_path});
+
+    var current: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
+    defer current.deinit(gpa);
+
+    for (steps, 1..) |step, step_no| {
+        std.log.info("step {d}: {s}", .{ step_no, @tagName(step) });
+        const next = switch (step) {
+            .resize => |o| try resize.apply(io, gpa, current, o),
+            .blur => |o| try blur.apply(io, gpa, current, o),
+            .edges => |o| try edges.apply(io, gpa, current, o),
+        };
+        current.deinit(gpa);
+        current = next;
+    }
+
+    if (target) |tgt| {
+        const resolved = try tgt.resolveOutputPath(gpa, input_path);
+        defer resolved.deinit(gpa);
+        std.log.info("saving to {s}...", .{resolved.path});
+        try current.save(io, gpa, resolved.path);
+    }
+
+    if (should_display) {
+        const format = try display.resolveDisplayFormat(options.protocol, options.width, options.height);
+        try display.displayCanvas(io, writer, current, format);
+    }
+}

--- a/src/cli/pipeline.zig
+++ b/src/cli/pipeline.zig
@@ -37,7 +37,7 @@ const Args = struct {
     display: bool = false,
     width: ?u32 = null,
     height: ?u32 = null,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .output = .{ .help = "Output file or directory (overrides recipe .output)", .metavar = "path", .short = 'o' },
@@ -52,17 +52,17 @@ pub const description =
     \\Apply a sequence of operations described by a .zon recipe file.
     \\
     \\A recipe lists ordered steps; each step's fields mirror the matching CLI
-    \\command's options (enum values are plain strings, e.g. "gaussian"). The
-    \\recipe may set .input/.output, which a CLI positional/--output override.
+    \\command's options (enum-valued options are enum literals, e.g. .gaussian).
+    \\The recipe may set .input/.output, which a CLI positional/--output override.
     \\
     \\Example recipe (recipe.zon):
     \\  .{
     \\      .input = "assets/liza.jpg",
     \\      .output = "out.png",
     \\      .steps = .{
-    \\          .{ .resize = .{ .width = 800, .filter = "lanczos" } },
-    \\          .{ .blur = .{ .type = "gaussian", .sigma = 2.0 } },
-    \\          .{ .edges = .{ .filter = "sobel" } },
+    \\          .{ .resize = .{ .width = 800, .filter = .lanczos } },
+    \\          .{ .blur = .{ .type = .gaussian, .sigma = 2.0 } },
+    \\          .{ .edges = .{ .filter = .sobel } },
     \\      },
     \\  }
 ;
@@ -174,7 +174,7 @@ fn processImage(
     }
 
     if (should_display) {
-        const format = try display.resolveDisplayFormat(options.protocol, options.width, options.height);
+        const format = display.resolveDisplayFormat(options.protocol, options.width, options.height);
         try display.displayCanvas(io, writer, current, format);
     }
 }

--- a/src/cli/qr.zig
+++ b/src/cli/qr.zig
@@ -20,7 +20,7 @@ const Args = struct {
         .symbol_version = .{ .help = "Force the QR version 1-40 (default: smallest that fits)", .metavar = "1-40" },
         .module_size = .{ .help = "Pixels per module when saving an image (default 8)", .metavar = "pixels" },
         .quiet_zone = .{ .help = "Light border around the symbol in modules (default 4)", .metavar = "modules" },
-        .output = .{ .help = "Save the encoded QR as an image instead of printing it", .metavar = "path" },
+        .output = .{ .help = "Save the encoded QR as an image instead of printing it", .metavar = "path", .short = 'o' },
     };
 };
 

--- a/src/cli/resize.zig
+++ b/src/cli/resize.zig
@@ -7,7 +7,7 @@ const zignal = @import("zignal");
 const args = @import("args.zig");
 const common = @import("common.zig");
 
-const Args = struct {
+pub const Args = struct {
     scale: ?f32 = null,
     width: ?u32 = null,
     height: ?u32 = null,
@@ -19,7 +19,7 @@ const Args = struct {
         .width = .{ .help = "Target width in pixels", .metavar = "pixels" },
         .height = .{ .help = "Target height in pixels", .metavar = "pixels" },
         .filter = .{ .help = "Interpolation filter (" ++ common.joinFieldNames(zignal.Interpolation) ++ ")", .metavar = "name" },
-        .output = .{ .help = "Output file or directory path (mandatory)", .metavar = "path" },
+        .output = .{ .help = "Output file or directory path (mandatory)", .metavar = "path", .short = 'o' },
     };
 };
 
@@ -45,27 +45,47 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         return error.InvalidArguments;
     };
 
-    if (parsed.options.scale != null and (parsed.options.width != null or parsed.options.height != null)) {
-        std.log.err("cannot specify both --scale and --width/--height", .{});
-        return error.InvalidArguments;
-    }
-
-    if (parsed.options.scale == null and parsed.options.width == null and parsed.options.height == null) {
-        std.log.err("must specify at least one of --scale, --width, or --height", .{});
-        return error.InvalidArguments;
-    }
-
-    const filter = try common.resolveFilter(parsed.options.filter);
-
     const is_batch = parsed.positionals.len > 1;
     const target = try common.resolveOutputTarget(io, output_arg, is_batch);
 
     for (parsed.positionals) |input_path| {
-        processImage(io, gpa, input_path, target, is_batch, filter, parsed.options) catch |err| {
+        processImage(io, gpa, input_path, target, is_batch, parsed.options) catch |err| {
             std.log.err("failed to resize '{s}': {t}", .{ input_path, err });
             if (!is_batch) return err;
         };
     }
+}
+
+/// Resize `img` according to `options`, returning a freshly allocated image the
+/// caller owns. Shared by the standalone command and the `pipeline` command.
+pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options: Args) !zignal.Image(zignal.Rgba(u8)) {
+    if (img.rows == 0 or img.cols == 0) {
+        std.log.err("input image has zero dimensions ({d}x{d})", .{ img.cols, img.rows });
+        return error.InvalidDimensions;
+    }
+
+    if (options.scale != null and (options.width != null or options.height != null)) {
+        std.log.err("cannot specify both scale and width/height", .{});
+        return error.InvalidArguments;
+    }
+    if (options.scale == null and options.width == null and options.height == null) {
+        std.log.err("must specify at least one of scale, width, or height", .{});
+        return error.InvalidArguments;
+    }
+
+    const filter = try common.resolveFilter(options.filter);
+    const dims = try computeTargetDimensions(img, options);
+
+    std.log.info("resizing from {d}x{d} to {d}x{d} using {s}...", .{ img.cols, img.rows, dims.width, dims.height, @tagName(filter) });
+
+    var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, dims.height, dims.width);
+    errdefer out.deinit(gpa);
+
+    const timer = common.Timer.begin(io);
+    img.resize(out, gpa, filter);
+    timer.logElapsed("resize");
+
+    return out;
 }
 
 fn processImage(
@@ -74,7 +94,6 @@ fn processImage(
     input_path: []const u8,
     target: common.OutputTarget,
     is_batch: bool,
-    filter: zignal.Interpolation,
     options: Args,
 ) !void {
     std.log.debug("{s} {s}...", .{ if (is_batch) "processing" else "loading", input_path });
@@ -85,24 +104,10 @@ fn processImage(
     var img: zignal.Image(zignal.Rgba(u8)) = try .load(io, gpa, input_path);
     defer img.deinit(gpa);
 
-    if (img.rows == 0 or img.cols == 0) {
-        std.log.err("input image has zero dimensions ({d}x{d})", .{ img.cols, img.rows });
-        return error.InvalidDimensions;
-    }
-
-    const dims = try computeTargetDimensions(img, options);
-
-    const indent: []const u8 = if (is_batch) "  " else "";
-    std.log.info("{s}resizing from {d}x{d} to {d}x{d} using {s}...", .{ indent, img.cols, img.rows, dims.width, dims.height, @tagName(filter) });
-
-    var out: zignal.Image(zignal.Rgba(u8)) = try .init(gpa, dims.height, dims.width);
+    var out = try apply(io, gpa, img, options);
     defer out.deinit(gpa);
 
-    const timer = common.Timer.begin(io);
-    img.resize(out, gpa, filter);
-    timer.logElapsed("resize");
-
-    std.log.info("{s}saving to {s}...", .{ indent, resolved.path });
+    std.log.info("saving to {s}...", .{resolved.path});
     try out.save(io, gpa, resolved.path);
 }
 

--- a/src/cli/resize.zig
+++ b/src/cli/resize.zig
@@ -11,7 +11,7 @@ pub const Args = struct {
     scale: ?f32 = null,
     width: ?u32 = null,
     height: ?u32 = null,
-    filter: ?[]const u8 = null,
+    filter: ?common.InterpolationTag = null,
     output: ?[]const u8 = null,
 
     pub const meta = .{
@@ -73,7 +73,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
         return error.InvalidArguments;
     }
 
-    const filter = try common.resolveFilter(options.filter);
+    const filter = common.resolveFilter(options.filter);
     const dims = try computeTargetDimensions(img, options);
 
     std.log.info("resizing from {d}x{d} to {d}x{d} using {s}...", .{ img.cols, img.rows, dims.width, dims.height, @tagName(filter) });

--- a/src/cli/tile.zig
+++ b/src/cli/tile.zig
@@ -17,14 +17,14 @@ const LayoutMode = enum {
 };
 
 const Args = struct {
-    mode: ?[]const u8 = null,
+    mode: ?LayoutMode = null,
     rows: ?u32 = null,
     cols: ?u32 = null,
     width: ?u32 = null,
     height: ?u32 = null,
     output: ?[]const u8 = null,
     display: bool = false,
-    protocol: ?[]const u8 = null,
+    protocol: ?display.ProtocolTag = null,
 
     pub const meta = .{
         .mode = .{ .help = "Layout mode: " ++ common.joinFieldNames(LayoutMode), .metavar = "mode" },
@@ -61,13 +61,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
 
     const should_display = parsed.options.display or output_path == null;
 
-    var mode: LayoutMode = .square;
-    if (parsed.options.mode) |m| {
-        mode = common.parseEnum(LayoutMode, m) orelse {
-            std.log.err("unknown layout mode: {s}", .{m});
-            return error.InvalidArguments;
-        };
-    }
+    const mode = parsed.options.mode orelse .square;
 
     var rows: u32 = 0;
     var cols: u32 = 0;
@@ -204,7 +198,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     }
 
     if (should_display) {
-        const format = try display.resolveDisplayFormat(parsed.options.protocol, null, null);
+        const format = display.resolveDisplayFormat(parsed.options.protocol, null, null);
         try display.displayCanvas(io, writer, &canvas, format);
     }
 }

--- a/src/cli/tile.zig
+++ b/src/cli/tile.zig
@@ -32,8 +32,8 @@ const Args = struct {
         .cols = .{ .help = "Number of columns (for grid mode)", .metavar = "N" },
         .width = .{ .help = "Force cell width (default: first image width)", .metavar = "N" },
         .height = .{ .help = "Force cell height (default: first image height)", .metavar = "N" },
-        .output = .{ .help = "Output file path", .metavar = "file" },
-        .display = .{ .help = "Display the result in the terminal" },
+        .output = .{ .help = "Output file path", .metavar = "file", .short = 'o' },
+        .display = .{ .help = "Display the result in the terminal", .short = 'd' },
         .protocol = .{ .help = display.protocol_help, .metavar = "p" },
     };
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,7 @@ pub const edges = @import("cli/edges.zig");
 pub const fdm = @import("cli/fdm.zig");
 pub const info = @import("cli/info.zig");
 pub const metrics = @import("cli/metrics.zig");
+pub const pipeline = @import("cli/pipeline.zig");
 pub const qr = @import("cli/qr.zig");
 pub const resize = @import("cli/resize.zig");
 pub const tile = @import("cli/tile.zig");


### PR DESCRIPTION
Introduces a new `pipeline` command to run sequential image operations
defined in a `.zon` recipe file.

Also adds support for single-character short option aliases (e.g., `-o`
and `-d`) across CLI commands, and refactors `blur`, `edges`, and
`resize` to expose reusable `apply` functions.