### PR TITLE
feat(examples): add image codec playground

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -21,6 +21,7 @@ pub fn build(b: *std.Build) void {
         "hough_animation",
         "global_optimization",
         "qrcode",
+        "codec_playground",
     };
 
     // List of additional examples to build as executables

--- a/examples/src/codec_playground.zig
+++ b/examples/src/codec_playground.zig
@@ -1,0 +1,291 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const zignal = @import("zignal");
+const Image = zignal.Image;
+const ImageFormat = zignal.ImageFormat;
+const png = zignal.png;
+const jpeg = zignal.jpeg;
+const bmp = zignal.bmp;
+const gif = zignal.gif;
+
+const Rgba = zignal.Rgba(u8);
+
+const js = @import("js.zig");
+
+pub const std_options: std.Options = .{
+    .logFn = if (builtin.cpu.arch.isWasm()) js.logFn else std.log.defaultLog,
+    .log_level = std.log.default_level,
+};
+
+comptime {
+    _ = js.alloc;
+    _ = js.free;
+}
+
+pub fn panic(msg: []const u8, st: ?*std.builtin.StackTrace, addr: ?usize) noreturn {
+    _ = st;
+    _ = addr;
+    std.log.err("panic: {s}", .{msg});
+    @trap();
+}
+
+const allocator = if (builtin.cpu.arch.isWasm() and builtin.os.tag == .freestanding)
+    std.heap.wasm_allocator
+else
+    std.heap.page_allocator;
+
+// Single-image pipeline state; all results cross the JS boundary as JSON via json_ptr/json_len.
+var g_source: ?Image(Rgba) = null;
+var g_source_gray: bool = false;
+var g_gray: ?Image(u8) = null; // lazy grayscale conversion of g_source
+var g_encoded: ?[]u8 = null;
+var g_output: ?Image(Rgba) = null;
+var g_json: ?[]u8 = null;
+
+fn setJson(json: []u8) void {
+    if (g_json) |old| allocator.free(old);
+    g_json = json;
+}
+
+fn fail(err_name: []const u8, message: []const u8) i32 {
+    const json = std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":false,\"error\":\"{s}\",\"message\":\"{s}\"}}",
+        .{ err_name, message },
+    ) catch @panic("OOM");
+    setJson(json);
+    return 0;
+}
+
+fn failErr(err: anyerror) i32 {
+    const message = switch (err) {
+        error.ImageTooLarge, error.PngDataTooLarge => "Image exceeds the decoder size limits.",
+        error.OutOfMemory => "Out of memory.",
+        else => "",
+    };
+    return fail(@errorName(err), message);
+}
+
+pub export fn json_ptr() [*]const u8 {
+    return if (g_json) |json| json.ptr else @ptrCast("");
+}
+
+pub export fn json_len() usize {
+    return if (g_json) |json| json.len else 0;
+}
+
+fn isGrayscale(image: Image(Rgba)) bool {
+    for (image.data) |px| {
+        if (px.r != px.g or px.g != px.b or px.a != 255) return false;
+    }
+    return true;
+}
+
+/// Writes the info-object fields sans surrounding braces so callers can append
+/// their own; enums emit raw tag names (display formatting lives in JS).
+fn writeInfoFields(w: *std.Io.Writer, format: ImageFormat, data: []const u8) !void {
+    switch (format) {
+        inline else => |f| {
+            const codec = switch (f) {
+                .jpeg => jpeg,
+                .png => png,
+                .bmp => bmp,
+                .gif => gif,
+            };
+            var reader: std.Io.Reader = .fixed(data);
+            const h = try codec.getInfo(&reader, .{});
+            try w.print("\"format\":\"{t}\",\"width\":{d},\"height\":{d},\"file_size\":{d},\"details\":{{", .{ f, h.width, h.height, data.len });
+            switch (f) {
+                .jpeg => {
+                    try w.print("\"frame_type\":\"{t}\",\"num_components\":{d},\"precision\":{d},\"subsampling\":", .{ h.frame_type, h.num_components, h.precision });
+                    if (h.subsampling) |s| try w.print("\"{t}\"", .{s}) else try w.writeAll("null");
+                },
+                .png => {
+                    try w.print("\"bit_depth\":{d},\"color_type\":\"{t}\",\"interlaced\":{},\"gamma\":", .{ h.bit_depth, h.color_type, h.interlace_method == 1 });
+                    if (h.gamma) |g| try w.print("{d:.4}", .{g}) else try w.writeAll("null");
+                    try w.writeAll(",\"srgb_intent\":");
+                    if (h.srgb_intent) |s| try w.print("\"{t}\"", .{s}) else try w.writeAll("null");
+                },
+                .bmp => {
+                    // tagName over {t}: Compression and DibHeaderKind are non-exhaustive.
+                    try w.print("\"bit_depth\":{d},\"compression\":\"{s}\",\"dib_header\":\"{s}\",\"top_down\":{},\"palette_entries\":{d},\"has_alpha\":{}", .{
+                        h.bit_depth,
+                        std.enums.tagName(bmp.Compression, h.compression) orelse "unknown",
+                        std.enums.tagName(bmp.DibHeaderKind, h.dib_kind) orelse "unknown",
+                        h.top_down,
+                        h.palette_entries,
+                        h.hasAlpha(),
+                    });
+                },
+                .gif => {
+                    try w.print("\"version\":\"{t}\",\"frame_count\":{d},\"loop_count\":{d},\"global_color_table_size\":{d}", .{ h.version, h.frame_count, h.loop_count, h.global_color_table_size });
+                },
+            }
+            try w.writeAll("}");
+        },
+    }
+}
+
+/// Decodes the image (first frame for animated GIFs) and stores source-info
+/// JSON. Returns 1 on success; the input bytes are not retained.
+pub export fn load_image(ptr: [*]const u8, len: usize) i32 {
+    const data = ptr[0..len];
+
+    const format = ImageFormat.detectFromBytes(data) orelse
+        return fail("UnsupportedFormat", "Unrecognized image format. Supported: PNG, JPEG, BMP, GIF.");
+
+    const t0 = js.nowFn();
+    const image = Image(Rgba).loadFromBytes(allocator, data) catch |err| return failErr(err);
+    const decode_ms = js.nowFn() - t0;
+
+    if (g_source) |*old| old.deinit(allocator);
+    g_source = image;
+    if (g_gray) |*old| old.deinit(allocator);
+    g_gray = null;
+    g_source_gray = isGrayscale(image);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+    write: {
+        w.writeAll("{\"ok\":true,") catch break :write;
+        writeInfoFields(w, format, data) catch break :write;
+        w.print(",\"grayscale\":{},\"decode_ms\":{d:.1}}}", .{ g_source_gray, decode_ms }) catch break :write;
+        setJson(aw.toOwnedSlice() catch @panic("OOM"));
+        return 1;
+    }
+    return fail("InfoFailed", "Failed to read image metadata.");
+}
+
+pub export fn source_width() u32 {
+    return if (g_source) |image| image.cols else 0;
+}
+
+pub export fn source_height() u32 {
+    return if (g_source) |image| image.rows else 0;
+}
+
+pub export fn source_pixels() [*]const u8 {
+    return if (g_source) |image| @ptrCast(image.data.ptr) else @ptrCast("");
+}
+
+/// Takes ownership of `bytes`; decodes it back for the preview and builds the stats JSON.
+fn finishEncode(format: ImageFormat, bytes: []u8, encode_ms: f32) i32 {
+    if (g_encoded) |old| allocator.free(old);
+    g_encoded = bytes;
+    if (g_output) |*old| old.deinit(allocator);
+    g_output = null;
+
+    g_output = Image(Rgba).loadFromBytes(allocator, bytes) catch |err| return failErr(err);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+    write: {
+        w.print("{{\"ok\":true,\"size\":{d},\"encode_ms\":{d:.1},\"info\":{{", .{ bytes.len, encode_ms }) catch break :write;
+        writeInfoFields(w, format, bytes) catch break :write;
+        w.writeAll("}}") catch break :write;
+        setJson(aw.toOwnedSlice() catch @panic("OOM"));
+        return 1;
+    }
+    return fail("InfoFailed", "Failed to read encoded image metadata.");
+}
+
+/// Runs `codec.encode` on the source as Rgba, or as u8 via the cached grayscale conversion.
+fn encodeSource(comptime codec: type, as_gray: u32, options: codec.EncodeOptions) ![]u8 {
+    const source = g_source orelse return error.NoImage;
+    if (as_gray != 0) {
+        if (g_gray == null) g_gray = try source.convert(allocator, u8);
+        return codec.encode(u8, allocator, g_gray.?, options);
+    }
+    return codec.encode(Rgba, allocator, source, options);
+}
+
+/// Shared tail of the encode_* exports: time the encode and finish with stats JSON.
+fn encodeAndFinish(comptime codec: type, format: ImageFormat, as_gray: u32, options: codec.EncodeOptions) i32 {
+    const t0 = js.nowFn();
+    const bytes = encodeSource(codec, as_gray, options) catch |err| return failErr(err);
+    return finishEncode(format, bytes, js.nowFn() - t0);
+}
+
+pub export fn encode_jpeg(
+    as_gray: u32,
+    quality: u32,
+    subsampling: u32, // 0 = 4:4:4, 1 = 4:2:2, 2 = 4:2:0
+    density_dpi: u32,
+    comment_ptr: [*]const u8,
+    comment_len: usize,
+) i32 {
+    return encodeAndFinish(jpeg, .jpeg, as_gray, .{
+        .quality = @intCast(std.math.clamp(quality, 1, 100)),
+        .subsampling = switch (subsampling) {
+            0 => .yuv444,
+            1 => .yuv422,
+            else => .yuv420,
+        },
+        .density_dpi = @intCast(std.math.clamp(density_dpi, 1, 65535)),
+        .comment = if (comment_len > 0) comment_ptr[0..comment_len] else null,
+    });
+}
+
+pub export fn encode_png(
+    as_gray: u32,
+    filter_mode: u32, // 0 = adaptive, 1 = none, 2..5 = fixed sub/up/average/paeth
+    compression: u32, // 0 = filtered preset (default), 1 = fastest, 2 = default, 3 = best
+    gamma: f32, // <= 0 means omit
+    srgb_intent: i32, // -1 = omit, 0..3 = SrgbRenderingIntent
+) i32 {
+    return encodeAndFinish(png, .png, as_gray, .{
+        .filter = switch (filter_mode) {
+            1 => .none,
+            2 => .{ .fixed = .sub },
+            3 => .{ .fixed = .up },
+            4 => .{ .fixed = .average },
+            5 => .{ .fixed = .paeth },
+            else => .adaptive,
+        },
+        .compress_options = switch (compression) {
+            1 => .fastest,
+            2 => .default,
+            3 => .best,
+            else => png.EncodeOptions.default.compress_options,
+        },
+        .gamma = if (gamma > 0) gamma else null,
+        .srgb_intent = if (srgb_intent >= 0 and srgb_intent <= 3) @enumFromInt(srgb_intent) else null,
+    });
+}
+
+pub export fn encode_bmp(as_gray: u32, use_palette_for_grayscale: u32, top_down: u32) i32 {
+    return encodeAndFinish(bmp, .bmp, as_gray, .{
+        .use_palette_for_grayscale = use_palette_for_grayscale != 0,
+        .top_down = top_down != 0,
+    });
+}
+
+pub export fn encode_gif(as_gray: u32, max_colors: u32, dither: u32) i32 {
+    return encodeAndFinish(gif, .gif, as_gray, .{
+        .max_colors = @intCast(std.math.clamp(max_colors, 2, 256)),
+        .dither = dither != 0,
+    });
+}
+
+pub export fn encoded_ptr() [*]const u8 {
+    return if (g_encoded) |bytes| bytes.ptr else @ptrCast("");
+}
+
+pub export fn encoded_len() usize {
+    return if (g_encoded) |bytes| bytes.len else 0;
+}
+
+pub export fn output_width() u32 {
+    return if (g_output) |image| image.cols else 0;
+}
+
+pub export fn output_height() u32 {
+    return if (g_output) |image| image.rows else 0;
+}
+
+pub export fn output_pixels() [*]const u8 {
+    return if (g_output) |image| @ptrCast(image.data.ptr) else @ptrCast("");
+}

--- a/examples/web/codec-playground.html
+++ b/examples/web/codec-playground.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Image Codec Playground</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/png" href="favicon.png">
+  </head>
+  <body>
+    <div class="header">
+      <h1>Image Codec Playground</h1>
+      <p>Inspect how an image is encoded and re-encode it with zignal's PNG, JPEG, BMP, and GIF codecs</p>
+    </div>
+
+    <div class="instructions">
+      Drop or click the source panel to load a PNG, JPEG, BMP, or GIF. Decoding and encoding run in your
+      browser with zignal's own codecs — tweak the encoder options to see how they affect the output.
+    </div>
+
+    <div class="codec-controls">
+      <div class="codec-table">
+        <label class="codec-choice"><input type="radio" name="format" value="jpeg" checked> JPEG</label>
+        <div class="codec-options" id="options-jpeg">
+          <label>Quality <input type="range" id="jpeg-quality" min="1" max="100" value="90"> <span id="jpeg-quality-value">90</span></label>
+          <label>Subsampling
+            <select id="jpeg-subsampling">
+              <option value="0">4:4:4</option>
+              <option value="1">4:2:2</option>
+              <option value="2" selected>4:2:0</option>
+            </select>
+          </label>
+          <label>Density (DPI) <input type="number" id="jpeg-dpi" min="1" max="65535" value="72"></label>
+          <label>Comment <input type="text" id="jpeg-comment" placeholder="(none)"></label>
+        </div>
+        <label class="codec-choice"><input type="radio" name="format" value="png"> PNG</label>
+        <div class="codec-options" id="options-png">
+          <label>Filter
+            <select id="png-filter">
+              <option value="0" selected>adaptive</option>
+              <option value="1">none</option>
+              <option value="2">sub</option>
+              <option value="3">up</option>
+              <option value="4">average</option>
+              <option value="5">paeth</option>
+            </select>
+          </label>
+          <label>Compression
+            <select id="png-compression">
+              <option value="0" selected>filtered (default)</option>
+              <option value="1">fastest</option>
+              <option value="2">balanced</option>
+              <option value="3">best</option>
+            </select>
+          </label>
+          <label title="Writes a gAMA chunk; ignored when an sRGB intent is set">Gamma <input type="number" id="png-gamma" min="0" step="0.0001" placeholder="(omit)"></label>
+          <label>sRGB intent
+            <select id="png-intent">
+              <option value="-1" selected>(omit)</option>
+              <option value="0">perceptual</option>
+              <option value="1">relative colorimetric</option>
+              <option value="2">saturation</option>
+              <option value="3">absolute colorimetric</option>
+            </select>
+          </label>
+        </div>
+        <label class="codec-choice"><input type="radio" name="format" value="bmp"> BMP</label>
+        <div class="codec-options" id="options-bmp">
+          <label><input type="checkbox" id="bmp-palette"> Grayscale palette (8bpp indexed)</label>
+          <label><input type="checkbox" id="bmp-topdown"> Top-down rows</label>
+        </div>
+        <label class="codec-choice"><input type="radio" name="format" value="gif"> GIF</label>
+        <div class="codec-options" id="options-gif">
+          <label>Max colors <input type="range" id="gif-colors" min="2" max="256" value="256"> <span id="gif-colors-value">256</span></label>
+          <label><input type="checkbox" id="gif-dither"> Floyd–Steinberg dithering</label>
+        </div>
+        <label class="codec-choice codec-gray" title="Convert to single-channel grayscale before encoding"><input type="checkbox" id="opt-gray"> Grayscale</label>
+        <span id="status"></span>
+      </div>
+    </div>
+
+    <div class="metrics-container">
+      <div class="canvas-group">
+        <h3>Source</h3>
+        <canvas id="source-canvas" class="image-drop" width="320" height="200"></canvas>
+        <div class="codec-info" id="source-info"></div>
+      </div>
+      <div class="canvas-group">
+        <h3>Output</h3>
+        <canvas id="output-canvas" class="image-drop codec-output" width="320" height="200"></canvas>
+        <p id="output-stats"></p>
+        <div class="codec-info" id="output-info"></div>
+        <div><button id="download-button" class="codec-download" disabled>Download</button></div>
+      </div>
+    </div>
+
+    <script src="utils.js"></script>
+    <script src="codec-playground.js"></script>
+  </body>
+</html>

--- a/examples/web/codec-playground.js
+++ b/examples/web/codec-playground.js
@@ -1,0 +1,302 @@
+(function () {
+  const { createFileInput, enableDrop, loadWasm } = window.ZignalUtils;
+
+  let exports = null;
+  let decodeString = null;
+  let currentFormat = "jpeg";
+  let encodedFormat = null;
+  let sourceLoaded = false;
+  let sourceName = "image";
+  let sourceSize = 0;
+  let downloadUrl = null;
+  let debounceTimer = null;
+  // Infinity so the very first encode (unknown cost) shows the status.
+  let lastEncodeMs = Infinity;
+
+  const FORMATS = ["jpeg", "png", "bmp", "gif"];
+  const MIME = { jpeg: "image/jpeg", png: "image/png", bmp: "image/bmp", gif: "image/gif" };
+  const EXT = { jpeg: "jpg", png: "png", bmp: "bmp", gif: "gif" };
+  const SUBSAMPLING = { yuv444: "4:4:4", yuv422: "4:2:2", yuv420: "4:2:0" };
+  const textEncoder = new TextEncoder();
+
+  const DETAIL_LABELS = {
+    frame_type: "Frame type",
+    num_components: "Components",
+    precision: "Precision (bits)",
+    subsampling: "Chroma subsampling",
+    bit_depth: "Bit depth",
+    color_type: "Color type",
+    interlaced: "Interlaced (Adam7)",
+    gamma: "Gamma",
+    srgb_intent: "sRGB intent",
+    compression: "Compression",
+    dib_header: "DIB header",
+    top_down: "Top-down rows",
+    palette_entries: "Palette entries",
+    has_alpha: "Alpha channel",
+    version: "Version",
+    frame_count: "Frames",
+    loop_count: "Loop count",
+    global_color_table_size: "Global palette size",
+  };
+
+  const sourceCanvas = document.getElementById("source-canvas");
+  const outputCanvas = document.getElementById("output-canvas");
+  const sourceInfoEl = document.getElementById("source-info");
+  const outputInfoEl = document.getElementById("output-info");
+  const outputStats = document.getElementById("output-stats");
+  const statusEl = document.getElementById("status");
+  const downloadButton = document.getElementById("download-button");
+  const grayCheckbox = document.getElementById("opt-gray");
+  const jpegQuality = document.getElementById("jpeg-quality");
+  const jpegSubsampling = document.getElementById("jpeg-subsampling");
+  const jpegDpi = document.getElementById("jpeg-dpi");
+  const jpegComment = document.getElementById("jpeg-comment");
+  const pngFilter = document.getElementById("png-filter");
+  const pngCompression = document.getElementById("png-compression");
+  const pngGamma = document.getElementById("png-gamma");
+  const pngIntent = document.getElementById("png-intent");
+  const bmpPalette = document.getElementById("bmp-palette");
+  const bmpTopdown = document.getElementById("bmp-topdown");
+  const gifColors = document.getElementById("gif-colors");
+  const gifDither = document.getElementById("gif-dither");
+
+  const formatRadios = document.querySelectorAll('input[name="format"]');
+  formatRadios.forEach(function (radio) {
+    radio.addEventListener("change", function () {
+      if (!radio.checked) return;
+      currentFormat = radio.value;
+      updateControls();
+      scheduleEncode();
+    });
+  });
+
+  document.querySelectorAll(".codec-options input, .codec-options select, .codec-gray input").forEach(function (el) {
+    el.addEventListener(el.type === "range" || el.type === "text" || el.type === "number" ? "input" : "change", scheduleEncode);
+  });
+
+  jpegQuality.addEventListener("input", function () {
+    document.getElementById("jpeg-quality-value").textContent = this.value;
+  });
+  gifColors.addEventListener("input", function () {
+    document.getElementById("gif-colors-value").textContent = this.value;
+  });
+  grayCheckbox.addEventListener("change", updateControls);
+  pngIntent.addEventListener("change", updateControls);
+
+  // Only the selected codec's options are enabled; the per-option graying is
+  // cosmetic — the encoders already ignore ineffective settings.
+  function updateControls() {
+    const gray = grayCheckbox.checked;
+    FORMATS.forEach(function (f) {
+      const panel = document.getElementById("options-" + f);
+      const active = f === currentFormat;
+      panel.classList.toggle("inactive", !active);
+      panel.querySelectorAll("input, select").forEach(function (el) {
+        el.disabled = !sourceLoaded || !active;
+      });
+    });
+    formatRadios.forEach(function (radio) {
+      radio.disabled = !sourceLoaded;
+    });
+    grayCheckbox.disabled = !sourceLoaded;
+    bmpPalette.disabled = !sourceLoaded || currentFormat !== "bmp" || !gray;
+    jpegSubsampling.disabled = !sourceLoaded || currentFormat !== "jpeg" || gray;
+    pngGamma.disabled = !sourceLoaded || currentFormat !== "png" || pngIntent.value !== "-1";
+  }
+  updateControls();
+
+  function setStatus(text, isError) {
+    statusEl.textContent = text;
+    statusEl.classList.toggle("error", !!isError);
+  }
+
+  function humanSize(n) {
+    if (n < 1024) return n + " B";
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+    return (n / (1024 * 1024)).toFixed(2) + " MB";
+  }
+
+  function renderInfo(container, info, extraRows = []) {
+    const rows = [
+      ["Format", info.format.toUpperCase()],
+      ["Dimensions", info.width + "×" + info.height + " px"],
+      ["File size", humanSize(info.file_size)],
+    ];
+    for (const key in info.details) {
+      let value = info.details[key];
+      if (value === null) value = "—";
+      else if (typeof value === "boolean") value = value ? "yes" : "no";
+      else if (key === "loop_count" && value === 0) value = "infinite";
+      else if (key === "subsampling") value = SUBSAMPLING[value] || value;
+      rows.push([DETAIL_LABELS[key] || key, String(value)]);
+    }
+    rows.push(...extraRows);
+    const table = document.createElement("table");
+    rows.forEach(function (row) {
+      const tr = document.createElement("tr");
+      row.forEach(function (cell) {
+        const td = document.createElement("td");
+        td.textContent = cell;
+        tr.appendChild(td);
+      });
+      table.appendChild(tr);
+    });
+    container.replaceChildren(table);
+  }
+
+  function readJson() {
+    return JSON.parse(decodeString(exports.json_ptr(), exports.json_len()));
+  }
+
+  // Fresh view per call (memory growth detaches buffers); no copy needed since
+  // no wasm call happens before putImageData consumes it.
+  function drawPixels(canvas, ptr, width, height) {
+    canvas.width = width;
+    canvas.height = height;
+    const data = new Uint8ClampedArray(exports.memory.buffer, ptr, width * height * 4);
+    canvas.getContext("2d").putImageData(new ImageData(data, width, height), 0, 0);
+  }
+
+  function clearCanvas(canvas) {
+    canvas.width = 320;
+    canvas.height = 200;
+    canvas.getContext("2d").clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  // A failed load clears all state describing the previous file.
+  function resetSource() {
+    sourceLoaded = false;
+    encodedFormat = null;
+    sourceInfoEl.replaceChildren();
+    outputInfoEl.replaceChildren();
+    outputStats.textContent = "";
+    clearCanvas(sourceCanvas);
+    clearCanvas(outputCanvas);
+    updateControls();
+    downloadButton.disabled = true;
+  }
+
+  function loadFile(file) {
+    if (!exports) {
+      setStatus("WebAssembly module is still loading, try again.");
+      return;
+    }
+    file.arrayBuffer().then(function (buffer) {
+      const bytes = new Uint8Array(buffer);
+      const ptr = exports.alloc(bytes.length);
+      new Uint8Array(exports.memory.buffer, ptr, bytes.length).set(bytes);
+      const ok = exports.load_image(ptr, bytes.length);
+      exports.free(ptr, bytes.length);
+      const result = readJson();
+      if (!ok) {
+        resetSource();
+        setStatus(result.message || "Failed to load image: " + result.error, true);
+        return;
+      }
+      sourceLoaded = true;
+      sourceName = file.name.replace(/\.[^.]+$/, "") || "image";
+      sourceSize = result.file_size;
+      updateControls();
+      drawPixels(sourceCanvas, exports.source_pixels(), exports.source_width(), exports.source_height());
+      const extra = [
+        ["Grayscale content", result.grayscale ? "yes" : "no"],
+        ["Decode time", result.decode_ms.toFixed(1) + " ms"],
+      ];
+      if (result.details.frame_count > 1) {
+        extra.push(["Note", "showing frame 1 of " + result.details.frame_count + "; re-encoding produces a single-frame image"]);
+      }
+      renderInfo(sourceInfoEl, result, extra);
+      setStatus("");
+      scheduleEncode();
+    }).catch(function (error) {
+      resetSource();
+      setStatus("Failed to read file: " + error, true);
+    });
+  }
+
+  function scheduleEncode() {
+    if (!sourceLoaded) return;
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function () {
+      // Skip the status flash when the last encode was fast.
+      if (lastEncodeMs < 100) return runEncode();
+      setStatus("Encoding…");
+      // Give the status a frame to paint before the synchronous wasm call.
+      requestAnimationFrame(function () {
+        setTimeout(runEncode, 0);
+      });
+    }, 200);
+  }
+
+  function runEncode() {
+    if (!sourceLoaded || !exports) return;
+    const started = performance.now();
+    const asGray = grayCheckbox.checked ? 1 : 0;
+    const format = currentFormat;
+    let ok;
+    if (format === "jpeg") {
+      const comment = textEncoder.encode(jpegComment.value);
+      let commentPtr = 0;
+      if (comment.length > 0) {
+        commentPtr = exports.alloc(comment.length);
+        new Uint8Array(exports.memory.buffer, commentPtr, comment.length).set(comment);
+      }
+      ok = exports.encode_jpeg(asGray, Number(jpegQuality.value), Number(jpegSubsampling.value), Number(jpegDpi.value) || 72, commentPtr, comment.length);
+      if (comment.length > 0) exports.free(commentPtr, comment.length);
+    } else if (format === "png") {
+      const gamma = parseFloat(pngGamma.value);
+      ok = exports.encode_png(asGray, Number(pngFilter.value), Number(pngCompression.value), isNaN(gamma) ? 0 : gamma, Number(pngIntent.value));
+    } else if (format === "bmp") {
+      ok = exports.encode_bmp(asGray, bmpPalette.checked ? 1 : 0, bmpTopdown.checked ? 1 : 0);
+    } else {
+      ok = exports.encode_gif(asGray, Number(gifColors.value), gifDither.checked ? 1 : 0);
+    }
+    const result = readJson();
+    lastEncodeMs = performance.now() - started;
+    if (!ok) {
+      setStatus(result.message || "Encode failed: " + result.error, true);
+      return;
+    }
+    encodedFormat = format;
+    drawPixels(outputCanvas, exports.output_pixels(), exports.output_width(), exports.output_height());
+    outputStats.textContent =
+      humanSize(result.size) +
+      " — " +
+      Math.round((result.size / sourceSize) * 100) +
+      "% of source (" +
+      humanSize(sourceSize) +
+      "), " +
+      result.encode_ms.toFixed(1) +
+      " ms";
+    renderInfo(outputInfoEl, result.info);
+    downloadButton.disabled = false;
+    setStatus("");
+  }
+
+  // Encoded bytes stay valid until the next encode; read lazily instead of copying per re-encode.
+  downloadButton.addEventListener("click", function () {
+    if (!encodedFormat || exports.encoded_len() === 0) return;
+    const bytes = new Uint8Array(exports.memory.buffer, exports.encoded_ptr(), exports.encoded_len());
+    if (downloadUrl) URL.revokeObjectURL(downloadUrl);
+    downloadUrl = URL.createObjectURL(new Blob([bytes], { type: MIME[encodedFormat] }));
+    const link = document.createElement("a");
+    link.href = downloadUrl;
+    link.download = sourceName + "." + EXT[encodedFormat];
+    link.click();
+  });
+
+  const fileInput = createFileInput(loadFile, { accept: ".png,.jpg,.jpeg,.bmp,.gif,image/*" });
+  enableDrop(sourceCanvas, {
+    onClick: function () {
+      fileInput.click();
+    },
+    onDrop: loadFile,
+  });
+
+  loadWasm("codec_playground.wasm").then(function (loaded) {
+    exports = loaded.exports;
+    decodeString = loaded.decodeString;
+    console.log("wasm loaded");
+  });
+})();

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -75,6 +75,10 @@
 				<h3><a href="global-optimization.html">Global Optimization</a></h3>
 				<p>Type a JavaScript function and watch the MaxLIPO+TR optimizer search for its optimum</p>
 			</div>
+			<div class="example-card">
+				<h3><a href="codec-playground.html">Image Codec Playground</a></h3>
+				<p>Inspect how an image is encoded and re-encode it as PNG, JPEG, BMP, or GIF with full control over the encoder options</p>
+			</div>
 		</div>
 	</body>
 </html>

--- a/examples/web/styles.css
+++ b/examples/web/styles.css
@@ -48,6 +48,12 @@ body {
   color: #333;
   font-size: clamp(0.9rem, 3vw, 1.1rem);
 }
+/* Canvases are inline by default, which would let sibling panels (e.g. the
+   codec info table) flow beside them instead of stacking. */
+.canvas-group canvas {
+  display: block;
+  margin: 0 auto;
+}
 .image-drop {
   width: 320px;
   height: 200px;
@@ -433,13 +439,15 @@ canvas:hover {
 .mode-select .mode-label {
   color: #333;
 }
-.mode-select label {
+.mode-select label,
+.codec-choice {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   cursor: pointer;
 }
-.mode-select input {
+.mode-select input,
+.codec-choice input {
   accent-color: #007bff;
   margin: 0;
   cursor: pointer;
@@ -822,4 +830,104 @@ input[type="radio"] {
   background: #eee;
   color: #aaa;
   cursor: not-allowed;
+}
+
+/* Codec playground: encoder controls bar and per-panel info tables. */
+.codec-controls {
+  max-width: 720px;
+  margin: 0 auto 20px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  padding: 14px 18px;
+  text-align: center;
+}
+/* Reserve the status line's height so appearing text doesn't shift the controls. */
+.codec-controls #status {
+  min-height: 1.2em;
+}
+.codec-controls #status.error {
+  color: #bf616a;
+}
+/* Two-column grid: format radios left, that codec's options right. */
+.codec-table {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 12px 18px;
+  align-items: center;
+  text-align: left;
+}
+/* Layout and accent shared with .mode-select; see the extended selectors there. */
+.codec-choice {
+  gap: 6px;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.9rem;
+}
+.codec-choice input:disabled {
+  cursor: not-allowed;
+}
+.codec-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  color: #333;
+  font-size: 0.9rem;
+}
+.codec-options label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.codec-options.inactive {
+  opacity: 0.5;
+}
+.codec-options.inactive label {
+  cursor: not-allowed;
+}
+.codec-options input[type="number"] {
+  width: 70px;
+}
+.codec-options input[type="text"] {
+  width: 130px;
+}
+/* Kill the base #status top margin so it centers in its grid row. */
+.codec-table #status {
+  margin: 0;
+}
+.codec-output {
+  cursor: default;
+  border-style: solid;
+  border-color: #ddd;
+}
+.codec-info {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 6px 10px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  font-size: 0.85rem;
+  color: #333;
+  text-align: left;
+}
+.codec-info:empty {
+  display: none;
+}
+.codec-info td {
+  padding: 2px 8px;
+}
+.codec-info td:first-child {
+  color: #666;
+}
+#output-stats {
+  margin: 8px 0 0;
+  color: #333;
+  font-size: 0.9rem;
+}
+/* Sizing tweaks over the unified button rule. */
+.codec-download {
+  margin: 10px 0 0;
+  padding: 8px 20px;
+  font-size: 0.95rem;
 }

--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -64,6 +64,8 @@ pub const Header = struct {
     frame_type: FrameType,
     num_components: u8,
     precision: u8,
+    /// Derived from SOF sampling factors; null for grayscale or exotic layouts.
+    subsampling: ?Subsampling = null,
 
     pub fn totalPixels(self: Header) u64 {
         return @as(u64, self.width) * @as(u64, self.height);
@@ -142,11 +144,20 @@ pub fn getInfo(reader: *Io.Reader, limits: DecodeLimits) !Header {
             const num_components = try reader.takeByte();
             bytes_read += 6; // precision(1) + height(2) + width(2) + components(1)
 
-            // Discard remaining component info if any
-            if (payload_len > 6) {
-                const skip = payload_len - 6;
-                bytes_read += try reader.discard(.limited(skip));
+            var subsampling: ?Subsampling = null;
+            var remaining: usize = payload_len - 6;
+            if (num_components == 3 and remaining >= 9) {
+                var factors: [3]u8 = undefined;
+                for (&factors) |*f| f.* = (try reader.takeArray(3))[1]; // id, sampling (h << 4 | v), quant table
+                bytes_read += 9;
+                remaining -= 9;
+                if (factors[1] == 0x11 and factors[2] == 0x11) {
+                    subsampling = Subsampling.fromLumaFactors(factors[0]);
+                }
             }
+
+            // Discard remaining component info if any
+            bytes_read += try reader.discard(.limited(remaining));
 
             return Header{
                 .width = width,
@@ -154,6 +165,7 @@ pub fn getInfo(reader: *Io.Reader, limits: DecodeLimits) !Header {
                 .frame_type = if (marker_val == 0xFFC2) .progressive else .baseline,
                 .num_components = num_components,
                 .precision = precision,
+                .subsampling = subsampling,
             };
         }
 
@@ -204,6 +216,41 @@ test "JPEG getInfo" {
     try std.testing.expectEqual(8, header.precision);
     try std.testing.expectEqual(3, header.num_components);
     try std.testing.expectEqual(FrameType.baseline, header.frame_type);
+    try std.testing.expectEqual(Subsampling.yuv444, header.subsampling);
+}
+
+test "JPEG getInfo subsampling" {
+    const gpa = std.testing.allocator;
+
+    const cases = [_]struct { luma: u8, expected: ?Subsampling }{
+        .{ .luma = 0x22, .expected = .yuv420 },
+        .{ .luma = 0x21, .expected = .yuv422 },
+        .{ .luma = 0x11, .expected = .yuv444 },
+        .{ .luma = 0x12, .expected = null },
+    };
+
+    for (cases) |case| {
+        var data: std.ArrayList(u8) = .empty;
+        defer data.deinit(gpa);
+
+        try data.appendSlice(gpa, &signature);
+        // SOF0
+        try data.append(gpa, 0xFF);
+        try data.append(gpa, 0xC0);
+        try data.appendSlice(gpa, std.mem.asBytes(&std.mem.nativeTo(u16, 17, .big))); // Length
+        try data.append(gpa, 8); // Precision
+        try data.appendSlice(gpa, std.mem.asBytes(&std.mem.nativeTo(u16, 100, .big))); // Height
+        try data.appendSlice(gpa, std.mem.asBytes(&std.mem.nativeTo(u16, 200, .big))); // Width
+        try data.append(gpa, 3); // Components
+        try data.appendSlice(gpa, &[_]u8{ 1, case.luma, 0, 2, 0x11, 1, 3, 0x11, 1 });
+        // EOI
+        try data.append(gpa, 0xFF);
+        try data.append(gpa, 0xD9);
+
+        var reader: Io.Reader = .fixed(data.items);
+        const header = try getInfo(&reader, .{});
+        try std.testing.expectEqual(case.expected, header.subsampling);
+    }
 }
 
 // -----------------------------
@@ -214,6 +261,24 @@ pub const Subsampling = enum {
     yuv444,
     yuv422,
     yuv420,
+
+    /// Packed SOF luma sampling factors (h << 4 | v); chroma is always 1x1.
+    pub fn lumaFactors(self: Subsampling) u8 {
+        return switch (self) {
+            .yuv444 => 0x11,
+            .yuv422 => 0x21,
+            .yuv420 => 0x22,
+        };
+    }
+
+    pub fn fromLumaFactors(factors: u8) ?Subsampling {
+        return switch (factors) {
+            0x11 => .yuv444,
+            0x21 => .yuv422,
+            0x22 => .yuv420,
+            else => null,
+        };
+    }
 };
 
 pub const EncodeOptions = struct {
@@ -440,12 +505,7 @@ fn writeSOF0(dst: *std.ArrayList(u8), gpa: Allocator, width: u16, height: u16, g
         try tmp.append(gpa, 3);
         // Y
         try tmp.append(gpa, 1);
-        const y_sampling: u8 = switch (subsampling) {
-            .yuv444 => 0x11,
-            .yuv422 => 0x21,
-            .yuv420 => 0x22,
-        };
-        try tmp.append(gpa, y_sampling);
+        try tmp.append(gpa, subsampling.lumaFactors());
         try tmp.append(gpa, 0);
         // Cb
         try tmp.append(gpa, 2);


### PR DESCRIPTION
Adds an interactive web-based playground to experiment with PNG, JPEG, BMP, and GIF encoders. Also updates the JPEG decoder to extract chroma subsampling info.