### PR TITLE
feat(iterm2): add inline image protocol support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -82,6 +82,7 @@ pub fn build(b: *Build) void {
         .{ .name = "pca", .path = "src/pca.zig" },
         .{ .name = "sixel", .path = "src/sixel.zig" },
         .{ .name = "kitty", .path = "src/kitty.zig" },
+        .{ .name = "iterm2", .path = "src/iterm2.zig" },
         .{ .name = "terminal", .path = "src/terminal.zig" },
         .{ .name = "font", .path = "src/font.zig" },
         .{ .name = "features", .path = "src/features.zig" },

--- a/src/image.zig
+++ b/src/image.zig
@@ -448,7 +448,8 @@ pub fn Image(comptime T: type) type {
         /// - `.braille`: Uses Braille patterns for 2x4 resolution (requires Unicode Braille support U+2800-U+28FF; dots binarized by `threshold`, optionally tinted with truecolor or a quantized palette)
         /// - `.sixel`: Uses the sixel graphics protocol if supported
         /// - `.kitty`: Uses the kitty graphics protocol if supported
-        /// - `.auto`: Automatically selects best available format: kitty -> sixel -> sgr
+        /// - `.iterm2`: Uses the iTerm2 inline image protocol if supported
+        /// - `.auto`: Automatically selects best available format: kitty -> iterm2 -> sixel -> sgr
         ///
         /// Example:
         /// ```zig

--- a/src/image/display.zig
+++ b/src/image/display.zig
@@ -6,6 +6,7 @@ const Io = std.Io;
 const color = @import("../color.zig");
 const Image = @import("../image.zig").Image;
 const Interpolation = @import("interpolation.zig").Interpolation;
+const iterm2 = @import("../iterm2.zig");
 const kitty = @import("../kitty.zig");
 const quantize = @import("quantize.zig");
 const sixel = @import("../sixel.zig");
@@ -13,7 +14,7 @@ const terminal = @import("../terminal.zig");
 
 /// Display format options
 pub const DisplayFormat = union(enum) {
-    /// Automatically detect the best format (kitty -> sixel -> sgr)
+    /// Automatically detect the best format (kitty -> iterm2 -> sixel -> sgr)
     auto: struct {
         /// Optional target width in pixels
         width: ?u32 = null,
@@ -25,6 +26,8 @@ pub const DisplayFormat = union(enum) {
     },
     /// Kitty graphics protocol with options
     kitty: kitty.Options,
+    /// iTerm2 inline image protocol with options
+    iterm2: iterm2.Options,
     /// Force sixel output with specific options
     sixel: sixel.Options,
     /// SGR (Select Graphic Rendition) with Unicode half-block characters for 2x vertical resolution
@@ -71,7 +74,7 @@ pub const DisplayFormat = union(enum) {
     /// not resample.
     pub fn setInterpolation(self: *DisplayFormat, interp: Interpolation) void {
         switch (self.*) {
-            inline .kitty, .sixel, .auto => |*opts| opts.interpolation = interp,
+            inline .kitty, .iterm2, .sixel, .auto => |*opts| opts.interpolation = interp,
             .sgr, .braille => {},
         }
     }
@@ -113,6 +116,12 @@ pub fn DisplayFormatter(comptime T: type) type {
                         opts.height = options.height;
                         if (options.interpolation) |interp| opts.interpolation = interp;
                         continue :fmt .{ .kitty = opts };
+                    } else if (iterm2.isSupported(self.io)) {
+                        var opts: iterm2.Options = .default;
+                        opts.width = options.width;
+                        opts.height = options.height;
+                        if (options.interpolation) |interp| opts.interpolation = interp;
+                        continue :fmt .{ .iterm2 = opts };
                     } else if (sixel.isSupported(self.io)) {
                         var opts: sixel.Options = .default;
                         opts.width = options.width;
@@ -135,6 +144,18 @@ pub fn DisplayFormatter(comptime T: type) type {
                     } else {
                         try writer.writeAll("\x1b_Ga=d\x1b\\");
                     }
+                },
+                .iterm2 => |options| {
+                    const data = iterm2.fromImage(T, self.image.*, allocator, options) catch |err| switch (err) {
+                        error.OutOfMemory => iterm2.fromImage(T, self.image.*, allocator, .default) catch null,
+                        else => null,
+                    };
+                    if (data) |d| {
+                        try writer.writeAll(d);
+                    } else if (self.display_format == .auto) {
+                        continue :fmt .{ .sgr = .{ .width = options.width, .height = options.height } };
+                    }
+                    // iTerm2 has no image-reset sequence; on failure emit nothing.
                 },
                 .sixel => |options| {
                     const data = sixel.fromImage(T, self.image.*, allocator, options) catch |err| switch (err) {

--- a/src/iterm2.zig
+++ b/src/iterm2.zig
@@ -1,0 +1,152 @@
+//! iTerm2 inline image protocol support for image rendering
+//!
+//! This module converts images to the iTerm2 inline image protocol (`OSC 1337`),
+//! supported by iTerm2, WezTerm, and other compatible terminal emulators.
+//!
+//! The image is PNG-encoded and base64-wrapped in a single control sequence:
+//! `ESC ] 1337 ; File = inline=1 ; size=<bytes> : <base64> BEL`.
+//! Unlike Kitty, there is no cache/placement lifecycle — each call emits one
+//! self-contained image at the cursor.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const Image = @import("image.zig").Image;
+const Interpolation = @import("image/interpolation.zig").Interpolation;
+const png = @import("codecs.zig").png;
+const Rgb = @import("color.zig").Rgb(u8);
+const terminal = @import("terminal.zig");
+
+/// Options for iTerm2 inline image encoding
+pub const Options = struct {
+    /// Display width in pixels (null = image's natural width)
+    width: ?u32 = null,
+    /// Display height in pixels (null = aspect-preserved from width, or natural height)
+    height: ?u32 = null,
+    /// Interpolation method to use when scaling the image
+    interpolation: Interpolation = .bilinear,
+
+    /// Default options for automatic formatting
+    pub const default: Options = .{
+        .width = null,
+        .height = null,
+        .interpolation = .bilinear,
+    };
+};
+
+/// Converts an image to iTerm2 inline image protocol format
+pub fn fromImage(
+    comptime T: type,
+    image: Image(T),
+    gpa: Allocator,
+    options: Options,
+) ![]u8 {
+    var image_to_encode = image;
+    var scaled_image: ?Image(T) = null;
+    defer if (scaled_image) |*img| img.deinit(gpa);
+
+    const scale_factor = terminal.aspectScale(options.width, options.height, image.rows, image.cols);
+    if (@abs(scale_factor - 1.0) > 0.001) {
+        scaled_image = try image.scale(gpa, scale_factor, options.interpolation);
+        image_to_encode = scaled_image.?;
+    }
+
+    const png_data = try png.encode(T, gpa, image_to_encode, .default);
+    defer gpa.free(png_data);
+
+    const encoder = std.base64.standard.Encoder;
+    const base64_data = try gpa.alloc(u8, encoder.calcSize(png_data.len));
+    defer gpa.free(base64_data);
+    _ = encoder.encode(base64_data, png_data);
+
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(gpa);
+    try output.ensureTotalCapacity(gpa, base64_data.len + 64);
+
+    // OSC 1337 ; File=inline=1 ; size=<png bytes> : <base64> BEL.
+    // `size` is the decoded (PNG) byte count, not the base64 length.
+    try output.print(gpa, "\x1b]1337;File=inline=1;size={d}:", .{png_data.len});
+    try output.appendSlice(gpa, base64_data);
+    try output.append(gpa, 0x07);
+    return output.toOwnedSlice(gpa);
+}
+
+/// Detects if the terminal supports the iTerm2 inline image protocol.
+/// Identified via the terminal's XTVERSION name (iTerm2, WezTerm).
+pub fn isSupported(io: std.Io) bool {
+    if (!terminal.isStdoutTty(io)) return false;
+    return terminal.isIterm2Supported(io) catch false;
+}
+
+// Tests
+test "imageToIterm2 basic functionality" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var img = try Image(Rgb).init(allocator, 2, 2);
+    defer img.deinit(allocator);
+
+    img.at(0, 0).* = Rgb{ .r = 255, .g = 0, .b = 0 };
+    img.at(0, 1).* = Rgb{ .r = 0, .g = 255, .b = 0 };
+    img.at(1, 0).* = Rgb{ .r = 0, .g = 0, .b = 255 };
+    img.at(1, 1).* = Rgb{ .r = 255, .g = 255, .b = 255 };
+
+    const data = try fromImage(Rgb, img, allocator, .default);
+    defer allocator.free(data);
+
+    // Starts with the OSC 1337 File preamble
+    try testing.expect(std.mem.startsWith(u8, data, "\x1b]1337;File="));
+    // Marks the payload as an inline image with a declared size
+    try testing.expect(std.mem.find(u8, data, "inline=1") != null);
+    try testing.expect(std.mem.find(u8, data, "size=") != null);
+    // Terminated by BEL
+    try testing.expect(std.mem.endsWith(u8, data, "\x07"));
+}
+
+test "imageToIterm2 with scaling" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var img = try Image(Rgb).init(allocator, 4, 4);
+    defer img.deinit(allocator);
+
+    for (0..4) |y| {
+        for (0..4) |x| {
+            const val: u8 = @intCast((x + y) * 32);
+            img.at(y, x).* = Rgb{ .r = val, .g = val, .b = val };
+        }
+    }
+
+    const options: Options = .{ .width = 16, .height = 16 };
+    const data = try fromImage(Rgb, img, allocator, options);
+    defer allocator.free(data);
+
+    try testing.expect(std.mem.startsWith(u8, data, "\x1b]1337;File="));
+    try testing.expect(std.mem.endsWith(u8, data, "\x07"));
+    try testing.expect(data.len > 100);
+}
+
+test "imageToIterm2 declared size matches decoded payload" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var img = try Image(Rgb).init(allocator, 3, 3);
+    defer img.deinit(allocator);
+    for (0..3) |y| for (0..3) |x| {
+        img.at(y, x).* = Rgb{ .r = @intCast(x * 80), .g = @intCast(y * 80), .b = 40 };
+    };
+
+    const data = try fromImage(Rgb, img, allocator, .default);
+    defer allocator.free(data);
+
+    // Parse the declared size and the base64 payload, then verify size ==
+    // decoded length so the `size=` field can't silently drift to base64 length.
+    const size_start = (std.mem.find(u8, data, "size=") orelse unreachable) + "size=".len;
+    const colon = std.mem.indexOfScalarPos(u8, data, size_start, ':') orelse unreachable;
+    const declared_size = try std.fmt.parseInt(usize, data[size_start..colon], 10);
+
+    const payload = data[colon + 1 .. data.len - 1]; // strip trailing BEL
+    const decoder = std.base64.standard.Decoder;
+    const decoded_len = try decoder.calcSizeForSlice(payload);
+    try testing.expectEqual(declared_size, decoded_len);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -81,6 +81,7 @@ pub const dither = @import("image/dither.zig");
 pub const terminal = @import("terminal.zig");
 pub const sixel = @import("sixel.zig");
 pub const kitty = @import("kitty.zig");
+pub const iterm2 = @import("iterm2.zig");
 
 const codecs = @import("codecs.zig");
 pub const png = codecs.png;

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -1,7 +1,7 @@
 //! Terminal capability detection and support utilities
 //!
 //! Provides cross-platform terminal detection for graphics protocols
-//! (sixel, kitty) and other terminal features.
+//! (sixel, kitty, iterm2) and other terminal features.
 
 const std = @import("std");
 const Io = std.Io;
@@ -93,6 +93,33 @@ pub fn isKittySupported(io: Io) !bool {
     // If we get a graphics query response, Kitty is supported
     // The response will contain "\x1b_G" if Kitty processed the graphics query
     return std.mem.find(u8, response, "\x1b_G") != null;
+}
+
+/// Detect if the terminal supports the iTerm2 inline image protocol.
+///
+/// iTerm2 inline images (`OSC 1337`) have no dedicated probe, so we identify the
+/// terminal via XTVERSION (`CSI > q`), which iTerm2 and WezTerm answer with a
+/// `DCS > | <name> ST` string naming themselves; both implement the protocol.
+/// The query is chased with primary Device Attributes so terminals that ignore
+/// XTVERSION still reply and we don't wait out the full timeout.
+pub fn isIterm2Supported(io: Io) !bool {
+    var state: State = try .init(io);
+    defer state.deinit();
+
+    var response_buf: [response_buffer_size]u8 = undefined;
+    const query_seq = "\x1b[>q\x1b[c";
+
+    const response = state.query(query_seq, &response_buf, 100) catch |err| {
+        std.log.debug("iterm2 xtversion query: {s}", .{@errorName(err)});
+        return err;
+    };
+
+    std.log.debug("iterm2 query response ({d} bytes): {f}", .{ response.len, std.ascii.hexEscape(response, .lower) });
+
+    // XTVERSION name is reported inside the DCS reply, e.g. "iTerm2 3.5.0" or
+    // "WezTerm ...". Both report a stable casing, so an exact match suffices.
+    return std.mem.find(u8, response, "iTerm2") != null or
+        std.mem.find(u8, response, "WezTerm") != null;
 }
 
 /// Compute aspect-preserving scale factor given optional target width/height.


### PR DESCRIPTION
Implements the iTerm2 inline image protocol (OSC 1337) for rendering images in compatible terminals like iTerm2 and WezTerm. Integrates it into the automatic display format detection pipeline.