### PR TITLE
perf(image): optimize convolution hot paths

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) void {
         "motion_blur_demo",
         "edge_detection",
         "blur_box_vs_gaussian",
+        "convolution_bench",
         "trace_edges",
         "colormaps_demo",
         "optimization_example",

--- a/examples/src/convolution_bench.zig
+++ b/examples/src/convolution_bench.zig
@@ -1,0 +1,205 @@
+//! Convolution micro-benchmarks: gaussian blur, 2D convolve, sobel, motion blur, separable.
+//! Synthetic seeded-random images, no file I/O; reports median time over several iterations.
+//! Optional CLI arg filters benchmarks by substring: `run-convolution-bench -- gaussian`
+
+const std = @import("std");
+const zignal = @import("zignal");
+
+const Image = zignal.Image;
+const Rgb = zignal.Rgb(u8);
+const BorderMode = zignal.BorderMode;
+
+const warmup_iters = 2;
+const max_iters = 101;
+
+const sharpen_3x3: [3][3]f32 = .{
+    .{ 0, -1, 0 },
+    .{ -1, 5, -1 },
+    .{ 0, -1, 0 },
+};
+const box_7x7: [7][7]f32 = @splat(@splat(1.0 / 49.0));
+const gaussian_9: [9]f32 = .{ 0.05, 0.09, 0.12, 0.15, 0.18, 0.15, 0.12, 0.09, 0.05 };
+
+fn itersFor(rows: usize, cols: usize) usize {
+    const pixels = rows * cols;
+    return if (pixels <= 64 * 64) max_iters else if (pixels <= 640 * 480) 21 else if (pixels <= 2048 * 2048) 7 else 5;
+}
+
+fn fillRandom(comptime T: type, img: Image(T), random: std.Random) void {
+    for (img.data) |*px| {
+        px.* = switch (T) {
+            u8 => random.int(u8),
+            f32 => 255 * random.float(f32),
+            Rgb => .{ .r = random.int(u8), .g = random.int(u8), .b = random.int(u8) },
+            else => @compileError("unsupported pixel type"),
+        };
+    }
+}
+
+/// Runs ctx.run() warmup + iters times and reports the median.
+fn benchOp(io: std.Io, name: []const u8, rows: usize, cols: usize, filter: ?[]const u8, ctx: anytype) !void {
+    if (filter) |f| {
+        if (std.mem.indexOf(u8, name, f) == null) return;
+    }
+    var samples: [max_iters]u64 = undefined;
+    const iters = itersFor(rows, cols);
+    for (0..warmup_iters) |_| try ctx.run();
+    for (samples[0..iters]) |*s| {
+        const start = std.Io.Clock.awake.now(io);
+        try ctx.run();
+        s.* = @intCast(start.durationTo(std.Io.Clock.awake.now(io)).toNanoseconds());
+    }
+    std.mem.sort(u64, samples[0..iters], {}, std.sort.asc(u64));
+    const median_ns = samples[iters / 2];
+
+    const ms = @as(f64, @floatFromInt(median_ns)) / std.time.ns_per_ms;
+    const mpix_s = @as(f64, @floatFromInt(rows * cols)) / @as(f64, @floatFromInt(median_ns)) * 1000.0;
+    std.debug.print("{s:<42} | {d:>4}x{d:<4} | {d:>10.3} | {d:>8.1}\n", .{ name, rows, cols, ms, mpix_s });
+}
+
+fn benchGaussian(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, sigma: f32) !void {
+    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer dst.deinit(gpa);
+    fillRandom(T, src, random);
+
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "gaussianBlur {s} sigma={d}", .{ @typeName(T), sigma });
+    const Ctx = struct {
+        src: Image(T),
+        dst: Image(T),
+        gpa: std.mem.Allocator,
+        sigma: f32,
+        fn run(self: @This()) !void {
+            try self.src.gaussianBlur(self.dst, self.gpa, self.sigma);
+        }
+    };
+    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .sigma = sigma });
+}
+
+fn benchConvolve2D(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, comptime kernel: anytype, kernel_name: []const u8, border: BorderMode) !void {
+    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer dst.deinit(gpa);
+    fillRandom(T, src, random);
+
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "convolve {s} {s} .{s}", .{ kernel_name, @typeName(T), @tagName(border) });
+    const Ctx = struct {
+        src: Image(T),
+        dst: Image(T),
+        gpa: std.mem.Allocator,
+        border: BorderMode,
+        fn run(self: @This()) !void {
+            try self.src.convolve(self.dst, self.gpa, kernel, self.border);
+        }
+    };
+    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .border = border });
+}
+
+fn benchSobel(io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize) !void {
+    var src: Image(f32) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer src.deinit(gpa);
+    var dst: Image(u8) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer dst.deinit(gpa);
+    fillRandom(f32, src, random);
+
+    const Ctx = struct {
+        src: Image(f32),
+        dst: Image(u8),
+        gpa: std.mem.Allocator,
+        fn run(self: @This()) !void {
+            try self.src.sobel(self.dst, self.gpa);
+        }
+    };
+    try benchOp(io, "sobel f32", rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa });
+}
+
+fn benchMotionBlur(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, distance: usize) !void {
+    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer dst.deinit(gpa);
+    fillRandom(T, src, random);
+
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "motionBlur linear horizontal {s} d={d}", .{ @typeName(T), distance });
+    const Ctx = struct {
+        src: Image(T),
+        dst: Image(T),
+        gpa: std.mem.Allocator,
+        distance: usize,
+        fn run(self: @This()) !void {
+            try self.src.motionBlur(self.dst, self.gpa, .{ .linear = .{ .angle = 0, .distance = self.distance } });
+        }
+    };
+    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .distance = distance });
+}
+
+fn benchSeparable(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize) !void {
+    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    defer dst.deinit(gpa);
+    fillRandom(T, src, random);
+
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "convolveSeparable {s} 9-tap .mirror", .{@typeName(T)});
+    const Ctx = struct {
+        src: Image(T),
+        dst: Image(T),
+        gpa: std.mem.Allocator,
+        fn run(self: @This()) !void {
+            try self.src.convolveSeparable(self.dst, self.gpa, &gaussian_9, &gaussian_9, .mirror);
+        }
+    };
+    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa });
+}
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(gpa);
+    defer args.deinit();
+    _ = args.skip();
+    const filter = args.next();
+
+    var prng = std.Random.DefaultPrng.init(0x5eed_2026);
+    const random = prng.random();
+
+    std.debug.print("{s:<42} | {s:^9} | {s:>10} | {s:>8}\n", .{ "benchmark", "size", "ms", "MPix/s" });
+    std.debug.print("{s:-<42}-+-{s:-<9}-+-{s:-<10}-+-{s:-<8}\n", .{ "", "", "", "" });
+
+    // Gaussian blur (separable u8 fixed-point and struct paths)
+    try benchGaussian(u8, io, gpa, random, filter, 480, 640, 1);
+    try benchGaussian(u8, io, gpa, random, filter, 480, 640, 3);
+    try benchGaussian(u8, io, gpa, random, filter, 480, 640, 8);
+    try benchGaussian(u8, io, gpa, random, filter, 2048, 2048, 3);
+    try benchGaussian(u8, io, gpa, random, filter, 2160, 3840, 3);
+    try benchGaussian(Rgb, io, gpa, random, filter, 480, 640, 3);
+    try benchGaussian(Rgb, io, gpa, random, filter, 2160, 3840, 3);
+
+    // 2D convolution (interior SIMD + border rows; 64x64 with 7x7 is border-dominated)
+    try benchConvolve2D(u8, io, gpa, random, filter, 480, 640, sharpen_3x3, "3x3", .mirror);
+    try benchConvolve2D(f32, io, gpa, random, filter, 480, 640, sharpen_3x3, "3x3", .mirror);
+    try benchConvolve2D(u8, io, gpa, random, filter, 480, 640, box_7x7, "7x7", .mirror);
+    try benchConvolve2D(f32, io, gpa, random, filter, 480, 640, box_7x7, "7x7", .mirror);
+    try benchConvolve2D(u8, io, gpa, random, filter, 64, 64, box_7x7, "7x7", .mirror);
+    try benchConvolve2D(u8, io, gpa, random, filter, 64, 64, box_7x7, "7x7", .zero);
+
+    // Sobel (two 3x3 convolutions over the same f32 source)
+    try benchSobel(io, gpa, random, filter, 480, 640);
+    try benchSobel(io, gpa, random, filter, 2160, 3840);
+
+    // Axis-aligned motion blur (separable with an identity 1-tap vertical kernel)
+    try benchMotionBlur(Rgb, io, gpa, random, filter, 480, 640, 15);
+    try benchMotionBlur(u8, io, gpa, random, filter, 480, 640, 15);
+
+    // Separable f32
+    try benchSeparable(f32, io, gpa, random, filter, 480, 640);
+    try benchSeparable(f32, io, gpa, random, filter, 2048, 2048);
+    try benchSeparable(f32, io, gpa, random, filter, 2160, 3840);
+}

--- a/examples/src/convolution_bench.zig
+++ b/examples/src/convolution_bench.zig
@@ -36,11 +36,19 @@ fn fillRandom(comptime T: type, img: Image(T), random: std.Random) void {
     }
 }
 
+/// Checked before any image allocation so filtered-out benchmarks cost nothing.
+fn skipped(name: []const u8, filter: ?[]const u8) bool {
+    return if (filter) |f| std.mem.indexOf(u8, name, f) == null else false;
+}
+
+fn initRandom(comptime T: type, gpa: std.mem.Allocator, random: std.Random, rows: usize, cols: usize) !Image(T) {
+    const img: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
+    fillRandom(T, img, random);
+    return img;
+}
+
 /// Runs ctx.run() warmup + iters times and reports the median.
-fn benchOp(io: std.Io, name: []const u8, rows: usize, cols: usize, filter: ?[]const u8, ctx: anytype) !void {
-    if (filter) |f| {
-        if (std.mem.indexOf(u8, name, f) == null) return;
-    }
+fn benchOp(io: std.Io, name: []const u8, rows: usize, cols: usize, ctx: anytype) !void {
     var samples: [max_iters]u64 = undefined;
     const iters = itersFor(rows, cols);
     for (0..warmup_iters) |_| try ctx.run();
@@ -58,14 +66,15 @@ fn benchOp(io: std.Io, name: []const u8, rows: usize, cols: usize, filter: ?[]co
 }
 
 fn benchGaussian(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, sigma: f32) !void {
-    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer src.deinit(gpa);
-    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer dst.deinit(gpa);
-    fillRandom(T, src, random);
-
     var name_buf: [64]u8 = undefined;
     const name = try std.fmt.bufPrint(&name_buf, "gaussianBlur {s} sigma={d}", .{ @typeName(T), sigma });
+    if (skipped(name, filter)) return;
+
+    var src = try initRandom(T, gpa, random, rows, cols);
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .initLike(gpa, src);
+    defer dst.deinit(gpa);
+
     const Ctx = struct {
         src: Image(T),
         dst: Image(T),
@@ -75,18 +84,19 @@ fn benchGaussian(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: s
             try self.src.gaussianBlur(self.dst, self.gpa, self.sigma);
         }
     };
-    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .sigma = sigma });
+    try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .sigma = sigma });
 }
 
 fn benchConvolve2D(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, comptime kernel: anytype, kernel_name: []const u8, border: BorderMode) !void {
-    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer src.deinit(gpa);
-    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer dst.deinit(gpa);
-    fillRandom(T, src, random);
-
     var name_buf: [64]u8 = undefined;
     const name = try std.fmt.bufPrint(&name_buf, "convolve {s} {s} .{s}", .{ kernel_name, @typeName(T), @tagName(border) });
+    if (skipped(name, filter)) return;
+
+    var src = try initRandom(T, gpa, random, rows, cols);
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .initLike(gpa, src);
+    defer dst.deinit(gpa);
+
     const Ctx = struct {
         src: Image(T),
         dst: Image(T),
@@ -96,15 +106,16 @@ fn benchConvolve2D(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random:
             try self.src.convolve(self.dst, self.gpa, kernel, self.border);
         }
     };
-    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .border = border });
+    try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .border = border });
 }
 
 fn benchSobel(io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize) !void {
-    var src: Image(f32) = try .init(gpa, @intCast(rows), @intCast(cols));
+    if (skipped("sobel f32", filter)) return;
+
+    var src = try initRandom(f32, gpa, random, rows, cols);
     defer src.deinit(gpa);
     var dst: Image(u8) = try .init(gpa, @intCast(rows), @intCast(cols));
     defer dst.deinit(gpa);
-    fillRandom(f32, src, random);
 
     const Ctx = struct {
         src: Image(f32),
@@ -114,18 +125,19 @@ fn benchSobel(io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[
             try self.src.sobel(self.dst, self.gpa);
         }
     };
-    try benchOp(io, "sobel f32", rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa });
+    try benchOp(io, "sobel f32", rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa });
 }
 
 fn benchMotionBlur(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize, distance: usize) !void {
-    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer src.deinit(gpa);
-    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer dst.deinit(gpa);
-    fillRandom(T, src, random);
-
     var name_buf: [64]u8 = undefined;
     const name = try std.fmt.bufPrint(&name_buf, "motionBlur linear horizontal {s} d={d}", .{ @typeName(T), distance });
+    if (skipped(name, filter)) return;
+
+    var src = try initRandom(T, gpa, random, rows, cols);
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .initLike(gpa, src);
+    defer dst.deinit(gpa);
+
     const Ctx = struct {
         src: Image(T),
         dst: Image(T),
@@ -135,18 +147,19 @@ fn benchMotionBlur(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random:
             try self.src.motionBlur(self.dst, self.gpa, .{ .linear = .{ .angle = 0, .distance = self.distance } });
         }
     };
-    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa, .distance = distance });
+    try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .distance = distance });
 }
 
 fn benchSeparable(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[]const u8, rows: usize, cols: usize) !void {
-    var src: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer src.deinit(gpa);
-    var dst: Image(T) = try .init(gpa, @intCast(rows), @intCast(cols));
-    defer dst.deinit(gpa);
-    fillRandom(T, src, random);
-
     var name_buf: [64]u8 = undefined;
     const name = try std.fmt.bufPrint(&name_buf, "convolveSeparable {s} 9-tap .mirror", .{@typeName(T)});
+    if (skipped(name, filter)) return;
+
+    var src = try initRandom(T, gpa, random, rows, cols);
+    defer src.deinit(gpa);
+    var dst: Image(T) = try .initLike(gpa, src);
+    defer dst.deinit(gpa);
+
     const Ctx = struct {
         src: Image(T),
         dst: Image(T),
@@ -155,7 +168,7 @@ fn benchSeparable(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: 
             try self.src.convolveSeparable(self.dst, self.gpa, &gaussian_9, &gaussian_9, .mirror);
         }
     };
-    try benchOp(io, name, rows, cols, filter, Ctx{ .src = src, .dst = dst, .gpa = gpa });
+    try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa });
 }
 
 pub fn main(init: std.process.Init) !void {

--- a/src/image.zig
+++ b/src/image.zig
@@ -1266,5 +1266,6 @@ test {
     _ = @import("image/hough.zig");
     _ = @import("image/colormaps.zig");
     _ = @import("image/border.zig");
+    _ = @import("image/convolution.zig");
     _ = @import("image/tests/flood_fill.zig");
 }

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -108,98 +108,172 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
             return result;
         }
 
-        fn convolvePixelWithBorder(src: Image(T), dst: Image(T), r: usize, c: usize, kernel: [size]KernelScalar, border_mode: BorderMode) void {
+        fn convolvePixelWithBorder(comptime n: usize, src: Image(T), dsts: [n]Image(T), r: usize, c: usize, kernels: [n][size]KernelScalar, border_mode: BorderMode) void {
             const ir: isize = @intCast(r);
             const ic: isize = @intCast(c);
-            var result: AccumScalar = 0;
+            var results: [n]AccumScalar = @splat(0);
             inline for (0..rows) |ky| {
                 inline for (0..cols) |kx| {
                     const iry = ir + @as(isize, ky) - half_h;
                     const icx = ic + @as(isize, kx) - half_w;
                     const pixel_val: AccumScalar = border.getPixel(T, src, iry, icx, border_mode);
-                    const k_val: AccumScalar = kernel[ky * cols + kx];
-                    result += pixel_val * k_val;
+                    inline for (0..n) |i| {
+                        const k_val: AccumScalar = kernels[i][ky * cols + kx];
+                        results[i] += pixel_val * k_val;
+                    }
                 }
             }
-            dst.data[r * dst.stride + c] = Pixels.store(result);
+            inline for (0..n) |i| {
+                dsts[i].data[r * dsts[i].stride + c] = Pixels.store(results[i]);
+            }
         }
 
-        fn convolve(src: Image(T), dst: Image(T), kernel: [size]KernelScalar, border_mode: BorderMode) void {
-            var kernel_vecs: [size]@Vector(vec_len, AccumScalar) = undefined;
-            inline for (0..size) |i| {
-                const k_val: AccumScalar = kernel[i];
-                kernel_vecs[i] = @splat(k_val);
+        /// Per-tap source-row base offsets for one output row; null = row of zeros (.zero border).
+        fn RowOffsets(comptime maybe_zero: bool) type {
+            return [rows](if (maybe_zero) ?usize else usize);
+        }
+
+        /// Convolves columns [c_start, c_end) of one output row from precomputed row offsets,
+        /// applying all `n` kernels per loaded pixel.
+        /// Columns in the span are horizontally in-bounds; when `maybe_zero` is false the
+        /// null checks fold away and this is exactly the interior fast path.
+        inline fn convolveRowSpan(
+            comptime n: usize,
+            comptime maybe_zero: bool,
+            src: Image(T),
+            dsts: [n]Image(T),
+            row_offsets: RowOffsets(maybe_zero),
+            kernels: [n][size]KernelScalar,
+            kernel_vecs: *const [n][size]@Vector(vec_len, AccumScalar),
+            r: usize,
+            c_start: usize,
+            c_end: usize,
+        ) void {
+            var c = c_start;
+
+            if (src.cols >= vec_len + 2 * half_w) {
+                while (c + vec_len <= c_end) : (c += vec_len) {
+                    var result_vecs: [n]@Vector(vec_len, AccumScalar) = @splat(@splat(0));
+                    inline for (0..rows) |ky| {
+                        const maybe_base = row_offsets[ky];
+                        if (if (maybe_zero) maybe_base != null else true) {
+                            const base = if (maybe_zero) maybe_base.? else maybe_base;
+                            inline for (0..cols) |kx| {
+                                const pixel_vec = Pixels.loadVec(src.data, base + c + kx - half_w);
+                                inline for (0..n) |i| {
+                                    result_vecs[i] += pixel_vec * kernel_vecs[i][ky * cols + kx];
+                                }
+                            }
+                        }
+                    }
+                    inline for (0..n) |i| {
+                        Pixels.storeVec(result_vecs[i], dsts[i].data, r * dsts[i].stride + c);
+                    }
+                }
+            }
+
+            while (c < c_end) : (c += 1) {
+                var results: [n]AccumScalar = @splat(0);
+                inline for (0..rows) |ky| {
+                    const maybe_base = row_offsets[ky];
+                    if (if (maybe_zero) maybe_base != null else true) {
+                        const base = if (maybe_zero) maybe_base.? else maybe_base;
+                        inline for (0..cols) |kx| {
+                            const pixel_val = Pixels.load(src.data[base + c + kx - half_w]);
+                            inline for (0..n) |i| {
+                                const k_val: AccumScalar = kernels[i][ky * cols + kx];
+                                results[i] += pixel_val * k_val;
+                            }
+                        }
+                    }
+                }
+                inline for (0..n) |i| {
+                    dsts[i].data[r * dsts[i].stride + c] = Pixels.store(results[i]);
+                }
+            }
+        }
+
+        /// Applies `n` same-shaped kernels in a single pass over `src`; each source pixel is
+        /// loaded once and feeds every kernel's accumulator.
+        fn convolveMulti(comptime n: usize, src: Image(T), dsts: [n]Image(T), kernels: [n][size]KernelScalar, border_mode: BorderMode) void {
+            var kernel_vecs: [n][size]@Vector(vec_len, AccumScalar) = undefined;
+            inline for (0..n) |i| {
+                inline for (0..size) |j| {
+                    const k_val: AccumScalar = kernels[i][j];
+                    kernel_vecs[i][j] = @splat(k_val);
+                }
             }
 
             for (0..src.rows) |r| {
-                const row_in_band = r >= half_h and r + half_h < src.rows;
-
-                if (!row_in_band) {
-                    for (0..src.cols) |c| {
-                        convolvePixelWithBorder(src, dst, r, c, kernel, border_mode);
-                    }
-                    continue;
-                }
-
                 var c: usize = 0;
-
                 while (c < @min(half_w, src.cols)) : (c += 1) {
-                    convolvePixelWithBorder(src, dst, r, c, kernel, border_mode);
+                    convolvePixelWithBorder(n, src, dsts, r, c, kernels, border_mode);
                 }
 
                 const safe_end = src.cols -| half_w;
-
-                if (src.cols >= vec_len + 2 * half_w) {
-                    while (c + vec_len <= safe_end) : (c += vec_len) {
-                        var result_vec: @Vector(vec_len, AccumScalar) = @splat(0);
-
-                        inline for (0..rows) |ky| {
-                            inline for (0..cols) |kx| {
-                                const kid = ky * cols + kx;
-                                const kernel_vec = kernel_vecs[kid];
-
-                                const src_r = r + ky - half_h;
-                                const src_c = c + kx - half_w;
-                                const src_idx = src_r * src.stride + src_c;
-                                const pixel_vec = Pixels.loadVec(src.data, src_idx);
-                                result_vec += pixel_vec * kernel_vec;
-                            }
-                        }
-
-                        Pixels.storeVec(result_vec, dst.data, r * dst.stride + c);
-                    }
-                }
-
-                while (c < safe_end) : (c += 1) {
-                    var result: AccumScalar = 0;
+                const row_in_band = r >= half_h and r + half_h < src.rows;
+                if (row_in_band) {
+                    var offs: RowOffsets(false) = undefined;
                     inline for (0..rows) |ky| {
-                        inline for (0..cols) |kx| {
-                            const src_r = r + ky - half_h;
-                            const src_c = c + kx - half_w;
-                            const pixel_val = Pixels.load(src.data[src_r * src.stride + src_c]);
-                            const k_val: AccumScalar = kernel[ky * cols + kx];
-                            result += pixel_val * k_val;
-                        }
+                        offs[ky] = (r + ky - half_h) * src.stride;
                     }
-                    dst.data[r * dst.stride + c] = Pixels.store(result);
+                    convolveRowSpan(n, false, src, dsts, offs, kernels, &kernel_vecs, r, c, safe_end);
+                } else {
+                    const ir: isize = @intCast(r);
+                    var offs: RowOffsets(true) = undefined;
+                    inline for (0..rows) |ky| {
+                        const resolved = border.resolveIndex(ir + @as(isize, ky) - half_h, @intCast(src.rows), border_mode);
+                        offs[ky] = if (resolved) |sr| sr * src.stride else null;
+                    }
+                    convolveRowSpan(n, true, src, dsts, offs, kernels, &kernel_vecs, r, c, safe_end);
                 }
 
+                c = @max(c, safe_end);
                 while (c < src.cols) : (c += 1) {
-                    convolvePixelWithBorder(src, dst, r, c, kernel, border_mode);
+                    convolvePixelWithBorder(n, src, dsts, r, c, kernels, border_mode);
                 }
             }
+        }
+
+        fn convolve(src: Image(T), dst: Image(T), kernel: [size]KernelScalar, border_mode: BorderMode) void {
+            convolveMulti(1, src, .{dst}, .{kernel}, border_mode);
         }
     };
 }
 
+/// Comptime {height, width} of a 2D array kernel type.
+fn kernelDims(comptime K: type) [2]usize {
+    const info = @typeInfo(K);
+    if (info != .array) @compileError("Kernel must be a 2D array");
+    if (@typeInfo(info.array.child) != .array) @compileError("Kernel must be a 2D array");
+    return .{ info.array.len, @typeInfo(info.array.child).array.len };
+}
+
+/// Applies two same-shaped 2D kernels in a single pass over `self`, writing into `out_a` and
+/// `out_b`; each source pixel is loaded once. Supports u8 and f32 planes only.
+pub fn convolvePair(
+    comptime T: type,
+    self: Image(T),
+    out_a: Image(T),
+    out_b: Image(T),
+    kernel_a: anytype,
+    kernel_b: anytype,
+    border_mode: BorderMode,
+) void {
+    if (T != u8 and T != f32) @compileError("convolvePair supports u8 and f32 planes only");
+    const dims_a = comptime kernelDims(@TypeOf(kernel_a));
+    const dims_b = comptime kernelDims(@TypeOf(kernel_b));
+    if (dims_a[0] != dims_b[0] or dims_a[1] != dims_b[1]) @compileError("convolvePair kernels must have identical dimensions");
+
+    const Kernel = ConvolutionKernel(T, dims_a[0], dims_a[1]);
+    Kernel.convolveMulti(2, self, .{ out_a, out_b }, .{ Kernel.flatten(kernel_a), Kernel.flatten(kernel_b) }, border_mode);
+}
+
 /// Applies a 2D convolution with the given kernel, writing into `out`.
 pub fn convolve(comptime T: type, self: Image(T), out: Image(T), allocator: Allocator, kernel: anytype, border_mode: BorderMode) !void {
-    const kernel_info = @typeInfo(@TypeOf(kernel));
-    if (kernel_info != .array) @compileError("Kernel must be a 2D array");
-    const outer_array = kernel_info.array;
-    if (@typeInfo(outer_array.child) != .array) @compileError("Kernel must be a 2D array");
-    const kernel_height = outer_array.len;
-    const kernel_width = @typeInfo(outer_array.child).array.len;
+    const dims = comptime kernelDims(@TypeOf(kernel));
+    const kernel_height = dims[0];
+    const kernel_width = dims[1];
 
     switch (T) {
         u8, f32 => {
@@ -302,6 +376,32 @@ fn scaleKernelToInt(allocator: Allocator, kernel: []const f32) ![]i32 {
     return result;
 }
 
+/// A 1-tap identity kernel makes its whole pass a copy; detected on the raw f32 kernel so
+/// the check is shared by every pixel-type arm.
+inline fn isIdentityKernel(kernel: []const f32) bool {
+    return kernel.len == 1 and kernel[0] == 1;
+}
+
+/// Single-axis separable pass straight src -> dst, used when the other axis is a 1-tap
+/// identity: no temp plane, and u8 results carry a single `fixed_point_scale` (exact —
+/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)).
+fn convolveSeparableSingle(
+    comptime PixelT: type,
+    comptime vertical: bool,
+    image: Image(PixelT),
+    out: Image(PixelT),
+    allocator: Allocator,
+    kernel: []const (if (PixelT == u8) i32 else f32),
+    border_mode: BorderMode,
+) !void {
+    const Pass = SeparablePass(PixelT, PixelT, fixed_point_scale);
+    if (vertical) {
+        try Pass.vertical(image, out, allocator, kernel, border_mode);
+    } else {
+        try Pass.horizontal(image, out, allocator, kernel, border_mode);
+    }
+}
+
 /// Separable convolution: applies two 1D kernels (horizontal then vertical).
 /// Much faster than `convolve` for separable filters like Gaussian blur.
 pub fn convolveSeparable(
@@ -313,23 +413,51 @@ pub fn convolveSeparable(
     kernel_y: []const f32,
     border_mode: BorderMode,
 ) !void {
+    const identity_x = isIdentityKernel(kernel_x);
+    const identity_y = isIdentityKernel(kernel_y);
+    if (identity_x and identity_y) {
+        image.copy(out);
+        return;
+    }
+
     switch (T) {
         u8 => {
-            var temp = try Image(i32).initLike(allocator, image);
-            defer temp.deinit(allocator);
+            if (identity_y) {
+                const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
+                defer allocator.free(kernel_x_int);
+                try convolveSeparableSingle(u8, false, image, out, allocator, kernel_x_int, border_mode);
+            } else if (identity_x) {
+                const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
+                defer allocator.free(kernel_y_int);
+                try convolveSeparableSingle(u8, true, image, out, allocator, kernel_y_int, border_mode);
+            } else {
+                const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
+                defer allocator.free(kernel_x_int);
+                const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
+                defer allocator.free(kernel_y_int);
 
-            const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
-            defer allocator.free(kernel_x_int);
-            const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
-            defer allocator.free(kernel_y_int);
-
-            convolveSeparablePlane(u8, i32, image, out, temp, kernel_x_int, kernel_y_int, border_mode);
+                if (useFusedSeparable(i32, image.rows, image.cols, kernel_y.len, border_mode)) {
+                    try convolveSeparablePlaneFused(u8, i32, image, out, allocator, kernel_x_int, kernel_y_int, border_mode);
+                } else {
+                    var temp = try Image(i32).initLike(allocator, image);
+                    defer temp.deinit(allocator);
+                    try convolveSeparablePlane(u8, i32, image, out, temp, allocator, kernel_x_int, kernel_y_int, border_mode);
+                }
+            }
         },
         f32 => {
-            var temp = try Image(T).initLike(allocator, image);
-            defer temp.deinit(allocator);
+            if (identity_y) {
+                try convolveSeparableSingle(f32, false, image, out, allocator, kernel_x, border_mode);
+            } else if (identity_x) {
+                try convolveSeparableSingle(f32, true, image, out, allocator, kernel_y, border_mode);
+            } else if (useFusedSeparable(f32, image.rows, image.cols, kernel_y.len, border_mode)) {
+                try convolveSeparablePlaneFused(f32, f32, image, out, allocator, kernel_x, kernel_y, border_mode);
+            } else {
+                var temp = try Image(T).initLike(allocator, image);
+                defer temp.deinit(allocator);
 
-            convolveSeparablePlane(f32, f32, image, out, temp, kernel_x, kernel_y, border_mode);
+                try convolveSeparablePlane(f32, f32, image, out, temp, allocator, kernel_x, kernel_y, border_mode);
+            }
         },
         else => switch (@typeInfo(T)) {
             .@"struct" => {
@@ -349,15 +477,31 @@ pub fn convolveSeparable(
                         allocator: Allocator,
                         kernel_x: []const i32,
                         kernel_y: []const i32,
+                        passes: enum { both, horizontal_only, vertical_only },
                         temp: []i32 = &.{},
 
                         fn convolvePlane(ctx: *@This(), src: Image(u8), dst: Image(u8), mode: BorderMode) !void {
-                            if (ctx.temp.len == 0) ctx.temp = try ctx.allocator.alloc(i32, src.rows * src.cols);
-                            const temp = Image(i32).initFromSlice(src.rows, src.cols, ctx.temp);
-                            convolveSeparablePlane(u8, i32, src, dst, temp, ctx.kernel_x, ctx.kernel_y, mode);
+                            switch (ctx.passes) {
+                                .horizontal_only => try convolveSeparableSingle(u8, false, src, dst, ctx.allocator, ctx.kernel_x, mode),
+                                .vertical_only => try convolveSeparableSingle(u8, true, src, dst, ctx.allocator, ctx.kernel_y, mode),
+                                .both => {
+                                    if (useFusedSeparable(i32, src.rows, src.cols, ctx.kernel_y.len, mode)) {
+                                        try convolveSeparablePlaneFused(u8, i32, src, dst, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode);
+                                    } else {
+                                        if (ctx.temp.len == 0) ctx.temp = try ctx.allocator.alloc(i32, src.rows * src.cols);
+                                        const temp = Image(i32).initFromSlice(src.rows, src.cols, ctx.temp);
+                                        try convolveSeparablePlane(u8, i32, src, dst, temp, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode);
+                                    }
+                                },
+                            }
                         }
                     };
-                    var ctx: PlaneCtx = .{ .allocator = allocator, .kernel_x = kernel_x_int, .kernel_y = kernel_y_int };
+                    var ctx: PlaneCtx = .{
+                        .allocator = allocator,
+                        .kernel_x = kernel_x_int,
+                        .kernel_y = kernel_y_int,
+                        .passes = if (identity_y) .horizontal_only else if (identity_x) .vertical_only else .both,
+                    };
                     defer allocator.free(ctx.temp);
                     try convolvePlanes(T, image, out, allocator, kx_sum * ky_sum, fixed_point_scale_sq, border_mode, &ctx);
                 } else {
@@ -369,6 +513,430 @@ pub fn convolveSeparable(
     }
 }
 
+/// Resolved 1-D source indices for the border positions of one separable pass.
+/// Border resolution is 1-D per axis (the other coordinate is always in bounds), and the
+/// resolved indices are identical across that other axis — so they are computed once per
+/// pass instead of per pixel. `indices[ordinal * kernel_len + tap]` is an in-bounds index,
+/// or `zero_sentinel` when the tap reads a zero value (.zero mode or empty axis).
+const BorderIndexTable = struct {
+    const zero_sentinel: usize = std.math.maxInt(usize);
+
+    indices: []usize,
+    kernel_len: usize,
+
+    /// Border positions are [0, low_end) and [high_start, axis_len); callers must pass the
+    /// exact range bounds their loops use so table and loops cannot drift.
+    fn init(
+        allocator: Allocator,
+        axis_len: usize,
+        kernel_len: usize,
+        half: usize,
+        low_end: usize,
+        high_start: usize,
+        border_mode: BorderMode,
+    ) !BorderIndexTable {
+        const n_positions = low_end + (axis_len - high_start);
+        const indices = try allocator.alloc(usize, n_positions * kernel_len);
+        var w: usize = 0;
+        for (0..low_end) |pos| {
+            for (0..kernel_len) |i| {
+                indices[w] = resolveTap(pos, i, half, axis_len, border_mode);
+                w += 1;
+            }
+        }
+        for (high_start..axis_len) |pos| {
+            for (0..kernel_len) |i| {
+                indices[w] = resolveTap(pos, i, half, axis_len, border_mode);
+                w += 1;
+            }
+        }
+        return .{ .indices = indices, .kernel_len = kernel_len };
+    }
+
+    fn resolveTap(pos: usize, tap: usize, half: usize, axis_len: usize, border_mode: BorderMode) usize {
+        const idx: isize = @as(isize, @intCast(pos)) + @as(isize, @intCast(tap)) - @as(isize, @intCast(half));
+        return border.resolveIndex(idx, @intCast(axis_len), border_mode) orelse zero_sentinel;
+    }
+
+    fn deinit(self: BorderIndexTable, allocator: Allocator) void {
+        allocator.free(self.indices);
+    }
+
+    inline fn taps(self: BorderIndexTable, ordinal: usize) []const usize {
+        return self.indices[ordinal * self.kernel_len ..][0..self.kernel_len];
+    }
+};
+
+/// One direction of a separable convolution with load/store policies derived from the
+/// source and destination scalar types. `dst_scale` is the fixed-point divisor applied
+/// when storing to u8 (unused for i32/f32 destinations).
+fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: comptime_int) type {
+    return struct {
+        const KernelT = if (SrcT == f32 or DstT == f32) f32 else i32;
+        const AccumT = if (KernelT == f32) f32 else i64;
+        const vec_len = std.simd.suggestVectorLength(KernelT) orelse 1;
+
+        inline fn isNegligible(k: KernelT) bool {
+            return if (KernelT == f32) @abs(k) < 1e-10 else k == 0;
+        }
+
+        inline fn promote(v: anytype) if (@typeInfo(@TypeOf(v)) == .vector) @Vector(vec_len, AccumT) else AccumT {
+            return if (AccumT == i64) @intCast(v) else v;
+        }
+
+        inline fn loadVec(ptr: [*]const SrcT) @Vector(vec_len, AccumT) {
+            const v: @Vector(vec_len, SrcT) = ptr[0..vec_len].*;
+            return promote(v);
+        }
+
+        inline fn store(val: AccumT) DstT {
+            return switch (DstT) {
+                u8 => divClampU8(dst_scale, val),
+                i32 => @intCast(meta.clamp(i32, val)),
+                f32 => val,
+                else => unreachable,
+            };
+        }
+
+        inline fn storeVec(val: @Vector(vec_len, AccumT), ptr: [*]DstT) void {
+            switch (DstT) {
+                u8 => ptr[0..vec_len].* = divClampU8Vec(dst_scale, vec_len, val),
+                i32 => {
+                    const min_vec: @Vector(vec_len, i64) = @splat(std.math.minInt(i32));
+                    const max_vec: @Vector(vec_len, i64) = @splat(std.math.maxInt(i32));
+                    const narrowed: @Vector(vec_len, i32) = @intCast(@max(min_vec, @min(max_vec, val)));
+                    ptr[0..vec_len].* = narrowed;
+                },
+                f32 => ptr[0..vec_len].* = val,
+                else => unreachable,
+            }
+        }
+
+        /// Full-kernel accumulation for one border pixel from pre-resolved column indices
+        /// (full kernel, zero adds included, to keep f32 accumulation order).
+        inline fn borderPixelResolved(src: Image(SrcT), kernel: []const KernelT, tap_idx: []const usize, src_offset: usize) AccumT {
+            var result: AccumT = 0;
+            for (kernel, tap_idx) |k, idx| {
+                const pv: SrcT = if (idx == BorderIndexTable.zero_sentinel) 0 else src.data[src_offset + idx];
+                result += promote(pv) * promote(k);
+            }
+            return result;
+        }
+
+        /// One row of the horizontal pass into a caller-provided contiguous row buffer.
+        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, left_end: usize, right_start: usize) void {
+            const half = kernel.len / 2;
+            const cols = src.cols;
+            const src_offset = r * src.stride;
+            var c: usize = 0;
+
+            while (c < left_end) : (c += 1) {
+                dst_row[c] = store(borderPixelResolved(src, kernel, table.taps(c), src_offset));
+            }
+
+            if (cols > 2 * half) {
+                const interior_end = cols - half;
+
+                while (c + vec_len <= interior_end) : (c += vec_len) {
+                    var acc: @Vector(vec_len, AccumT) = @splat(0);
+                    for (kernel, 0..) |k, ki| {
+                        if (!isNegligible(k)) {
+                            const vec = loadVec(src.data[src_offset + c + ki - half ..].ptr);
+                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
+                            acc += vec * k_vec;
+                        }
+                    }
+                    storeVec(acc, dst_row[c..].ptr);
+                }
+
+                while (c < interior_end) : (c += 1) {
+                    var result: AccumT = 0;
+                    const c0 = c - half;
+                    for (kernel, 0..) |k, i| {
+                        if (!isNegligible(k)) {
+                            result += promote(src.data[src_offset + c0 + i]) * promote(k);
+                        }
+                    }
+                    dst_row[c] = store(result);
+                }
+            }
+
+            while (c < cols) : (c += 1) {
+                dst_row[c] = store(borderPixelResolved(src, kernel, table.taps(left_end + (c - right_start)), src_offset));
+            }
+        }
+
+        /// Row-major 1D pass along columns (src -> dst).
+        fn horizontal(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
+            const half = kernel.len / 2;
+            const cols = src.cols;
+            const left_end = @min(half, cols);
+            const right_start = if (cols > 2 * half) cols - half else left_end;
+
+            const table: BorderIndexTable = try .init(allocator, cols, kernel.len, half, left_end, right_start, border_mode);
+            defer table.deinit(allocator);
+
+            for (0..src.rows) |r| {
+                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table, left_end, right_start);
+            }
+        }
+
+        /// One vertical-pass output row combined from per-tap source row base offsets
+        /// (`BorderIndexTable.zero_sentinel` = row of zeros). Border rows keep the full
+        /// kernel with explicit zero adds; interior rows skip negligible taps — both
+        /// matching the standard vertical pass per pixel.
+        fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT) void {
+            const cols = dst.cols;
+            const dst_offset = r * dst.stride;
+            var c: usize = 0;
+
+            while (c + vec_len <= cols) : (c += vec_len) {
+                var acc: @Vector(vec_len, AccumT) = @splat(0);
+                for (kernel, bases) |k, base| {
+                    if (border_row) {
+                        const vec: @Vector(vec_len, AccumT) = if (base == BorderIndexTable.zero_sentinel)
+                            @splat(0)
+                        else
+                            loadVec(src_data[base + c ..].ptr);
+                        const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
+                        acc += vec * k_vec;
+                    } else if (!isNegligible(k)) {
+                        const vec = loadVec(src_data[base + c ..].ptr);
+                        const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
+                        acc += vec * k_vec;
+                    }
+                }
+                storeVec(acc, dst.data[dst_offset + c ..].ptr);
+            }
+
+            while (c < cols) : (c += 1) {
+                var result: AccumT = 0;
+                for (kernel, bases) |k, base| {
+                    if (border_row) {
+                        const pv: SrcT = if (base == BorderIndexTable.zero_sentinel) 0 else src_data[base + c];
+                        result += promote(pv) * promote(k);
+                    } else if (!isNegligible(k)) {
+                        result += promote(src_data[base + c]) * promote(k);
+                    }
+                }
+                dst.data[dst_offset + c] = store(result);
+            }
+        }
+
+        /// Column-tiled 1D pass along rows (src -> dst); tiling keeps the working set cache-resident.
+        fn vertical(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
+            const half = kernel.len / 2;
+            const rows = src.rows;
+            const cols = src.cols;
+            const tile_width = @max(vec_len, 16);
+
+            if (rows > 2 * half) {
+                const safe_end_r = rows - half;
+
+                var tile_c: usize = 0;
+                while (tile_c < cols) : (tile_c += tile_width) {
+                    const tile_end = @min(tile_c + tile_width, cols);
+                    var c: usize = tile_c;
+
+                    while (c + vec_len <= tile_end) : (c += vec_len) {
+                        for (half..safe_end_r) |r| {
+                            var acc: @Vector(vec_len, AccumT) = @splat(0);
+                            for (kernel, 0..) |k, ki| {
+                                if (!isNegligible(k)) {
+                                    const vec = loadVec(src.data[(r + ki - half) * src.stride + c ..].ptr);
+                                    const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
+                                    acc += vec * k_vec;
+                                }
+                            }
+                            storeVec(acc, dst.data[r * dst.stride + c ..].ptr);
+                        }
+                    }
+
+                    while (c < tile_end) : (c += 1) {
+                        for (half..safe_end_r) |r| {
+                            var result: AccumT = 0;
+                            const r0 = r - half;
+                            for (kernel, 0..) |k, i| {
+                                if (isNegligible(k)) continue;
+                                result += promote(src.data[(r0 + i) * src.stride + c]) * promote(k);
+                            }
+                            dst.data[r * dst.stride + c] = store(result);
+                        }
+                    }
+                }
+            }
+
+            // Top and bottom border rows: row taps resolved once per row, then SIMD across
+            // columns (each lane accumulates in the same tap order as the scalar loop).
+            const top_end = @min(half, rows);
+            const bottom_start = if (rows > half) @max(top_end, rows - half) else rows;
+
+            const table: BorderIndexTable = try .init(allocator, rows, kernel.len, half, top_end, bottom_start, border_mode);
+            defer table.deinit(allocator);
+
+            const border_rows = [_][2]usize{
+                .{ 0, top_end },
+                .{ bottom_start, rows },
+            };
+
+            for (border_rows) |range| {
+                for (range[0]..range[1]) |r| {
+                    const ordinal = if (r < top_end) r else top_end + (r - bottom_start);
+                    const tap_idx = table.taps(ordinal);
+                    const dst_offset = r * dst.stride;
+                    var c: usize = 0;
+
+                    while (c + vec_len <= cols) : (c += vec_len) {
+                        var acc: @Vector(vec_len, AccumT) = @splat(0);
+                        for (kernel, tap_idx) |k, idx| {
+                            const vec: @Vector(vec_len, AccumT) = if (idx == BorderIndexTable.zero_sentinel)
+                                @splat(0)
+                            else
+                                loadVec(src.data[idx * src.stride + c ..].ptr);
+                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
+                            acc += vec * k_vec;
+                        }
+                        storeVec(acc, dst.data[dst_offset + c ..].ptr);
+                    }
+
+                    while (c < cols) : (c += 1) {
+                        var result: AccumT = 0;
+                        for (kernel, tap_idx) |k, idx| {
+                            const pv: SrcT = if (idx == BorderIndexTable.zero_sentinel) 0 else src.data[idx * src.stride + c];
+                            result += promote(pv) * promote(k);
+                        }
+                        dst.data[dst_offset + c] = store(result);
+                    }
+                }
+            }
+        }
+    };
+}
+
+/// Cache thresholds for the fused (ring-buffer) separable path: fuse only when the full
+/// temp plane would clearly exceed cache but the ring of kernel rows stays resident.
+const fused_min_temp_bytes: usize = 8 << 20;
+const fused_max_ring_bytes: usize = 1 << 20;
+
+fn useFusedSeparable(comptime TempT: type, rows: usize, cols: usize, kernel_y_len: usize, border_mode: BorderMode) bool {
+    // .wrap needs far-end temp rows for the top border rows, which a sliding window lacks.
+    if (border_mode == .wrap) return false;
+    if (rows <= 2 * (kernel_y_len / 2)) return false;
+    const temp_bytes = rows * cols * @sizeOf(TempT);
+    const ring_bytes = kernel_y_len * cols * @sizeOf(TempT);
+    return temp_bytes > fused_min_temp_bytes and ring_bytes <= fused_max_ring_bytes;
+}
+
+/// Separable convolution with the horizontal producer and vertical consumer fused over a
+/// ring of `kernel_y.len` temp rows, avoiding the full-plane temp round-trip to DRAM.
+/// Bit-exact with `convolveSeparablePlane` for the border modes the gate admits.
+fn convolveSeparablePlaneFused(
+    comptime PixelT: type,
+    comptime TempT: type,
+    src_img: Image(PixelT),
+    dst_img: Image(PixelT),
+    allocator: Allocator,
+    kernel_x: []const TempT,
+    kernel_y: []const TempT,
+    border_mode: BorderMode,
+) !void {
+    const HPass = SeparablePass(PixelT, TempT, fixed_point_scale_sq);
+    const VPass = SeparablePass(TempT, PixelT, fixed_point_scale_sq);
+
+    const rows = src_img.rows;
+    const cols = src_img.cols;
+    const klen_y = kernel_y.len;
+    const half_y = klen_y / 2;
+    const half_x = kernel_x.len / 2;
+
+    const left_end = @min(half_x, cols);
+    const right_start = if (cols > 2 * half_x) cols - half_x else left_end;
+    const h_table: BorderIndexTable = try .init(allocator, cols, kernel_x.len, half_x, left_end, right_start, border_mode);
+    defer h_table.deinit(allocator);
+
+    const top_end = @min(half_y, rows);
+    const bottom_start = if (rows > half_y) @max(top_end, rows - half_y) else rows;
+    const v_table: BorderIndexTable = try .init(allocator, rows, klen_y, half_y, top_end, bottom_start, border_mode);
+    defer v_table.deinit(allocator);
+
+    // Temp row `tr` always lives in ring slot `tr % klen_y`.
+    const ring = try allocator.alloc(TempT, klen_y * cols);
+    defer allocator.free(ring);
+    const bases = try allocator.alloc(usize, klen_y);
+    defer allocator.free(bases);
+
+    var produced: usize = @min(klen_y, rows);
+    for (0..produced) |tr| {
+        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table, left_end, right_start);
+    }
+
+    for (0..rows) |r| {
+        if (r >= half_y and r + half_y < rows) {
+            // Highest temp row this output row taps (klen_y - 1 - half_y above r).
+            const need = r + klen_y - 1 - half_y;
+            while (produced <= need) : (produced += 1) {
+                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, left_end, right_start);
+            }
+            for (bases, 0..) |*b, i| b.* = ((r + i - half_y) % klen_y) * cols;
+            VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y);
+        } else {
+            // Bottom border rows read the final window; make sure it is complete. Top
+            // border rows only tap the initial window, which prefill already produced.
+            if (r >= bottom_start) {
+                while (produced < rows) : (produced += 1) {
+                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, left_end, right_start);
+                }
+            }
+            const ordinal = if (r < top_end) r else top_end + (r - bottom_start);
+            for (bases, v_table.taps(ordinal)) |*b, resolved| {
+                b.* = if (resolved == BorderIndexTable.zero_sentinel)
+                    BorderIndexTable.zero_sentinel
+                else
+                    (resolved % klen_y) * cols;
+            }
+            VPass.verticalRowFromBases(true, ring, bases, dst_img, r, kernel_y);
+        }
+    }
+}
+
+test "fused separable matches standard path" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(42);
+    const random = prng.random();
+
+    inline for ([_]type{ u8, f32 }) |T| {
+        const TempT = if (T == u8) i32 else f32;
+        const kernels = [_][]const f32{
+            &.{ 0.1, 0.2, 0.4, 0.2, 0.1 },
+            &.{ 0.25, 0.25, 0.25, 0.25 },
+        };
+        for (kernels) |kernel_f32| {
+            for ([_]BorderMode{ .zero, .replicate, .mirror }) |mode| {
+                var src: Image(T) = try .init(allocator, 40, 33);
+                defer src.deinit(allocator);
+                for (src.data) |*px| px.* = if (T == u8) random.int(u8) else 255 * random.float(f32);
+
+                var expected: Image(T) = try .initLike(allocator, src);
+                defer expected.deinit(allocator);
+                var actual: Image(T) = try .initLike(allocator, src);
+                defer actual.deinit(allocator);
+
+                const kernel = if (T == u8) try scaleKernelToInt(allocator, kernel_f32) else kernel_f32;
+                defer if (T == u8) allocator.free(kernel);
+
+                var temp: Image(TempT) = try .initLike(allocator, src);
+                defer temp.deinit(allocator);
+                try convolveSeparablePlane(T, TempT, src, expected, temp, allocator, kernel, kernel, mode);
+                try convolveSeparablePlaneFused(T, TempT, src, actual, allocator, kernel, kernel, mode);
+
+                try testing.expectEqualSlices(T, expected.data, actual.data);
+            }
+        }
+    }
+}
+
 /// Uses i64 accumulators for i32 intermediates to prevent overflow during the second pass.
 fn convolveSeparablePlane(
     comptime PixelT: type,
@@ -376,194 +944,11 @@ fn convolveSeparablePlane(
     src_img: Image(PixelT),
     dst_img: Image(PixelT),
     temp_img: Image(TempT),
+    allocator: Allocator,
     kernel_x: []const TempT,
     kernel_y: []const TempT,
     border_mode: BorderMode,
-) void {
-    const half_x = kernel_x.len / 2;
-    const half_y = kernel_y.len / 2;
-    const rows = src_img.rows;
-    const cols = src_img.cols;
-
-    const AccumT = if (TempT == i32) i64 else TempT;
-    const vec_len = std.simd.suggestVectorLength(TempT) orelse 1;
-
-    const isNegligible = struct {
-        inline fn check(k: TempT) bool {
-            if (TempT == f32) {
-                return @abs(k) < 1e-10;
-            } else {
-                return k == 0;
-            }
-        }
-    }.check;
-
-    // Two-pass results carry a squared fixed-point scale.
-    const DstIO = PixelIO(PixelT, vec_len, fixed_point_scale_sq);
-
-    const Ops = struct {
-        inline fn promote(v: anytype) if (@typeInfo(@TypeOf(v)) == .vector) @Vector(vec_len, AccumT) else AccumT {
-            return if (AccumT == i64) @intCast(v) else v;
-        }
-
-        inline fn loadSrcVec(ptr: [*]const PixelT) @Vector(vec_len, TempT) {
-            if (PixelT == u8 and TempT == i32) {
-                const v: @Vector(vec_len, u8) = ptr[0..vec_len].*;
-                return @intCast(v);
-            } else {
-                return ptr[0..vec_len].*;
-            }
-        }
-
-        inline fn storeTempVec(val: @Vector(vec_len, AccumT), ptr: [*]TempT) void {
-            if (TempT == i32 and AccumT == i64) {
-                const min_vec: @Vector(vec_len, i64) = @splat(std.math.minInt(i32));
-                const max_vec: @Vector(vec_len, i64) = @splat(std.math.maxInt(i32));
-                const clamped = @max(min_vec, @min(max_vec, val));
-                const narrowed: @Vector(vec_len, i32) = @intCast(clamped);
-                ptr[0..vec_len].* = narrowed;
-            } else {
-                ptr[0..vec_len].* = val;
-            }
-        }
-
-        inline fn storeTempScalar(val: AccumT) TempT {
-            if (TempT == i32 and AccumT == i64) {
-                return @intCast(meta.clamp(i32, val));
-            } else {
-                return val;
-            }
-        }
-    };
-
-    // Shared by the left and right border-column loops of the horizontal pass.
-    const hBorderPixel = struct {
-        inline fn accum(img: Image(PixelT), kernel: []const TempT, half: usize, r: usize, c: usize, mode: BorderMode) AccumT {
-            var result: AccumT = 0;
-            const ic: isize = @intCast(c);
-            for (kernel, 0..) |k, i| {
-                const icx = ic + @as(isize, @intCast(i)) - @as(isize, @intCast(half));
-                result += Ops.promote(border.getPixel(PixelT, img, @intCast(r), icx, mode)) * Ops.promote(k);
-            }
-            return result;
-        }
-    }.accum;
-
-    // Horizontal pass (src -> temp)
-    for (0..rows) |r| {
-        const row_offset = r * src_img.stride;
-        const temp_offset = r * temp_img.stride;
-        var c: usize = 0;
-
-        const left_border_end = @min(half_x, cols);
-        while (c < left_border_end) : (c += 1) {
-            temp_img.data[temp_offset + c] = Ops.storeTempScalar(hBorderPixel(src_img, kernel_x, half_x, r, c, border_mode));
-        }
-
-        if (cols > 2 * half_x) {
-            const interior_end = cols - half_x;
-
-            while (c + vec_len <= interior_end) : (c += vec_len) {
-                var acc: @Vector(vec_len, AccumT) = @splat(0);
-
-                for (kernel_x, 0..) |k, ki| {
-                    if (!isNegligible(k)) {
-                        const src_idx = row_offset + c + ki - half_x;
-                        const src_vec = Ops.loadSrcVec(src_img.data[src_idx..].ptr);
-
-                        const src_vec_acc = Ops.promote(src_vec);
-                        const k_vec: @Vector(vec_len, AccumT) = @splat(Ops.promote(k));
-                        acc += src_vec_acc * k_vec;
-                    }
-                }
-                Ops.storeTempVec(acc, temp_img.data[temp_offset + c ..].ptr);
-            }
-
-            while (c < interior_end) : (c += 1) {
-                var result: AccumT = 0;
-                const c0 = c - half_x;
-                for (kernel_x, 0..) |k, i| {
-                    if (!isNegligible(k)) {
-                        const src_val = src_img.data[row_offset + c0 + i];
-                        result += Ops.promote(src_val) * Ops.promote(k);
-                    }
-                }
-                temp_img.data[temp_offset + c] = Ops.storeTempScalar(result);
-            }
-        }
-
-        while (c < cols) : (c += 1) {
-            temp_img.data[temp_offset + c] = Ops.storeTempScalar(hBorderPixel(src_img, kernel_x, half_x, r, c, border_mode));
-        }
-    }
-
-    // Vertical pass (temp -> dst) with loop tiling for cache locality
-    const tile_width = @max(vec_len, 16);
-
-    if (rows > 2 * half_y) {
-        const safe_end_r = rows - half_y;
-
-        var tile_c: usize = 0;
-        while (tile_c < cols) : (tile_c += tile_width) {
-            const tile_end = @min(tile_c + tile_width, cols);
-            var c: usize = tile_c;
-
-            while (c + vec_len <= tile_end) : (c += vec_len) {
-                for (half_y..safe_end_r) |r| {
-                    var acc: @Vector(vec_len, AccumT) = @splat(0);
-
-                    for (kernel_y, 0..) |k, ki| {
-                        if (!isNegligible(k)) {
-                            const src_row = r + ki - half_y;
-                            const src_off = src_row * temp_img.stride;
-                            const src_vec: @Vector(vec_len, TempT) = temp_img.data[src_off + c ..][0..vec_len].*;
-
-                            const src_vec_acc = Ops.promote(src_vec);
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(Ops.promote(k));
-                            acc += src_vec_acc * k_vec;
-                        }
-                    }
-
-                    DstIO.storeVec(acc, dst_img.data, r * dst_img.stride + c);
-                }
-            }
-
-            while (c < tile_end) : (c += 1) {
-                for (half_y..safe_end_r) |r| {
-                    var result: AccumT = 0;
-                    const r0 = r - half_y;
-                    for (kernel_y, 0..) |k, i| {
-                        if (isNegligible(k)) continue;
-                        const rr = r0 + i;
-                        const src_val = temp_img.data[rr * temp_img.stride + c];
-                        result += Ops.promote(src_val) * Ops.promote(k);
-                    }
-                    dst_img.data[r * dst_img.stride + c] = DstIO.store(result);
-                }
-            }
-        }
-    }
-
-    // Top and bottom border rows require getPixel for out-of-bounds vertical access
-    const top_end = @min(half_y, rows);
-    const bottom_start = if (rows > half_y) @max(top_end, rows - half_y) else rows;
-    const border_rows = [_][2]usize{
-        .{ 0, top_end },
-        .{ bottom_start, rows },
-    };
-
-    for (border_rows) |range| {
-        for (range[0]..range[1]) |r| {
-            for (0..cols) |c| {
-                var result: AccumT = 0;
-                const ir: isize = @intCast(r);
-                for (kernel_y, 0..) |k, i| {
-                    const iry = ir + @as(isize, @intCast(i)) - @as(isize, @intCast(half_y));
-                    const pixel_val = border.getPixel(TempT, temp_img, iry, @intCast(c), border_mode);
-                    result += Ops.promote(pixel_val) * Ops.promote(k);
-                }
-                dst_img.data[r * dst_img.stride + c] = DstIO.store(result);
-            }
-        }
-    }
+) !void {
+    try SeparablePass(PixelT, TempT, fixed_point_scale_sq).horizontal(src_img, temp_img, allocator, kernel_x, border_mode);
+    try SeparablePass(TempT, PixelT, fixed_point_scale_sq).vertical(temp_img, dst_img, allocator, kernel_y, border_mode);
 }

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -155,9 +155,10 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                 while (c + vec_len <= c_end) : (c += vec_len) {
                     var result_vecs: [n]@Vector(vec_len, AccumScalar) = @splat(@splat(0));
                     inline for (0..rows) |ky| {
-                        const maybe_base = row_offsets[ky];
-                        if (if (maybe_zero) maybe_base != null else true) {
-                            const base = if (maybe_zero) maybe_base.? else maybe_base;
+                        // Runtime `continue` is not allowed in an inline for; the wrapping
+                        // `if` folds away at comptime when `maybe_zero` is false.
+                        if (if (maybe_zero) row_offsets[ky] != null else true) {
+                            const base = if (maybe_zero) row_offsets[ky].? else row_offsets[ky];
                             inline for (0..cols) |kx| {
                                 const pixel_vec = Pixels.loadVec(src.data, base + c + kx - half_w);
                                 inline for (0..n) |i| {
@@ -175,9 +176,8 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
             while (c < c_end) : (c += 1) {
                 var results: [n]AccumScalar = @splat(0);
                 inline for (0..rows) |ky| {
-                    const maybe_base = row_offsets[ky];
-                    if (if (maybe_zero) maybe_base != null else true) {
-                        const base = if (maybe_zero) maybe_base.? else maybe_base;
+                    if (if (maybe_zero) row_offsets[ky] != null else true) {
+                        const base = if (maybe_zero) row_offsets[ky].? else row_offsets[ky];
                         inline for (0..cols) |kx| {
                             const pixel_val = Pixels.load(src.data[base + c + kx - half_w]);
                             inline for (0..n) |i| {
@@ -382,23 +382,44 @@ inline fn isIdentityKernel(kernel: []const f32) bool {
     return kernel.len == 1 and kernel[0] == 1;
 }
 
-/// Single-axis separable pass straight src -> dst, used when the other axis is a 1-tap
-/// identity: no temp plane, and u8 results carry a single `fixed_point_scale` (exact —
-/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)).
-fn convolveSeparableSingle(
+/// Per-plane separable driver owning the strategy choice: identity axes skip their pass
+/// entirely (a u8 single pass carries one `fixed_point_scale`, exact because
+/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)), large planes take the fused
+/// ring path, everything else runs the standard two-pass over a temp plane.
+/// `cached_temp` lets struct-pixel callers reuse one temp allocation across planes.
+fn convolveSeparableAuto(
     comptime PixelT: type,
-    comptime vertical: bool,
-    image: Image(PixelT),
-    out: Image(PixelT),
+    comptime TempT: type,
+    src: Image(PixelT),
+    dst: Image(PixelT),
     allocator: Allocator,
-    kernel: []const (if (PixelT == u8) i32 else f32),
+    kernel_x: []const TempT,
+    kernel_y: []const TempT,
     border_mode: BorderMode,
+    cached_temp: ?*[]TempT,
 ) !void {
-    const Pass = SeparablePass(PixelT, PixelT, fixed_point_scale);
-    if (vertical) {
-        try Pass.vertical(image, out, allocator, kernel, border_mode);
+    // In TempT units a 1-tap identity is exactly `one` (1.0 quantizes to fixed_point_scale).
+    const one: TempT = if (TempT == i32) fixed_point_scale else 1;
+    const identity_x = kernel_x.len == 1 and kernel_x[0] == one;
+    const identity_y = kernel_y.len == 1 and kernel_y[0] == one;
+    const SinglePass = SeparablePass(PixelT, PixelT, if (PixelT == u8) fixed_point_scale else 1);
+
+    if (identity_x and identity_y) {
+        src.copy(dst);
+    } else if (identity_y) {
+        try SinglePass.horizontal(src, dst, allocator, kernel_x, border_mode);
+    } else if (identity_x) {
+        try SinglePass.vertical(src, dst, allocator, kernel_y, border_mode);
+    } else if (useFusedSeparable(TempT, src.rows, src.cols, kernel_y.len, border_mode)) {
+        try convolveSeparablePlaneFused(PixelT, TempT, src, dst, allocator, kernel_x, kernel_y, border_mode);
+    } else if (cached_temp) |temp_slot| {
+        if (temp_slot.len == 0) temp_slot.* = try allocator.alloc(TempT, @as(usize, src.rows) * src.cols);
+        const temp = Image(TempT).initFromSlice(src.rows, src.cols, temp_slot.*);
+        try convolveSeparablePlane(PixelT, TempT, src, dst, temp, allocator, kernel_x, kernel_y, border_mode);
     } else {
-        try Pass.horizontal(image, out, allocator, kernel, border_mode);
+        var temp = try Image(TempT).initLike(allocator, src);
+        defer temp.deinit(allocator);
+        try convolveSeparablePlane(PixelT, TempT, src, dst, temp, allocator, kernel_x, kernel_y, border_mode);
     }
 }
 
@@ -413,52 +434,21 @@ pub fn convolveSeparable(
     kernel_y: []const f32,
     border_mode: BorderMode,
 ) !void {
-    const identity_x = isIdentityKernel(kernel_x);
-    const identity_y = isIdentityKernel(kernel_y);
-    if (identity_x and identity_y) {
+    if (isIdentityKernel(kernel_x) and isIdentityKernel(kernel_y)) {
         image.copy(out);
         return;
     }
 
     switch (T) {
         u8 => {
-            if (identity_y) {
-                const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
-                defer allocator.free(kernel_x_int);
-                try convolveSeparableSingle(u8, false, image, out, allocator, kernel_x_int, border_mode);
-            } else if (identity_x) {
-                const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
-                defer allocator.free(kernel_y_int);
-                try convolveSeparableSingle(u8, true, image, out, allocator, kernel_y_int, border_mode);
-            } else {
-                const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
-                defer allocator.free(kernel_x_int);
-                const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
-                defer allocator.free(kernel_y_int);
+            const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
+            defer allocator.free(kernel_x_int);
+            const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
+            defer allocator.free(kernel_y_int);
 
-                if (useFusedSeparable(i32, image.rows, image.cols, kernel_y.len, border_mode)) {
-                    try convolveSeparablePlaneFused(u8, i32, image, out, allocator, kernel_x_int, kernel_y_int, border_mode);
-                } else {
-                    var temp = try Image(i32).initLike(allocator, image);
-                    defer temp.deinit(allocator);
-                    try convolveSeparablePlane(u8, i32, image, out, temp, allocator, kernel_x_int, kernel_y_int, border_mode);
-                }
-            }
+            try convolveSeparableAuto(u8, i32, image, out, allocator, kernel_x_int, kernel_y_int, border_mode, null);
         },
-        f32 => {
-            if (identity_y) {
-                try convolveSeparableSingle(f32, false, image, out, allocator, kernel_x, border_mode);
-            } else if (identity_x) {
-                try convolveSeparableSingle(f32, true, image, out, allocator, kernel_y, border_mode);
-            } else if (useFusedSeparable(f32, image.rows, image.cols, kernel_y.len, border_mode)) {
-                try convolveSeparablePlaneFused(f32, f32, image, out, allocator, kernel_x, kernel_y, border_mode);
-            } else {
-                var temp = try Image(T).initLike(allocator, image);
-                defer temp.deinit(allocator);
-
-                try convolveSeparablePlane(f32, f32, image, out, temp, allocator, kernel_x, kernel_y, border_mode);
-            }
-        },
+        f32 => try convolveSeparableAuto(f32, f32, image, out, allocator, kernel_x, kernel_y, border_mode, null),
         else => switch (@typeInfo(T)) {
             .@"struct" => {
                 if (comptime meta.allFieldsAreU8(T)) {
@@ -477,31 +467,13 @@ pub fn convolveSeparable(
                         allocator: Allocator,
                         kernel_x: []const i32,
                         kernel_y: []const i32,
-                        passes: enum { both, horizontal_only, vertical_only },
                         temp: []i32 = &.{},
 
                         fn convolvePlane(ctx: *@This(), src: Image(u8), dst: Image(u8), mode: BorderMode) !void {
-                            switch (ctx.passes) {
-                                .horizontal_only => try convolveSeparableSingle(u8, false, src, dst, ctx.allocator, ctx.kernel_x, mode),
-                                .vertical_only => try convolveSeparableSingle(u8, true, src, dst, ctx.allocator, ctx.kernel_y, mode),
-                                .both => {
-                                    if (useFusedSeparable(i32, src.rows, src.cols, ctx.kernel_y.len, mode)) {
-                                        try convolveSeparablePlaneFused(u8, i32, src, dst, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode);
-                                    } else {
-                                        if (ctx.temp.len == 0) ctx.temp = try ctx.allocator.alloc(i32, src.rows * src.cols);
-                                        const temp = Image(i32).initFromSlice(src.rows, src.cols, ctx.temp);
-                                        try convolveSeparablePlane(u8, i32, src, dst, temp, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode);
-                                    }
-                                },
-                            }
+                            try convolveSeparableAuto(u8, i32, src, dst, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode, &ctx.temp);
                         }
                     };
-                    var ctx: PlaneCtx = .{
-                        .allocator = allocator,
-                        .kernel_x = kernel_x_int,
-                        .kernel_y = kernel_y_int,
-                        .passes = if (identity_y) .horizontal_only else if (identity_x) .vertical_only else .both,
-                    };
+                    var ctx: PlaneCtx = .{ .allocator = allocator, .kernel_x = kernel_x_int, .kernel_y = kernel_y_int };
                     defer allocator.free(ctx.temp);
                     try convolvePlanes(T, image, out, allocator, kx_sum * ky_sum, fixed_point_scale_sq, border_mode, &ctx);
                 } else {
@@ -523,18 +495,15 @@ const BorderIndexTable = struct {
 
     indices: []usize,
     kernel_len: usize,
+    /// Border positions are [0, low_end) and [high_start, axis_len).
+    low_end: usize,
+    high_start: usize,
 
-    /// Border positions are [0, low_end) and [high_start, axis_len); callers must pass the
-    /// exact range bounds their loops use so table and loops cannot drift.
-    fn init(
-        allocator: Allocator,
-        axis_len: usize,
-        kernel_len: usize,
-        half: usize,
-        low_end: usize,
-        high_start: usize,
-        border_mode: BorderMode,
-    ) !BorderIndexTable {
+    fn init(allocator: Allocator, axis_len: usize, kernel_len: usize, border_mode: BorderMode) !BorderIndexTable {
+        const half = kernel_len / 2;
+        const low_end = @min(half, axis_len);
+        const high_start = if (axis_len > 2 * half) axis_len - half else low_end;
+
         const n_positions = low_end + (axis_len - high_start);
         const indices = try allocator.alloc(usize, n_positions * kernel_len);
         var w: usize = 0;
@@ -550,7 +519,7 @@ const BorderIndexTable = struct {
                 w += 1;
             }
         }
-        return .{ .indices = indices, .kernel_len = kernel_len };
+        return .{ .indices = indices, .kernel_len = kernel_len, .low_end = low_end, .high_start = high_start };
     }
 
     fn resolveTap(pos: usize, tap: usize, half: usize, axis_len: usize, border_mode: BorderMode) usize {
@@ -562,6 +531,11 @@ const BorderIndexTable = struct {
         allocator.free(self.indices);
     }
 
+    /// Table ordinal of a border position (low positions first, high positions after).
+    inline fn ordinalOf(self: BorderIndexTable, pos: usize) usize {
+        return if (pos < self.low_end) pos else self.low_end + (pos - self.high_start);
+    }
+
     inline fn taps(self: BorderIndexTable, ordinal: usize) []const usize {
         return self.indices[ordinal * self.kernel_len ..][0..self.kernel_len];
     }
@@ -569,8 +543,12 @@ const BorderIndexTable = struct {
 
 /// One direction of a separable convolution with load/store policies derived from the
 /// source and destination scalar types. `dst_scale` is the fixed-point divisor applied
-/// when storing to u8 (unused for i32/f32 destinations).
+/// when storing to u8; pass 1 for i32/f32 destinations.
 fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: comptime_int) type {
+    if (DstT != u8 and dst_scale != 1) {
+        @compileError("dst_scale only applies to u8 destinations");
+    }
+
     return struct {
         const KernelT = if (SrcT == f32 or DstT == f32) f32 else i32;
         const AccumT = if (KernelT == f32) f32 else i64;
@@ -592,7 +570,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         inline fn store(val: AccumT) DstT {
             return switch (DstT) {
                 u8 => divClampU8(dst_scale, val),
-                i32 => @intCast(meta.clamp(i32, val)),
+                i32 => meta.clamp(i32, val),
                 f32 => val,
                 else => unreachable,
             };
@@ -624,13 +602,13 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         }
 
         /// One row of the horizontal pass into a caller-provided contiguous row buffer.
-        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, left_end: usize, right_start: usize) void {
+        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable) void {
             const half = kernel.len / 2;
             const cols = src.cols;
             const src_offset = r * src.stride;
             var c: usize = 0;
 
-            while (c < left_end) : (c += 1) {
+            while (c < table.low_end) : (c += 1) {
                 dst_row[c] = store(borderPixelResolved(src, kernel, table.taps(c), src_offset));
             }
 
@@ -662,22 +640,18 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
             }
 
             while (c < cols) : (c += 1) {
-                dst_row[c] = store(borderPixelResolved(src, kernel, table.taps(left_end + (c - right_start)), src_offset));
+                dst_row[c] = store(borderPixelResolved(src, kernel, table.taps(table.ordinalOf(c)), src_offset));
             }
         }
 
         /// Row-major 1D pass along columns (src -> dst).
         fn horizontal(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
-            const half = kernel.len / 2;
             const cols = src.cols;
-            const left_end = @min(half, cols);
-            const right_start = if (cols > 2 * half) cols - half else left_end;
-
-            const table: BorderIndexTable = try .init(allocator, cols, kernel.len, half, left_end, right_start, border_mode);
+            const table: BorderIndexTable = try .init(allocator, cols, kernel.len, border_mode);
             defer table.deinit(allocator);
 
             for (0..src.rows) |r| {
-                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table, left_end, right_start);
+                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table);
             }
         }
 
@@ -766,47 +740,24 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                 }
             }
 
-            // Top and bottom border rows: row taps resolved once per row, then SIMD across
-            // columns (each lane accumulates in the same tap order as the scalar loop).
-            const top_end = @min(half, rows);
-            const bottom_start = if (rows > half) @max(top_end, rows - half) else rows;
-
-            const table: BorderIndexTable = try .init(allocator, rows, kernel.len, half, top_end, bottom_start, border_mode);
+            // Top and bottom border rows: row taps resolved once per row, then combined with
+            // the same per-row machinery the fused path uses.
+            const table: BorderIndexTable = try .init(allocator, rows, kernel.len, border_mode);
             defer table.deinit(allocator);
+            const bases = try allocator.alloc(usize, kernel.len);
+            defer allocator.free(bases);
 
             const border_rows = [_][2]usize{
-                .{ 0, top_end },
-                .{ bottom_start, rows },
+                .{ 0, table.low_end },
+                .{ table.high_start, rows },
             };
 
             for (border_rows) |range| {
                 for (range[0]..range[1]) |r| {
-                    const ordinal = if (r < top_end) r else top_end + (r - bottom_start);
-                    const tap_idx = table.taps(ordinal);
-                    const dst_offset = r * dst.stride;
-                    var c: usize = 0;
-
-                    while (c + vec_len <= cols) : (c += vec_len) {
-                        var acc: @Vector(vec_len, AccumT) = @splat(0);
-                        for (kernel, tap_idx) |k, idx| {
-                            const vec: @Vector(vec_len, AccumT) = if (idx == BorderIndexTable.zero_sentinel)
-                                @splat(0)
-                            else
-                                loadVec(src.data[idx * src.stride + c ..].ptr);
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                            acc += vec * k_vec;
-                        }
-                        storeVec(acc, dst.data[dst_offset + c ..].ptr);
+                    for (bases, table.taps(table.ordinalOf(r))) |*b, idx| {
+                        b.* = if (idx == BorderIndexTable.zero_sentinel) idx else idx * src.stride;
                     }
-
-                    while (c < cols) : (c += 1) {
-                        var result: AccumT = 0;
-                        for (kernel, tap_idx) |k, idx| {
-                            const pv: SrcT = if (idx == BorderIndexTable.zero_sentinel) 0 else src.data[idx * src.stride + c];
-                            result += promote(pv) * promote(k);
-                        }
-                        dst.data[dst_offset + c] = store(result);
-                    }
+                    verticalRowFromBases(true, src.data, bases, dst, r, kernel);
                 }
             }
         }
@@ -840,23 +791,17 @@ fn convolveSeparablePlaneFused(
     kernel_y: []const TempT,
     border_mode: BorderMode,
 ) !void {
-    const HPass = SeparablePass(PixelT, TempT, fixed_point_scale_sq);
-    const VPass = SeparablePass(TempT, PixelT, fixed_point_scale_sq);
+    const HPass = SeparablePass(PixelT, TempT, 1);
+    const VPass = SeparablePass(TempT, PixelT, if (PixelT == u8) fixed_point_scale_sq else 1);
 
     const rows = src_img.rows;
     const cols = src_img.cols;
     const klen_y = kernel_y.len;
     const half_y = klen_y / 2;
-    const half_x = kernel_x.len / 2;
 
-    const left_end = @min(half_x, cols);
-    const right_start = if (cols > 2 * half_x) cols - half_x else left_end;
-    const h_table: BorderIndexTable = try .init(allocator, cols, kernel_x.len, half_x, left_end, right_start, border_mode);
+    const h_table: BorderIndexTable = try .init(allocator, cols, kernel_x.len, border_mode);
     defer h_table.deinit(allocator);
-
-    const top_end = @min(half_y, rows);
-    const bottom_start = if (rows > half_y) @max(top_end, rows - half_y) else rows;
-    const v_table: BorderIndexTable = try .init(allocator, rows, klen_y, half_y, top_end, bottom_start, border_mode);
+    const v_table: BorderIndexTable = try .init(allocator, rows, klen_y, border_mode);
     defer v_table.deinit(allocator);
 
     // Temp row `tr` always lives in ring slot `tr % klen_y`.
@@ -867,7 +812,7 @@ fn convolveSeparablePlaneFused(
 
     var produced: usize = @min(klen_y, rows);
     for (0..produced) |tr| {
-        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table, left_end, right_start);
+        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table);
     }
 
     for (0..rows) |r| {
@@ -875,20 +820,19 @@ fn convolveSeparablePlaneFused(
             // Highest temp row this output row taps (klen_y - 1 - half_y above r).
             const need = r + klen_y - 1 - half_y;
             while (produced <= need) : (produced += 1) {
-                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, left_end, right_start);
+                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table);
             }
             for (bases, 0..) |*b, i| b.* = ((r + i - half_y) % klen_y) * cols;
             VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y);
         } else {
             // Bottom border rows read the final window; make sure it is complete. Top
             // border rows only tap the initial window, which prefill already produced.
-            if (r >= bottom_start) {
+            if (r >= v_table.high_start) {
                 while (produced < rows) : (produced += 1) {
-                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, left_end, right_start);
+                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table);
                 }
             }
-            const ordinal = if (r < top_end) r else top_end + (r - bottom_start);
-            for (bases, v_table.taps(ordinal)) |*b, resolved| {
+            for (bases, v_table.taps(v_table.ordinalOf(r))) |*b, resolved| {
                 b.* = if (resolved == BorderIndexTable.zero_sentinel)
                     BorderIndexTable.zero_sentinel
                 else
@@ -897,6 +841,22 @@ fn convolveSeparablePlaneFused(
             VPass.verticalRowFromBases(true, ring, bases, dst_img, r, kernel_y);
         }
     }
+}
+
+/// Uses i64 accumulators for i32 intermediates to prevent overflow during the second pass.
+fn convolveSeparablePlane(
+    comptime PixelT: type,
+    comptime TempT: type,
+    src_img: Image(PixelT),
+    dst_img: Image(PixelT),
+    temp_img: Image(TempT),
+    allocator: Allocator,
+    kernel_x: []const TempT,
+    kernel_y: []const TempT,
+    border_mode: BorderMode,
+) !void {
+    try SeparablePass(PixelT, TempT, 1).horizontal(src_img, temp_img, allocator, kernel_x, border_mode);
+    try SeparablePass(TempT, PixelT, if (PixelT == u8) fixed_point_scale_sq else 1).vertical(temp_img, dst_img, allocator, kernel_y, border_mode);
 }
 
 test "fused separable matches standard path" {
@@ -935,20 +895,4 @@ test "fused separable matches standard path" {
             }
         }
     }
-}
-
-/// Uses i64 accumulators for i32 intermediates to prevent overflow during the second pass.
-fn convolveSeparablePlane(
-    comptime PixelT: type,
-    comptime TempT: type,
-    src_img: Image(PixelT),
-    dst_img: Image(PixelT),
-    temp_img: Image(TempT),
-    allocator: Allocator,
-    kernel_x: []const TempT,
-    kernel_y: []const TempT,
-    border_mode: BorderMode,
-) !void {
-    try SeparablePass(PixelT, TempT, fixed_point_scale_sq).horizontal(src_img, temp_img, allocator, kernel_x, border_mode);
-    try SeparablePass(TempT, PixelT, fixed_point_scale_sq).vertical(temp_img, dst_img, allocator, kernel_y, border_mode);
 }

--- a/src/image/edges.zig
+++ b/src/image/edges.zig
@@ -7,7 +7,7 @@ const Image = @import("../image.zig").Image;
 const meta = @import("../meta.zig");
 const as = meta.as;
 const isScalar = meta.isScalar;
-const convolve = @import("convolution.zig").convolve;
+const convolvePair = @import("convolution.zig").convolvePair;
 const ShenCastan = @import("ShenCastan.zig");
 
 /// Sobel X gradient kernel (horizontal edges)
@@ -54,8 +54,7 @@ pub fn Edges(comptime T: type) type {
                 defer grad_x.deinit(allocator);
                 defer grad_y.deinit(allocator);
 
-                try convolve(f32, gray_float, grad_x, allocator, sobel_x, .replicate);
-                try convolve(f32, gray_float, grad_y, allocator, sobel_y, .replicate);
+                convolvePair(f32, gray_float, grad_x, grad_y, sobel_x, sobel_y, .replicate);
 
                 // Compute gradient magnitude
                 for (0..self.rows) |r| {
@@ -250,8 +249,7 @@ pub fn Edges(comptime T: type) type {
             defer grad_x.deinit(allocator);
             defer grad_y.deinit(allocator);
 
-            try convolve(f32, blurred, grad_x, allocator, sobel_x, .replicate);
-            try convolve(f32, blurred, grad_y, allocator, sobel_y, .replicate);
+            convolvePair(f32, blurred, grad_x, grad_y, sobel_x, sobel_y, .replicate);
 
             // Compute gradient magnitude
             var magnitude = try Image(f32).init(allocator, self.rows, self.cols);

--- a/src/image/tests/filters.zig
+++ b/src/image/tests/filters.zig
@@ -1340,3 +1340,45 @@ test "convolve regression issue #255 (missing pixels)" {
         try std.testing.expectEqual(@as(u8, 8), result.at(r, 1).*);
     }
 }
+
+test "convolvePair matches two independent convolves" {
+    const convolution = @import("../convolution.zig");
+    const allocator = std.testing.allocator;
+
+    const kernel_a = [3][3]f32{
+        .{ -1, 0, 1 },
+        .{ -2, 0, 2 },
+        .{ -1, 0, 1 },
+    };
+    const kernel_b = [3][3]f32{
+        .{ -1, -2, -1 },
+        .{ 0, 0, 0 },
+        .{ 1, 2, 1 },
+    };
+
+    inline for ([_]type{ u8, f32 }) |T| {
+        var src: Image(T) = try .init(allocator, 11, 17);
+        defer src.deinit(allocator);
+        for (src.data, 0..) |*px, i| {
+            px.* = @as(u8, @truncate(i * 31 + 7));
+        }
+
+        for ([_]BorderMode{ .replicate, .zero }) |mode| {
+            var pair_a: Image(T) = try .initLike(allocator, src);
+            defer pair_a.deinit(allocator);
+            var pair_b: Image(T) = try .initLike(allocator, src);
+            defer pair_b.deinit(allocator);
+            var solo_a: Image(T) = try .initLike(allocator, src);
+            defer solo_a.deinit(allocator);
+            var solo_b: Image(T) = try .initLike(allocator, src);
+            defer solo_b.deinit(allocator);
+
+            convolution.convolvePair(T, src, pair_a, pair_b, kernel_a, kernel_b, mode);
+            try src.convolve(solo_a, allocator, kernel_a, mode);
+            try src.convolve(solo_b, allocator, kernel_b, mode);
+
+            try std.testing.expectEqualSlices(T, solo_a.data, pair_a.data);
+            try std.testing.expectEqualSlices(T, solo_b.data, pair_b.data);
+        }
+    }
+}


### PR DESCRIPTION
Implements the efficiency findings from a convolution review as a benchmarked performance pass. Every change is bit-exact with the previous implementation (verified with a seeded-random hash harness across all pixel types, border modes, kernel shapes, and edge-case sizes), and the full test suite passes.

## Benchmarks (median ms, 480p = 640×480, 4K = 3840×2160)

| Benchmark | Size | Before | After | Speedup |
|---|---|---|---|---|
| gaussianBlur u8 σ=1 | 480p | 1.58 | 0.64 | 2.5× |
| gaussianBlur u8 σ=8 | 480p | 6.39 | 2.70 | 2.4× |
| gaussianBlur u8 σ=3 | 4K | 43.4 | 28.3 | 1.5× |
| gaussianBlur Rgb σ=3 | 4K | 138.7 | 110.1 | 1.26× |
| convolve 7×7 u8 | 480p | 1.56 | 1.09 | 1.4× |
| convolve 7×7 u8 .mirror | 64×64 | 0.096 | 0.053 | 1.8× |
| sobel f32 | 480p | 1.04 | 0.89 | 1.2× |
| motionBlur horizontal u8 | 480p | 0.85 | 0.50 | 1.7× |
| convolveSeparable f32 | 2048² | 10.7 | 2.44 | **4.4×** |
| convolveSeparable f32 | 4K | 18.4 | 5.12 | **3.6×** |

Measured with the new `convolution_bench` example (`zig build run-convolution-bench -Drelease=true` from `examples/`).

## Changes

- **SIMD border rows (2D convolve):** top/bottom border rows resolve their kernel-row indices once per row (`border.resolveIndex`, null = zero-row sentinel) and reuse the interior SIMD column span; only the corner columns remain scalar.
- **Fused gradient pairs:** `convolve` generalized to `convolveMulti(comptime n)` (n=1 compiles to the previous code) plus a public `convolvePair`; `sobel()` and `canny()` now load each source pixel once for both Sobel kernels.
- **Separable restructure:** the separable path is now a `SeparablePass(SrcT, DstT, scale)` factory with precomputed border tap-index tables — border resolution is 1-D per axis and identical across the other axis, so it is computed once per pass instead of per pixel, and the previously scalar vertical border epilogue is now SIMD. This is the biggest 480p win.
- **Identity 1-tap skip:** a `[1.0]` axis kernel skips its whole pass (single pass straight src→dst with a single fixed-point scale; both identity = copy). Axis-aligned motion blur no longer round-trips through an i32 temp plane. Exact by `divTrunc(256·S ± 32768, 65536) ≡ divTrunc(S ± 128, 256)`.
- **Ring-buffer fused separable path (gated):** for large images (temp plane > 8 MB, ring ≤ 1 MB, not `.wrap`), the horizontal producer and vertical consumer share a ring of `kernel_y.len` temp rows, eliminating the full temp-plane DRAM round-trip.
- **Tests:** `convolvePair` vs two independent convolves, and fused-vs-standard separable equality (u8/f32, odd/even kernels, three border modes).

Also tried and deliberately **not** included: hoisting kernel tap compaction/pre-splat out of the separable inner loops — it measured 16–48% *slower* because memory-loaded tap offsets defeat LLVM's induction-variable strength reduction, while the branch it removes is perfectly predicted for dense kernels.