### PR TITLE
refactor: migrate off deprecated std.meta field functions

### DIFF
--- a/bindings/python/src/python.zig
+++ b/bindings/python/src/python.zig
@@ -165,7 +165,7 @@ pub fn parse(comptime T: type, py_obj: ?*c.PyObject) !T {
 
             // ArrayList(T)
             if (@hasField(T, "items") and @hasField(T, "capacity") and @hasField(T, "allocator")) {
-                const Slice = std.meta.FieldType(T, .items);
+                const Slice = @FieldType(T, "items");
                 const Child = @typeInfo(Slice).pointer.child;
                 return toArrayList(Child, py_obj);
             }
@@ -339,9 +339,9 @@ pub fn getterOptionalPtr(
     comptime field_name: []const u8,
     comptime converter: anytype,
 ) *const anyopaque {
-    const field_index = std.meta.fieldIndex(Obj, field_name) orelse
+    if (!@hasField(Obj, field_name))
         @compileError("Field '" ++ field_name ++ "' not found on type " ++ @typeName(Obj));
-    const FieldType = std.meta.fieldTypes(Obj)[field_index];
+    const FieldType = @FieldType(Obj, field_name);
     const opt_info = @typeInfo(FieldType);
     if (opt_info != .optional) {
         @compileError("Field '" ++ field_name ++ "' on type " ++ @typeName(Obj) ++ " must be optional");

--- a/src/cli/common.zig
+++ b/src/cli/common.zig
@@ -103,7 +103,7 @@ pub fn toSnake(name: []const u8, buf: []u8) []const u8 {
 pub fn parseEnum(comptime T: type, name: []const u8) ?T {
     const max_len = comptime blk: {
         var m: usize = 0;
-        for (std.meta.fieldNames(T)) |field_name| {
+        for (@typeInfo(T).@"enum".field_names) |field_name| {
             if (field_name.len > m) m = field_name.len;
         }
         break :blk m;
@@ -118,7 +118,11 @@ pub fn parseEnum(comptime T: type, name: []const u8) ?T {
 /// tagged union so help text cannot drift from the type. Tags without
 /// underscores pass through unchanged.
 pub fn joinFieldNames(comptime T: type) []const u8 {
-    const names = std.meta.fieldNames(T);
+    const names = switch (@typeInfo(T)) {
+        .@"enum" => |info| info.field_names,
+        .@"union" => |info| info.field_names,
+        else => @compileError("joinFieldNames requires an enum or tagged union, got " ++ @typeName(T)),
+    };
     var result: []const u8 = "";
     inline for (names, 0..) |name, i| {
         inline for (name) |c| {


### PR DESCRIPTION
Upstream [ziglang/zig#36429](https://codeberg.org/ziglang/zig/pulls/36429) (merged today) deprecates `std.meta.fieldInfo`, `fieldNames` and `fieldTypes` in favor of using `@typeInfo` directly, since callsites always know what kind of type they have. The current minimum nightly (0.17.0-dev.1564) predates the merge, so this migrates proactively before the next toolchain bump.

## Changes

- **`src/cli/common.zig`**: `parseEnum` reads `@typeInfo(T).@"enum".field_names` directly (it feeds `stringToEnum`, so enum-only is correct); `joinFieldNames` gets an inline enum/union switch since it is called with both enums (`std.log.Level`, `BlurType`) and tagged unions (`DisplayFormat`, `Interpolation`).
- **`bindings/python/src/python.zig`**: `getterOptionalPtr` uses `@hasField` + the `@FieldType` builtin instead of `std.meta.fieldIndex` + `fieldTypes`.
- **Latent breakage fix**: `std.meta.FieldType` no longer exists in the current nightly at all — the `ArrayList` branch in `convertFromPython` only compiled because it is never analyzed for current instantiations. Now uses `@FieldType(T, "items")`.

Remaining `std.meta` usage (`eql`, `activeTag`, `Child`, `Tag`, `stringToEnum`, `declarations`) is unaffected by the upstream deprecation.

## Verification

`zig fmt`, `zig build test`, `zig build`, and `zig build python-bindings` all pass.