### PR TITLE
refactor(image): post-review cleanup of the filter perf pass

### DIFF
--- a/src/image.zig
+++ b/src/image.zig
@@ -625,7 +625,7 @@ pub fn Image(comptime T: type) type {
 
         /// Computes the integral image, also known as a summed-area table (SAT), of `self`.
         /// For multi-channel images (e.g., structs like `Rgba`), it computes a per-channel
-        /// integral image, storing the result as an array of floats per pixel in the output `integral` image.
+        /// integral image, storing one f32 plane per channel in `planes`.
         pub fn integral(self: Self, allocator: Allocator, planes: *Self.Integral.Planes) !void {
             return Self.Integral.compute(self, allocator, planes);
         }

--- a/src/image/box_blur.zig
+++ b/src/image/box_blur.zig
@@ -1,8 +1,8 @@
 //! Sliding-window box blur and unsharp sharpen with O(1) cost per pixel.
 //!
-//! Replaces the previous summed-area-table approach for these two filters: exact
-//! u32/f64 column sums avoid the f32 SAT's precision loss on large images, and the
-//! working state is one row of column sums instead of full-image float planes.
+//! Column sums (exact u32 for u8 planes, f64 for f32) slide down the image and a
+//! running window sum slides across each row; the only working state is one row of
+//! column sums, and borders use the clamped window renormalized by its actual area.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -29,34 +29,31 @@ fn apply(comptime T: type, comptime mode: Mode, image: Image(T), out: Image(T), 
         return;
     }
 
+    // The sliding-window passes read source rows ahead of the write cursor, so
+    // in-place calls run through a temp image.
+    if (out.data.ptr == image.data.ptr) {
+        var temp = try Image(T).initLike(allocator, image);
+        defer temp.deinit(allocator);
+        try applyInto(T, mode, image, temp, allocator, radius);
+        temp.copy(out);
+        return;
+    }
+    try applyInto(T, mode, image, out, allocator, radius);
+}
+
+fn applyInto(comptime T: type, comptime mode: Mode, image: Image(T), out: Image(T), allocator: Allocator, radius: usize) !void {
     switch (@typeInfo(T)) {
-        .int, .float => {
-            if (out.data.ptr == image.data.ptr) {
-                var temp = try Image(T).initLike(allocator, image);
-                defer temp.deinit(allocator);
-                try plane(T, mode, image, temp, allocator, radius);
-                temp.copy(out);
-            } else {
-                try plane(T, mode, image, out, allocator, radius);
-            }
-        },
+        .int, .float => try plane(T, mode, image, out, allocator, radius),
         .@"struct" => {
             if (comptime meta.allFieldsAreU8(T)) {
                 // All channels share the same pixel window, so the filter runs directly
                 // on the interleaved bytes — no channel split/merge passes.
-                if (out.data.ptr == image.data.ptr) {
-                    var temp = try Image(T).initLike(allocator, image);
-                    defer temp.deinit(allocator);
-                    try interleavedU8(T, mode, image, temp, allocator, radius);
-                    temp.copy(out);
-                } else {
-                    try interleavedU8(T, mode, image, out, allocator, radius);
-                }
+                try interleavedU8(T, mode, image, out, allocator, radius);
             } else {
                 const num_channels = comptime Image(T).channels();
+                const P = channel_ops.FieldTypeOf(T);
                 const planes = try channel_ops.splitChannels(T, image, allocator);
                 defer inline for (planes) |p| allocator.free(p);
-                const P = std.meta.Child(@TypeOf(planes[0]));
 
                 const plane_size = @as(usize, image.rows) * image.cols;
                 var dst_planes: [num_channels][]P = undefined;
@@ -83,10 +80,34 @@ fn apply(comptime T: type, comptime mode: Mode, image: Image(T), out: Image(T), 
 }
 
 /// One scalar plane. Column sums slide down the rows; a horizontal running sum
-/// slides across each row. Borders use the clamped window renormalized by its
-/// actual area (same geometry as the previous implementation); the division is
-/// two reciprocal multiplies since heights are row-invariant and widths are
-/// column-invariant.
+/// slides across each row. The per-pixel division is two reciprocal multiplies,
+/// since window heights are row-invariant and widths are column-invariant.
+/// Reciprocals of the clamped horizontal window widths (column-invariant across rows).
+fn invWidthTable(comptime F: type, allocator: Allocator, cols: usize, radius: usize) ![]F {
+    const inv_widths = try allocator.alloc(F, cols);
+    for (inv_widths, 0..) |*w, c| {
+        const c2 = @min(c + radius, cols - 1);
+        w.* = 1.0 / @as(F, @floatFromInt(c2 - (c -| radius) + 1));
+    }
+    return inv_widths;
+}
+
+/// Clamp-round epilogue shared by every u8 emit site; `offset` is the element offset of
+/// the pixel block in `src_row` (sharpen loads the original pixels from there).
+inline fn finishU8(comptime len: usize, comptime mode: Mode, src_row: []const u8, offset: usize, blurred: @Vector(len, f32)) @Vector(len, u8) {
+    const value = switch (mode) {
+        .blur => blurred,
+        .sharpen => blk: {
+            const orig: @Vector(len, u8) = src_row[offset..][0..len].*;
+            const orig_f: @Vector(len, f32) = @floatFromInt(orig);
+            break :blk orig_f + orig_f - blurred;
+        },
+    };
+    const zero: @Vector(len, f32) = @splat(0);
+    const max: @Vector(len, f32) = @splat(255);
+    return @round(@max(zero, @min(max, value)));
+}
+
 fn plane(comptime P: type, comptime mode: Mode, src: Image(P), dst: Image(P), allocator: Allocator, radius: usize) !void {
     if (P != u8 and P != f32) @compileError("box filters support u8 and f32 planes");
     const rows: usize = src.rows;
@@ -98,12 +119,8 @@ fn plane(comptime P: type, comptime mode: Mode, src: Image(P), dst: Image(P), al
     defer allocator.free(col_sums);
     @memset(col_sums, 0);
 
-    const inv_widths = try allocator.alloc(InvT, cols);
+    const inv_widths = try invWidthTable(InvT, allocator, cols, radius);
     defer allocator.free(inv_widths);
-    for (inv_widths, 0..) |*w, c| {
-        const c2 = @min(c + radius, cols - 1);
-        w.* = 1.0 / @as(InvT, @floatFromInt(c2 - (c -| radius) + 1));
-    }
 
     for (0..@min(radius + 1, rows)) |rr| {
         const row = src.data[rr * src.stride ..][0..cols];
@@ -148,29 +165,11 @@ fn plane(comptime P: type, comptime mode: Mode, src: Image(P), dst: Image(P), al
             while (c + vec_len + radius + 1 <= cols) : (c += vec_len) {
                 const hi: @Vector(vec_len, i32) = @intCast(@as(@Vector(vec_len, u32), col_sums[c + radius + 1 ..][0..vec_len].*));
                 const lo: @Vector(vec_len, i32) = @intCast(@as(@Vector(vec_len, u32), col_sums[c - radius ..][0..vec_len].*));
-                var deltas = hi - lo;
-                // Inclusive prefix sum in log2 steps.
-                deltas += std.simd.shiftElementsRight(deltas, 1, 0);
-                deltas += std.simd.shiftElementsRight(deltas, 2, 0);
-                if (vec_len >= 8) deltas += std.simd.shiftElementsRight(deltas, 4, 0);
-                if (vec_len >= 16) deltas += std.simd.shiftElementsRight(deltas, 8, 0);
-
+                const deltas = std.simd.prefixScan(.Add, 1, hi - lo);
                 const base: i32 = @intCast(hsum);
                 const hsums = @as(@Vector(vec_len, i32), @splat(base)) + std.simd.shiftElementsRight(deltas, 1, 0);
                 const blurred = @as(@Vector(vec_len, f32), @floatFromInt(hsums)) * @as(@Vector(vec_len, f32), @splat(inv_area));
-
-                const value = switch (mode) {
-                    .blur => blurred,
-                    .sharpen => blk: {
-                        const orig: @Vector(vec_len, u8) = src_row[c..][0..vec_len].*;
-                        const orig_f: @Vector(vec_len, f32) = @floatFromInt(orig);
-                        break :blk orig_f + orig_f - blurred;
-                    },
-                };
-                const zero: @Vector(vec_len, f32) = @splat(0);
-                const max: @Vector(vec_len, f32) = @splat(255);
-                const rounded: @Vector(vec_len, u8) = @round(@max(zero, @min(max, value)));
-                dst_row[c..][0..vec_len].* = rounded;
+                dst_row[c..][0..vec_len].* = finishU8(vec_len, mode, src_row, c, blurred);
 
                 hsum = @intCast(base + deltas[vec_len - 1]);
             }
@@ -216,12 +215,8 @@ fn interleavedU8(comptime T: type, comptime mode: Mode, image: Image(T), out: Im
     defer allocator.free(col_sums);
     @memset(col_sums, 0);
 
-    const inv_widths = try allocator.alloc(f32, cols);
+    const inv_widths = try invWidthTable(f32, allocator, cols, radius);
     defer allocator.free(inv_widths);
-    for (inv_widths, 0..) |*w, c| {
-        const c2 = @min(c + radius, cols - 1);
-        w.* = 1.0 / @as(f32, @floatFromInt(c2 - (c -| radius) + 1));
-    }
 
     for (0..@min(radius + 1, rows)) |rr| {
         const row = std.mem.sliceAsBytes(image.data[rr * image.stride ..][0..cols]);
@@ -280,29 +275,12 @@ fn interleavedU8(comptime T: type, comptime mode: Mode, image: Image(T), out: Im
             while (c + px_block + radius + 1 <= cols) : (c += px_block) {
                 const hi: @Vector(B, i32) = @intCast(@as(@Vector(B, u32), col_sums[(c + radius + 1) * n ..][0..B].*));
                 const lo: @Vector(B, i32) = @intCast(@as(@Vector(B, u32), col_sums[(c - radius) * n ..][0..B].*));
-                var deltas = hi - lo;
-                comptime var step = n;
-                inline while (step < B) : (step *= 2) {
-                    deltas += std.simd.shiftElementsRight(deltas, step, 0);
-                }
-
+                const deltas = std.simd.prefixScan(.Add, n, hi - lo);
                 const base_small: @Vector(n, i32) = @intCast(hsum);
                 const base = @shuffle(i32, base_small, undefined, repeat_mask);
                 const wsums = base + std.simd.shiftElementsRight(deltas, n, 0);
                 const blurred = @as(@Vector(B, f32), @floatFromInt(wsums)) * @as(@Vector(B, f32), @splat(inv_area));
-
-                const value = switch (mode) {
-                    .blur => blurred,
-                    .sharpen => blk: {
-                        const orig: @Vector(B, u8) = src_row[c * n ..][0..B].*;
-                        const orig_f: @Vector(B, f32) = @floatFromInt(orig);
-                        break :blk orig_f + orig_f - blurred;
-                    },
-                };
-                const zero: @Vector(B, f32) = @splat(0);
-                const max: @Vector(B, f32) = @splat(255);
-                const rounded: @Vector(B, u8) = @round(@max(zero, @min(max, value)));
-                dst_row[c * n ..][0..B].* = rounded;
+                dst_row[c * n ..][0..B].* = finishU8(B, mode, src_row, c * n, blurred);
 
                 hsum = @intCast(base_small + @shuffle(i32, deltas, undefined, tail_mask));
             }
@@ -319,18 +297,7 @@ inline fn emitPixel(comptime n: usize, comptime mode: Mode, src_row: []const u8,
     const hf: @Vector(n, f32) = @floatFromInt(hsum);
     // Two multiplies on the value, matching the scalar plane path's border rounding.
     const blurred = hf * @as(@Vector(n, f32), @splat(inv_h)) * @as(@Vector(n, f32), @splat(inv_w));
-    const value = switch (mode) {
-        .blur => blurred,
-        .sharpen => blk: {
-            const orig: @Vector(n, u8) = src_row[c * n ..][0..n].*;
-            const orig_f: @Vector(n, f32) = @floatFromInt(orig);
-            break :blk orig_f + orig_f - blurred;
-        },
-    };
-    const zero: @Vector(n, f32) = @splat(0);
-    const max: @Vector(n, f32) = @splat(255);
-    const rounded: @Vector(n, u8) = @round(@max(zero, @min(max, value)));
-    dst_row[c * n ..][0..n].* = rounded;
+    dst_row[c * n ..][0..n].* = finishU8(n, mode, src_row, c * n, blurred);
 }
 
 inline fn slidePixel(comptime n: usize, col_sums: []const u32, cols: usize, radius: usize, c: usize, hsum: *@Vector(n, u32)) void {

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -39,7 +39,7 @@ pub fn findUniformValue(comptime T: type, data: []const T) ?T {
 }
 
 /// Get the common type of all fields in a struct, or compile error if not uniform
-fn FieldTypeOf(comptime T: type) type {
+pub fn FieldTypeOf(comptime T: type) type {
     const fields = comptime meta.structFields(T);
     if (fields.len == 0) @compileError("Type " ++ @typeName(T) ++ " has no fields");
 

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -27,9 +27,9 @@ inline fn divClampU8(comptime scale: comptime_int, accum: anytype) u8 {
 /// SIMD variant of `divClampU8`.
 inline fn divClampU8Vec(
     comptime scale: comptime_int,
-    comptime N: usize,
     accum: anytype,
-) @Vector(N, u8) {
+) @Vector(@typeInfo(@TypeOf(accum)).vector.len, u8) {
+    const N = @typeInfo(@TypeOf(accum)).vector.len;
     const T = @typeInfo(@TypeOf(accum)).vector.child;
     const half_vec: @Vector(N, T) = @splat(scale / 2);
     const shift_vec: @Vector(N, std.math.Log2Int(T)) = @splat(comptime std.math.log2_int(u32, scale));
@@ -48,15 +48,18 @@ inline fn quantizeWeight(weight: f32) i32 {
 /// gain: the residual lands on the largest-magnitude tap (relative error <= 1/|k_max|).
 /// Without this, correlated rounding drifts the overall gain — a uniform 1/30 kernel
 /// quantizes to 30*9 = 270/256, brightening by +5.5% and clipping highlights.
-fn renormalizeQuantized(taps: []i32, target_sum: i64) void {
+/// For all-equal taps the strict `>` puts the residual on tap 0 — `isUniformBody`
+/// relies on that shape to detect uniform kernels after quantization.
+fn renormalizeQuantized(taps: []i32, weight_sum: f64) void {
     if (taps.len == 0) return;
+    const target: i64 = @round(fixed_point_scale * weight_sum);
     var sum: i64 = 0;
     var largest: usize = 0;
     for (taps, 0..) |k, i| {
         sum += k;
         if (@abs(k) > @abs(taps[largest])) largest = i;
     }
-    taps[largest] += @intCast(target_sum - sum);
+    taps[largest] += @intCast(target - sum);
 }
 
 fn PixelIO(comptime T: type, comptime vec_len: usize, comptime scale: comptime_int) type {
@@ -88,7 +91,7 @@ fn PixelIO(comptime T: type, comptime vec_len: usize, comptime scale: comptime_i
 
         inline fn storeVec(accum_vec: @Vector(vec_len, Scalar), dst: []T, offset: usize) void {
             if (T == u8) {
-                dst[offset..][0..vec_len].* = divClampU8Vec(scale, vec_len, accum_vec);
+                dst[offset..][0..vec_len].* = divClampU8Vec(scale, accum_vec);
             } else {
                 dst[offset..][0..vec_len].* = accum_vec;
             }
@@ -128,8 +131,7 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                 }
             }
             if (T == u8) {
-                const target: i64 = @round(fixed_point_scale * weight_sum);
-                renormalizeQuantized(&result, target);
+                renormalizeQuantized(&result, weight_sum);
             }
             return result;
         }
@@ -403,8 +405,7 @@ fn scaleKernelToInt(allocator: Allocator, kernel: []const f32) ![]i32 {
         r.* = quantizeWeight(k);
         weight_sum += k;
     }
-    const target: i64 = @round(fixed_point_scale * weight_sum);
-    renormalizeQuantized(result, target);
+    renormalizeQuantized(result, weight_sum);
     return result;
 }
 
@@ -417,7 +418,7 @@ inline fn isIdentityKernel(kernel: []const f32) bool {
 /// True when all taps except possibly the first are equal — the shape of a quantized
 /// uniform kernel after `renormalizeQuantized` parks the rounding residual on tap 0.
 /// Such kernels (axis-aligned motion blur) collapse to an O(1)/pixel running sum.
-fn isUniformBody(comptime TempT: type, kernel: []const TempT) bool {
+fn isUniformBody(kernel: anytype) bool {
     if (kernel.len < 2) return false;
     const k = kernel[1];
     for (kernel[2..]) |tap| {
@@ -426,11 +427,6 @@ fn isUniformBody(comptime TempT: type, kernel: []const TempT) bool {
     return true;
 }
 
-/// Per-plane separable driver owning the strategy choice: identity axes skip their pass
-/// entirely (a u8 single pass carries one `fixed_point_scale`, exact because
-/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)), large planes take the fused
-/// ring path, everything else runs the standard two-pass over a temp plane.
-/// `cached_temp` lets struct-pixel callers reuse one temp allocation across planes.
 /// True when i32 accumulators cannot overflow for these quantized kernels: the horizontal
 /// pass is bounded by 255*sum|kx| and the vertical pass by 255*sum|kx|*sum|ky|, with
 /// `fixed_point_scale_sq` of margin for the rounding half added before the final divide.
@@ -444,6 +440,8 @@ fn narrowAccumFits(kernel_x: []const i32, kernel_y: []const i32) bool {
     return 255 * sx <= limit and 255 * sx * sy <= limit;
 }
 
+/// Selects the accumulator width (i32 unless the kernels could overflow it) and runs the
+/// per-plane driver.
 fn convolveSeparableAuto(
     comptime PixelT: type,
     comptime TempT: type,
@@ -465,8 +463,9 @@ fn convolveSeparableAuto(
 
 /// Per-plane separable driver owning the strategy choice: identity axes skip their pass
 /// entirely (a u8 single pass carries one `fixed_point_scale`, exact because
-/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)), large planes take the fused
-/// ring path, everything else runs the standard two-pass over a temp plane.
+/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)), uniform-body kernels take
+/// the O(1)/pixel running-sum box passes, large planes take the fused ring path, and
+/// everything else runs the standard two-pass over a temp plane.
 /// `cached_temp` lets struct-pixel callers reuse one temp allocation across planes.
 fn convolveSeparableAutoImpl(
     comptime PixelT: type,
@@ -489,13 +488,13 @@ fn convolveSeparableAutoImpl(
     if (identity_x and identity_y) {
         src.copy(dst);
     } else if (identity_y) {
-        if (TempT == i32 and isUniformBody(TempT, kernel_x)) {
+        if (TempT == i32 and isUniformBody(kernel_x)) {
             try SinglePass.horizontalBox(src, dst, allocator, kernel_x, border_mode);
         } else {
             try SinglePass.horizontal(src, dst, allocator, kernel_x, border_mode);
         }
     } else if (identity_x) {
-        if (TempT == i32 and isUniformBody(TempT, kernel_y)) {
+        if (TempT == i32 and isUniformBody(kernel_y)) {
             try SinglePass.verticalBox(src, dst, allocator, kernel_y, border_mode);
         } else {
             try SinglePass.vertical(src, dst, allocator, kernel_y, border_mode);
@@ -686,7 +685,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
 
         inline fn storeVec(val: @Vector(vec_len, AccumT), ptr: [*]DstT) void {
             switch (DstT) {
-                u8 => ptr[0..vec_len].* = divClampU8Vec(dst_scale, vec_len, val),
+                u8 => ptr[0..vec_len].* = divClampU8Vec(dst_scale, val),
                 i32 => if (AccumT == i32) {
                     ptr[0..vec_len].* = val;
                 } else {
@@ -712,7 +711,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         }
 
         /// One row of the horizontal pass into a caller-provided contiguous row buffer.
-        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable) void {
+        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, folded: bool) void {
             const half = kernel.len / 2;
             const cols = src.cols;
             const src_offset = r * src.stride;
@@ -725,7 +724,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
             if (cols > 2 * half) {
                 const interior_end = cols - half;
 
-                if (KernelT == i32 and isSymmetric(kernel)) {
+                if (folded) {
                     while (c + vec_len <= interior_end) : (c += vec_len) {
                         const base = src_offset + c - half;
                         var acc: @Vector(vec_len, AccumT) = @splat(0);
@@ -779,9 +778,10 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
             const cols = src.cols;
             const table: BorderIndexTable = try .init(allocator, cols, kernel.len, border_mode);
             defer table.deinit(allocator);
+            const folded = KernelT == i32 and isSymmetric(kernel);
 
             for (0..src.rows) |r| {
-                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table);
+                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table, folded);
             }
         }
 
@@ -789,11 +789,33 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         /// (`BorderIndexTable.zero_sentinel` = row of zeros). Border rows keep the full
         /// kernel with explicit zero adds; interior rows skip negligible taps — both
         /// matching the standard vertical pass per pixel.
-        fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT) void {
+        /// Emits the top/bottom border rows from a row-resolved table; shared by the
+        /// dense and box vertical passes.
+        fn verticalBorderRows(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
+            const table: BorderIndexTable = try .init(allocator, src.rows, kernel.len, border_mode);
+            defer table.deinit(allocator);
+            const bases = try allocator.alloc(usize, kernel.len);
+            defer allocator.free(bases);
+
+            const border_rows = [_][2]usize{
+                .{ 0, table.low_end },
+                .{ table.high_start, src.rows },
+            };
+            for (border_rows) |range| {
+                for (range[0]..range[1]) |r| {
+                    for (bases, table.taps(table.ordinalOf(r))) |*b, idx| {
+                        b.* = if (idx == BorderIndexTable.zero_sentinel) idx else idx * src.stride;
+                    }
+                    verticalRowFromBases(true, src.data, bases, dst, r, kernel, false);
+                }
+            }
+        }
+
+        fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT, folded: bool) void {
             const cols = dst.cols;
             const dst_offset = r * dst.stride;
             const half = kernel.len / 2;
-            const folded = !border_row and KernelT == i32 and isSymmetric(kernel);
+            std.debug.assert(!(border_row and folded));
             var c: usize = 0;
 
             while (c + vec_len <= cols) : (c += vec_len) {
@@ -887,26 +909,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                 }
             }
 
-            // Top and bottom border rows: row taps resolved once per row, then combined with
-            // the same per-row machinery the fused path uses.
-            const table: BorderIndexTable = try .init(allocator, rows, kernel.len, border_mode);
-            defer table.deinit(allocator);
-            const bases = try allocator.alloc(usize, kernel.len);
-            defer allocator.free(bases);
-
-            const border_rows = [_][2]usize{
-                .{ 0, table.low_end },
-                .{ table.high_start, rows },
-            };
-
-            for (border_rows) |range| {
-                for (range[0]..range[1]) |r| {
-                    for (bases, table.taps(table.ordinalOf(r))) |*b, idx| {
-                        b.* = if (idx == BorderIndexTable.zero_sentinel) idx else idx * src.stride;
-                    }
-                    verticalRowFromBases(true, src.data, bases, dst, r, kernel);
-                }
-            }
+            try verticalBorderRows(src, dst, allocator, kernel, border_mode);
         }
 
         /// O(1)-per-pixel horizontal pass for uniform-body kernels (see `isUniformBody`):
@@ -947,11 +950,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                         while (c + vec_len + 1 <= interior_end) : (c += vec_len) {
                             const firsts = loadVec(src.data[src_offset + c - half ..].ptr);
                             const highs = loadVec(src.data[src_offset + c - half + len ..].ptr);
-                            var deltas = highs - firsts;
-                            comptime var step = 1;
-                            inline while (step < vec_len) : (step *= 2) {
-                                deltas += std.simd.shiftElementsRight(deltas, step, 0);
-                            }
+                            const deltas = std.simd.prefixScan(.Add, 1, highs - firsts);
                             const w_vec = @as(@Vector(vec_len, AccumT), @splat(sum)) +
                                 std.simd.shiftElementsRight(deltas, 1, 0);
                             storeVec(k_vec * w_vec + r_vec * firsts, dst.data[dst_offset + c ..].ptr);
@@ -981,21 +980,17 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
             const len = kernel.len;
             const rows = src.rows;
             const cols = src.cols;
-            const table: BorderIndexTable = try .init(allocator, rows, len, border_mode);
-            defer table.deinit(allocator);
-            const bases = try allocator.alloc(usize, len);
-            defer allocator.free(bases);
 
             const k = promote(kernel[1]);
             const residual = promote(kernel[0]) - k;
 
             if (rows > 2 * half) {
                 const safe_end = rows - half;
+                const k_vec: @Vector(vec_len, AccumT) = @splat(k);
+                const r_vec: @Vector(vec_len, AccumT) = @splat(residual);
                 var c: usize = 0;
 
                 while (c + vec_len <= cols) : (c += vec_len) {
-                    const k_vec: @Vector(vec_len, AccumT) = @splat(k);
-                    const r_vec: @Vector(vec_len, AccumT) = @splat(residual);
                     var sum: @Vector(vec_len, AccumT) = @splat(0);
                     for (0..len) |i| sum += loadVec(src.data[i * src.stride + c ..].ptr);
 
@@ -1022,18 +1017,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                 }
             }
 
-            const border_rows = [_][2]usize{
-                .{ 0, table.low_end },
-                .{ table.high_start, rows },
-            };
-            for (border_rows) |range| {
-                for (range[0]..range[1]) |r| {
-                    for (bases, table.taps(table.ordinalOf(r))) |*b, idx| {
-                        b.* = if (idx == BorderIndexTable.zero_sentinel) idx else idx * src.stride;
-                    }
-                    verticalRowFromBases(true, src.data, bases, dst, r, kernel);
-                }
-            }
+            try verticalBorderRows(src, dst, allocator, kernel, border_mode);
         }
     };
 }
@@ -1079,6 +1063,9 @@ fn convolveSeparablePlaneFused(
     const v_table: BorderIndexTable = try .init(allocator, rows, klen_y, border_mode);
     defer v_table.deinit(allocator);
 
+    const h_folded = HPass.KernelT == i32 and HPass.isSymmetric(kernel_x);
+    const v_folded = VPass.KernelT == i32 and VPass.isSymmetric(kernel_y);
+
     // Temp row `tr` always lives in ring slot `tr % klen_y`.
     const ring = try allocator.alloc(TempT, klen_y * cols);
     defer allocator.free(ring);
@@ -1087,7 +1074,7 @@ fn convolveSeparablePlaneFused(
 
     var produced: usize = @min(klen_y, rows);
     for (0..produced) |tr| {
-        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table);
+        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table, h_folded);
     }
 
     for (0..rows) |r| {
@@ -1095,16 +1082,16 @@ fn convolveSeparablePlaneFused(
             // Highest temp row this output row taps (klen_y - 1 - half_y above r).
             const need = r + klen_y - 1 - half_y;
             while (produced <= need) : (produced += 1) {
-                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table);
+                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
             }
             for (bases, 0..) |*b, i| b.* = ((r + i - half_y) % klen_y) * cols;
-            VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y);
+            VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y, v_folded);
         } else {
             // Bottom border rows read the final window; make sure it is complete. Top
             // border rows only tap the initial window, which prefill already produced.
             if (r >= v_table.high_start) {
                 while (produced < rows) : (produced += 1) {
-                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table);
+                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
                 }
             }
             for (bases, v_table.taps(v_table.ordinalOf(r))) |*b, resolved| {
@@ -1113,12 +1100,12 @@ fn convolveSeparablePlaneFused(
                 else
                     (resolved % klen_y) * cols;
             }
-            VPass.verticalRowFromBases(true, ring, bases, dst_img, r, kernel_y);
+            VPass.verticalRowFromBases(true, ring, bases, dst_img, r, kernel_y, false);
         }
     }
 }
 
-/// Uses i64 accumulators for i32 intermediates to prevent overflow during the second pass.
+/// Standard two-pass separable convolution through a full-size temp plane.
 fn convolveSeparablePlane(
     comptime PixelT: type,
     comptime TempT: type,

--- a/src/image/histogram.zig
+++ b/src/image/histogram.zig
@@ -481,7 +481,6 @@ pub fn Histogram(comptime T: type) type {
     };
 }
 
-/// Statistics functions for histogram data (discrete distributions)
 /// 0-based rank of the requested percentile in a population of `total` samples.
 /// Single source of truth for rank semantics across histogram-based selectors.
 pub fn percentileRank(p: f64, total: usize) usize {
@@ -494,6 +493,7 @@ pub fn percentileRank(p: f64, total: usize) usize {
     return std.math.clamp(rank_trunc, 0, total_minus_one);
 }
 
+/// Statistics functions for histogram data (discrete distributions)
 const stats = struct {
     /// Compute mean from histogram bins
     pub fn mean(bins: []const u32) f64 {

--- a/src/image/integral.zig
+++ b/src/image/integral.zig
@@ -6,7 +6,7 @@ const Image = @import("../image.zig").Image;
 const meta = @import("../meta.zig");
 const as = meta.as;
 
-/// Integral image operations for fast box filtering and region sums.
+/// Summed-area tables (integral images) for O(1) rectangular region sums.
 pub fn Integral(comptime T: type) type {
     return struct {
         const channel_count = Image(T).channels();

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -60,6 +60,40 @@ pub fn MotionBlurOps(comptime T: type) type {
         /// Radial blur types
         pub const RadialType = enum { zoom, spin };
 
+        /// Bilinearly samples all channels at (sample_x, sample_y) into `sums`, preserving
+        /// the per-channel two-stage lerp form. Returns false when the sample is out of
+        /// bounds (nothing accumulated).
+        inline fn accumulateBilinear(image: Image(T), sample_x: f32, sample_y: f32, sums: anytype) bool {
+            const fields = comptime meta.structFields(T);
+            if (!(sample_x >= 0 and sample_x < @as(f32, @floatFromInt(image.cols)) and
+                sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))) return false;
+
+            const x0: usize = @floor(sample_x);
+            const x1 = @min(x0 + 1, image.cols - 1);
+            const y0: usize = @floor(sample_y);
+            const y1 = @min(y0 + 1, image.rows - 1);
+
+            const fx = sample_x - @as(f32, @floatFromInt(x0));
+            const fy = sample_y - @as(f32, @floatFromInt(y0));
+
+            const p00 = image.at(y0, x0).*;
+            const p10 = image.at(y0, x1).*;
+            const p01 = image.at(y1, x0).*;
+            const p11 = image.at(y1, x1).*;
+
+            inline for (fields, 0..) |field, i| {
+                const v00 = as(f32, @field(p00, field.name));
+                const v10 = as(f32, @field(p10, field.name));
+                const v01 = as(f32, @field(p01, field.name));
+                const v11 = as(f32, @field(p11, field.name));
+
+                const v0 = v00 * (1 - fx) + v10 * fx;
+                const v1 = v01 * (1 - fx) + v11 * fx;
+                sums[i] += v0 * (1 - fy) + v1 * fy;
+            }
+            return true;
+        }
+
         /// Applies linear motion blur by averaging pixels along a line at the given `angle`
         /// (radians, 0 = horizontal) and `distance` (pixels).
         pub fn linear(image: Image(T), out: Image(T), allocator: Allocator, angle: f32, distance: usize) !void {
@@ -190,36 +224,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                                     const sample_x = @as(f32, @floatFromInt(c)) + t * cos_angle;
                                     const sample_y = @as(f32, @floatFromInt(r)) + t * sin_angle;
 
-                                    // Check bounds
-                                    if (sample_x >= 0 and sample_x < @as(f32, @floatFromInt(image.cols)) and
-                                        sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
-                                    {
-                                        // Bilinear interpolation
-                                        const x0: usize = @floor(sample_x);
-                                        const x1 = @min(x0 + 1, image.cols - 1);
-                                        const y0: usize = @floor(sample_y);
-                                        const y1 = @min(y0 + 1, image.rows - 1);
-
-                                        const fx = sample_x - @as(f32, @floatFromInt(x0));
-                                        const fy = sample_y - @as(f32, @floatFromInt(y0));
-
-                                        const p00 = image.at(y0, x0).*;
-                                        const p10 = image.at(y0, x1).*;
-                                        const p01 = image.at(y1, x0).*;
-                                        const p11 = image.at(y1, x1).*;
-
-                                        inline for (fields, 0..) |field, i| {
-                                            const v00 = as(f32, @field(p00, field.name));
-                                            const v10 = as(f32, @field(p10, field.name));
-                                            const v01 = as(f32, @field(p01, field.name));
-                                            const v11 = as(f32, @field(p11, field.name));
-
-                                            const v0 = v00 * (1 - fx) + v10 * fx;
-                                            const v1 = v01 * (1 - fx) + v11 * fx;
-                                            sums[i] += v0 * (1 - fy) + v1 * fy;
-                                        }
-                                        count += 1;
-                                    }
+                                    if (accumulateBilinear(image, sample_x, sample_y, &sums)) count += 1;
                                     t += 1.0;
                                 }
 
@@ -396,36 +401,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                                     sample_y = cy + distance * @sin(new_angle);
                                 }
 
-                                // Check bounds
-                                if (sample_x >= 0 and sample_x < @as(f32, @floatFromInt(image.cols)) and
-                                    sample_y >= 0 and sample_y < @as(f32, @floatFromInt(image.rows)))
-                                {
-                                    // Bilinear interpolation
-                                    const x0: usize = @floor(sample_x);
-                                    const x1 = @min(x0 + 1, image.cols - 1);
-                                    const y0: usize = @floor(sample_y);
-                                    const y1 = @min(y0 + 1, image.rows - 1);
-
-                                    const fx_interp = sample_x - @as(f32, @floatFromInt(x0));
-                                    const fy_interp = sample_y - @as(f32, @floatFromInt(y0));
-
-                                    const p00 = image.at(y0, x0).*;
-                                    const p10 = image.at(y0, x1).*;
-                                    const p01 = image.at(y1, x0).*;
-                                    const p11 = image.at(y1, x1).*;
-
-                                    inline for (fields, 0..) |field, i| {
-                                        const v00 = as(f32, @field(p00, field.name));
-                                        const v10 = as(f32, @field(p10, field.name));
-                                        const v01 = as(f32, @field(p01, field.name));
-                                        const v11 = as(f32, @field(p11, field.name));
-
-                                        const v0 = v00 * (1 - fx_interp) + v10 * fx_interp;
-                                        const v1 = v01 * (1 - fx_interp) + v11 * fx_interp;
-                                        sums[i] += v0 * (1 - fy_interp) + v1 * fy_interp;
-                                    }
-                                    count += 1;
-                                }
+                                if (accumulateBilinear(image, sample_x, sample_y, &sums)) count += 1;
                             }
 
                             var result_pixel: T = undefined;

--- a/src/image/order_statistic_blur.zig
+++ b/src/image/order_statistic_blur.zig
@@ -15,6 +15,9 @@ const Vec16 = @Vector(16, u16);
 /// [16b, 16b+15], fine[b][s] counts value 16b+s. u16 counts are safe because the
 /// two-level path only runs for window <= 255 (population <= 255^2 < 65536).
 const TwoLevelColumn = struct {
+    /// u16 counts hold up to window^2 samples, so the two-level path requires this.
+    const max_window = 255;
+
     coarse: [16]u16 align(32) = @splat(0),
     fine: [16][16]u16 align(32) = @splat(@splat(0)),
 
@@ -68,28 +71,24 @@ fn applyScalarOpTwoLevel(
     border: BorderMode,
     percentile: f64,
 ) !void {
+    // Aliasing is resolved by the public entry points (percentileBlur et al).
+    std.debug.assert(out.data.ptr != image.data.ptr);
     const window = radius * 2 + 1;
     const rows = image.rows;
     const cols = image.cols;
-
-    const alias = out.data.ptr == image.data.ptr;
-    var temp_out: Image(u8) = .empty;
-    defer temp_out.deinit(allocator);
-    var target: Image(u8) = out;
-    if (alias) {
-        temp_out = try .initLike(allocator, image);
-        target = temp_out;
-    }
+    const target = out;
 
     const column_hists = try allocator.alloc(TwoLevelColumn, cols);
     defer allocator.free(column_hists);
 
     const radius_isize: isize = @intCast(radius);
-    for (column_hists, 0..) |*hist, col| {
-        hist.* = .{};
-        for (0..window) |offset| {
-            const row_idx = @as(isize, @intCast(offset)) - radius_isize;
-            hist.addValue(border_module.getPixel(u8, image, row_idx, @intCast(col), border));
+    for (column_hists) |*hist| hist.* = .{};
+    for (0..window) |offset| {
+        const row_idx = @as(isize, @intCast(offset)) - radius_isize;
+        if (border_module.resolveIndex(row_idx, @intCast(rows), border)) |rr| {
+            for (column_hists, 0..) |*hist, col| hist.addValue(image.at(rr, col).*);
+        } else {
+            for (column_hists) |*hist| hist.addValue(0);
         }
     }
 
@@ -133,10 +132,6 @@ fn applyScalarOpTwoLevel(
             hist.removeValue(if (remove_row) |rr| image.at(rr, col).* else 0);
             hist.addValue(if (add_row) |ar| image.at(ar, col).* else 0);
         }
-    }
-
-    if (alias) {
-        target.copy(out);
     }
 }
 
@@ -370,7 +365,7 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
         ) !void {
             // Rank selection (median/percentile/min/max) takes the two-level fast path;
             // u16 counts require window <= 255 (larger radii keep the flat u32 path).
-            if (@TypeOf(reducer_in) == PercentileReducer and radius * 2 + 1 <= 255) {
+            if (@TypeOf(reducer_in) == PercentileReducer and radius * 2 + 1 <= TwoLevelColumn.max_window) {
                 return applyScalarOpTwoLevel(image, allocator, radius, out, border, reducer_in.percentile);
             }
             return applyScalarOpFlat(image, allocator, radius, out, border, reducer_in);


### PR DESCRIPTION
Follow-up cleanup for #392 from a four-angle code review (reuse / simplification / efficiency / altitude). No behavior changes: the 650-hash bit-exactness harness is identical and benchmarks are unchanged within noise; net −75 lines.

Highlights:
- Three hand-rolled SIMD prefix-sum ladders replaced with `std.simd.prefixScan` (generates the identical shift/add sequence — bit-exact).
- Box filter: shared `finishU8` emit epilogue (was four copies), shared inv-width table, aliasing handled once in `apply`.
- Separable passes: shared `verticalBorderRows` for the dense and box vertical passes; the per-row `isSymmetric` check hoisted to per-pass.
- Two-level median: row-major column init with row resolution hoisted out of the inner loop; the u16-count window limit is a named constant (`TwoLevelColumn.max_window`); the production-dead alias block replaced by an asserted precondition.
- Motion blur: struct-path bilinear sampling deduplicated into one helper (exact same expression order).
- Doc repairs: comments that had drifted onto the wrong declarations, plus stale module docs (`integral.zig` no longer claims box filtering).

Deliberately skipped (noted for the record): per-plane alloc helper shared across three modules, reducer-declared dispatch capability, fine-row memoization for the median (moderate complexity, gated benefit at large radii only), and hoisting the flat order-statistic path to file scope — all follow-up material, not cleanups.