### PR TITLE
refactor(border): centralize getPixel function

### DIFF
--- a/src/image/border.zig
+++ b/src/image/border.zig
@@ -6,6 +6,8 @@
 const std = @import("std");
 const clamp = std.math.clamp;
 
+const Image = @import("../image.zig").Image;
+
 /// Border handling modes for operations that access pixels outside image bounds
 pub const BorderMode = enum {
     /// Pad with zeros
@@ -60,6 +62,25 @@ pub fn resolveIndex(idx: isize, length: isize, border: BorderMode) ?usize {
         },
         .wrap => if (length == 0) null else @intCast(@mod(idx, length)),
     };
+}
+
+/// Fetches the pixel at (`row`, `col`), resolving out-of-bounds coordinates with `border`.
+/// Returns 0 when the position maps to no pixel (`.zero` mode or an empty image).
+pub fn getPixel(comptime T: type, img: Image(T), row: isize, col: isize, border: BorderMode) T {
+    const coords = computeCoords(row, col, @intCast(img.rows), @intCast(img.cols), border);
+    return if (coords) |c| img.at(c.row, c.col).* else 0;
+}
+
+test "getPixel border resolution" {
+    const testing = std.testing;
+    var data = [_]u8{ 1, 2, 3, 4 };
+    const img = Image(u8).initFromSlice(2, 2, &data);
+
+    try testing.expectEqual(@as(u8, 1), getPixel(u8, img, 0, 0, .zero));
+    try testing.expectEqual(@as(u8, 0), getPixel(u8, img, -1, 0, .zero));
+    try testing.expectEqual(@as(u8, 1), getPixel(u8, img, -1, -1, .replicate));
+    try testing.expectEqual(@as(u8, 4), getPixel(u8, img, 3, 3, .mirror));
+    try testing.expectEqual(@as(u8, 4), getPixel(u8, img, -1, -1, .wrap));
 }
 
 test "resolveIndex basic" {

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -114,7 +114,7 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                 inline for (0..cols) |kx| {
                     const iry = ir + @as(isize, ky) - half_h;
                     const icx = ic + @as(isize, kx) - half_w;
-                    const pixel_val: AccumScalar = getPixel(T, src, iry, icx, border_mode);
+                    const pixel_val: AccumScalar = border.getPixel(T, src, iry, icx, border_mode);
                     const k_val: AccumScalar = kernel[ky * cols + kx];
                     result += pixel_val * k_val;
                 }
@@ -443,7 +443,7 @@ fn convolveSeparablePlane(
             const ic: isize = @intCast(c);
             for (kernel, 0..) |k, i| {
                 const icx = ic + @as(isize, @intCast(i)) - @as(isize, @intCast(half));
-                result += Ops.promote(getPixel(PixelT, img, @intCast(r), icx, mode)) * Ops.promote(k);
+                result += Ops.promote(border.getPixel(PixelT, img, @intCast(r), icx, mode)) * Ops.promote(k);
             }
             return result;
         }
@@ -559,18 +559,11 @@ fn convolveSeparablePlane(
                 const ir: isize = @intCast(r);
                 for (kernel_y, 0..) |k, i| {
                     const iry = ir + @as(isize, @intCast(i)) - @as(isize, @intCast(half_y));
-                    const pixel_val = getPixel(TempT, temp_img, iry, @intCast(c), border_mode);
+                    const pixel_val = border.getPixel(TempT, temp_img, iry, @intCast(c), border_mode);
                     result += Ops.promote(pixel_val) * Ops.promote(k);
                 }
                 dst_img.data[r * dst_img.stride + c] = DstIO.store(result);
             }
         }
     }
-}
-
-/// Widens the result so callers can accumulate in i64/f32 without an extra cast at every callsite.
-fn getPixel(comptime T: type, img: Image(T), row: isize, col: isize, border_mode: BorderMode) if (T == f32) f32 else i32 {
-    if (T != u8 and T != f32 and T != i32) @compileError("getPixel only works with u8, i32 and f32 types");
-    const coords = border.computeCoords(row, col, @intCast(img.rows), @intCast(img.cols), border_mode);
-    return if (coords) |c| img.at(c.row, c.col).* else 0;
 }

--- a/src/image/order_statistic_blur.zig
+++ b/src/image/order_statistic_blur.zig
@@ -263,7 +263,7 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
                 var hist = Histogram(u8).init();
                 for (0..window) |offset| {
                     const row_idx = @as(isize, @intCast(offset)) - radius_isize;
-                    const sample = getPixel(image, border, row_idx, @intCast(col));
+                    const sample = border_module.getPixel(u8, image, row_idx, @intCast(col), border);
                     hist.addValue(sample);
                 }
                 column_hists[col] = hist;
@@ -333,17 +333,6 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
             var hist = Histogram(u8).init();
             hist.values[value] = @intCast(count);
             return hist;
-        }
-
-        fn getPixel(image: Image(u8), border: BorderMode, row: isize, col: isize) u8 {
-            const r = border_module.resolveIndex(row, @intCast(image.rows), border);
-            const c = border_module.resolveIndex(col, @intCast(image.cols), border);
-            if (r) |row_idx| {
-                if (c) |col_idx| {
-                    return image.at(row_idx, col_idx).*;
-                }
-            }
-            return 0;
         }
 
         const PercentileReducer = struct {


### PR DESCRIPTION
Move duplicated `getPixel` implementations from `convolution` and `order_statistic_blur` modules into `border.zig`.